### PR TITLE
remove unnecessary shutdown-agents

### DIFF
--- a/src/clj/rems/standalone.clj
+++ b/src/clj/rems/standalone.clj
@@ -36,8 +36,7 @@
 
 (defn stop-app []
   (doseq [component (:stopped (mount/stop))]
-    (log/info component "stopped"))
-  (shutdown-agents))
+    (log/info component "stopped")))
 
 (defn start-app [& args]
   (doseq [component (-> args


### PR DESCRIPTION
after this, (start-app) (stop-app) (start-app) works in the repl

also, "lein run" shuts down nicely with ^C, so I'd say shutdown-agents
was unnecessary