### PR TITLE
rems.context: fix docstrings

### DIFF
--- a/src/clj/rems/context.clj
+++ b/src/clj/rems/context.clj
@@ -4,17 +4,15 @@
    When referring, please make your use greppable with the prefix context,
    i.e. context/*root-path*.")
 
-(def ^:dynamic *root-path*
-  "Application root path also known as context-path.
+(def ^:dynamic ^{:doc "Application root path also known as context-path.
 
   If application does not live at '/',
-  then this is the path before application relative paths.")
+  then this is the path before application relative paths."}
+  *root-path*)
 
-(def ^:dynamic *user*
-  "User data available from request.")
+(def ^:dynamic ^{:doc "User data available from request."} *user*)
 
-(def ^:dynamic *tempura*
-  "Tempura object initialized with user's preferred language.")
+(def ^:dynamic ^{:doc "Tempura object initialized with user's preferred language."}
+  *tempura*)
 
-(def ^:dynamic *cart*
-  "Contents of the cart.")
+(def ^:dynamic ^{:doc "Contents of the cart."} *cart*)


### PR DESCRIPTION
var docstrings were getting interpreted as default values