### PR TITLE
each namespace defines its own component guide fragment

### DIFF
--- a/src/clj/rems/applications.clj
+++ b/src/clj/rems/applications.clj
@@ -1,6 +1,6 @@
 (ns rems.applications
   (:require [rems.context :as context]
-            [rems.example :refer :all]
+            [rems.guide :refer :all]
             [rems.text :refer [text]]
             [rems.db.core :as db]
             [rems.db.applications :refer [get-applications]]))

--- a/src/clj/rems/cart.clj
+++ b/src/clj/rems/cart.clj
@@ -1,6 +1,6 @@
 (ns rems.cart
   (:require [rems.context :as context]
-            [rems.example :refer :all]
+            [rems.guide :refer :all]
             [rems.text :refer :all]
             [rems.form :as form]
             [compojure.core :refer [defroutes POST]]

--- a/src/clj/rems/catalogue.clj
+++ b/src/clj/rems/catalogue.clj
@@ -1,11 +1,9 @@
 (ns rems.catalogue
   (:require [hiccup.element :refer [link-to image]]
-            [taoensso.tempura :refer [tr]]
-            [rems.locales :as locales]
             [rems.context :as context]
             [rems.cart :as cart]
             [rems.form :as form]
-            [rems.example :refer :all]
+            [rems.guide :refer :all]
             [rems.text :refer :all]
             [rems.db.catalogue :refer [get-localized-catalogue-items
                                        get-catalogue-item-title]]))
@@ -44,16 +42,13 @@
    (example "catalogue-item linked to urn.fi"
             [:table.rems-table
              (catalogue-item {:title "Item title" :resid "http://urn.fi/urn:nbn:fi:lb-201403262"})])
-   ;; TODO write helper for overriding language
    (example "catalogue-item in Finnish with localizations"
             [:table.rems-table
-             (binding [context/*lang* :fi
-                       context/*tempura* (partial tr locales/tconfig [:fi])]
+             (with-language :fi
                (catalogue-item {:title "Not used when there are localizations" :localizations {:fi {:title "Suomenkielinen title"} :en {:title "English title"}}}))])
    (example "catalogue-item in English with localizations"
             [:table.rems-table
-             (binding [context/*lang* :en
-                       context/*tempura* (partial tr locales/tconfig [:en])]
+             (with-language :en
                (catalogue-item {:title "Not used when there are localizations" :localizations {:fi {:title "Suomenkielinen title"} :en {:title "English title"}}}))])
 
    (example "catalogue-list empty"

--- a/src/clj/rems/example.clj
+++ b/src/clj/rems/example.clj
@@ -1,7 +1,0 @@
-(ns rems.example)
-
-(defn example [name content]
-  [:div.example
-   [:h3 name]
-   [:div.example-content content
-    [:div.example-content-end]]])

--- a/src/clj/rems/form.clj
+++ b/src/clj/rems/form.clj
@@ -2,7 +2,7 @@
   (:require [hiccup.form :as f]
             [rems.context :as context]
             [rems.layout :as layout]
-            [rems.example :refer :all]
+            [rems.guide :refer :all]
             [rems.text :refer :all]
             [rems.db.core :as db]
             [rems.db.applications :refer [get-form-for create-new-draft]]

--- a/src/clj/rems/guide.clj
+++ b/src/clj/rems/guide.clj
@@ -1,0 +1,15 @@
+(ns rems.guide
+  "Utilities for component guide."
+  (:require [taoensso.tempura :as tempura]
+            [rems.locales :as locales]))
+
+(defn example [name content]
+  [:div.example
+   [:h3 name]
+   [:div.example-content content
+    [:div.example-content-end]]])
+
+(defmacro with-language [lang & body]
+  `(binding [context/*lang* ~lang
+             context/*tempura* (partial tempura/tr locales/tconfig [~lang])]
+     ~@body))

--- a/src/clj/rems/layout.clj
+++ b/src/clj/rems/layout.clj
@@ -1,7 +1,7 @@
 (ns rems.layout
   (:require [compojure.response]
             [rems.context :as context]
-            [rems.example :refer :all]
+            [rems.guide :refer :all]
             [rems.text :refer :all]
             [rems.language-switcher :refer [language-switcher]]
             [hiccup.element :refer [link-to]]

--- a/src/clj/rems/routes/guide.clj
+++ b/src/clj/rems/routes/guide.clj
@@ -1,5 +1,5 @@
 (ns rems.routes.guide
-  (:require [rems.example :refer [example]]
+  (:require [rems.guide :refer :all]
             [rems.layout :as layout]
             [rems.context :as context]
             [rems.catalogue :as catalogue]
@@ -28,39 +28,38 @@
    (color-box "color-4" "#F16522")])
 
 (defn guide-page []
-  (binding [context/*root-path* "path/"
-            context/*lang* :en
-            context/*tempura* (partial tr locales/tconfig [:en])]
-    (h/html
-     [:head
-      [:link {:type "text/css" :rel "stylesheet" :href "/assets/bootstrap/css/bootstrap.min.css"}]
-      [:link {:type "text/css" :rel "stylesheet" :href "/assets/font-awesome/css/font-awesome.min.css"}]
-      [:link {:type "text/css" :rel "stylesheet" :href "/css/screen.css"}]]
-     [:body
-      [:div.example-page
-       [:h1 "Component Guide"]
+  (binding [context/*root-path* "path/"]
+    (with-language :en
+      (h/html
+       [:head
+        [:link {:type "text/css" :rel "stylesheet" :href "/assets/bootstrap/css/bootstrap.min.css"}]
+        [:link {:type "text/css" :rel "stylesheet" :href "/assets/font-awesome/css/font-awesome.min.css"}]
+        [:link {:type "text/css" :rel "stylesheet" :href "/css/screen.css"}]]
+       [:body
+        [:div.example-page
+         [:h1 "Component Guide"]
 
-       [:h2 "Colors"]
-       (example "" (color-boxes))
+         [:h2 "Colors"]
+         (example "" (color-boxes))
 
-       [:h2 "Layout components"]
-       (layout/guide)
+         [:h2 "Layout components"]
+         (layout/guide)
 
-       [:h2 "Catalogue components"]
-       (catalogue/guide)
+         [:h2 "Catalogue components"]
+         (catalogue/guide)
 
-       [:h2 "Cart components"]
-       (cart/guide)
+         [:h2 "Cart components"]
+         (cart/guide)
 
-       [:h2 "Applications list"]
-       (applications/guide)
+         [:h2 "Applications list"]
+         (applications/guide)
 
-       [:h2 "Forms"]
-       (form/guide)
+         [:h2 "Forms"]
+         (form/guide)
 
-       [:h2 "Misc components"]
-       (example "login" (contents/login "/"))
-       (example "about" (contents/about))]])))
+         [:h2 "Misc components"]
+         (example "login" (contents/login "/"))
+         (example "about" (contents/about))]]))))
 
 (defroutes guide-routes
   (GET "/guide" [] (guide-page)))


### PR DESCRIPTION
this allows for a cleaner structure and more private defs