### PR TITLE
custom request logging

### DIFF
--- a/src/clj/rems/middleware.clj
+++ b/src/clj/rems/middleware.clj
@@ -115,6 +115,25 @@
         (wrap-authentication authentication)
         (wrap-authorization authorization))))
 
+(defn wrap-logging
+  [handler]
+  (fn [request]
+    (let [uri (str (:uri request)
+                   (when-let [q (:query-string request)]
+                     (str "?" q)))]
+      (log/info ">" (:request-method request) uri
+                "lang:" context/*lang*
+                "user:" context/*user*
+                "roles:" context/*roles*
+                "active:" context/*active-role*)
+      (log/debug "session" (pr-str (:session request)))
+      (when-not (empty? (:form-params request))
+        (log/debug "form params" (pr-str (:form-params request))))
+      (let [response (handler request)]
+        (log/info "<" (:request-method request) uri (:status response)
+                  (or (get-in response [:headers "Location"]) ""))
+        response))))
+
 (def +wrap-defaults-settings+
   (-> site-defaults
       (assoc-in [:security :anti-forgery] true)
@@ -124,6 +143,7 @@
 (defn wrap-base [handler]
   (-> ((:middleware +defaults+) handler)
       wrap-unauthorized
+      wrap-logging
       wrap-i18n
       wrap-context
       wrap-auth


### PR DESCRIPTION
solutions like ring-logging were too verbose and on the other hand
didn't print out stuff like the session