### PR TITLE
Improve repl usage

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -71,7 +71,8 @@
 
                   :source-paths ["env/dev/clj" "test/clj"]
                   :resource-paths ["env/dev/resources"]
-                  :repl-options {:init-ns rems.standalone}
+                  :repl-options {:init-ns rems.standalone
+                                 :welcome (rems.standalone/repl-help)}
                   :injections [(require 'pjstadig.humane-test-output)
                                (pjstadig.humane-test-output/activate!)]}
    :project/test {:resource-paths ["env/test/resources"]}

--- a/src/clj/rems/standalone.clj
+++ b/src/clj/rems/standalone.clj
@@ -46,6 +46,10 @@
     (log/info component "started"))
   (.addShutdownHook (Runtime/getRuntime) (Thread. stop-app)))
 
+(defn repl-help []
+  (println "Welcome to REMS!")
+  (println "You can run the server with (start-app)"))
+
 (defn -main [& args]
   (cond
     (some #{"migrate" "rollback"} args)


### PR DESCRIPTION
Tiny change to allow calling start-app without parameters.

Welcome message for REPL users. Unfortunately emacs won't show this.