### PR TITLE
refactor: simplify code

### DIFF
--- a/src/clj/rems/routes/fake_shibboleth.clj
+++ b/src/clj/rems/routes/fake_shibboleth.clj
@@ -43,17 +43,16 @@ a:visited { color: #fff; }
     [:li {:onclick (str "window.location.href='" url "';")}
      [:a {:href url} username]]))
 
-(defn- fake-login-screen [{session :session username :fake-username :as req}]
-  (let [username (or username (-> req :params :username))]
-    (if username
-      (fake-login session username)
-      (-> (html5 [:head [:style fake-login-styles]]
-                 [:body
-                  [:div.login
-                   [:h1 "Development Login"]
-                   [:ul (map user-selection ["developer" "alice" "bob"])]]])
-          (response)
-          (content-type "text/html; charset=utf-8")))))
+(defn- fake-login-screen [{session :session :as req}]
+  (if-let [username (-> req :params :username)]
+    (fake-login session username)
+    (-> (html5 [:head [:style fake-login-styles]]
+               [:body
+                [:div.login
+                 [:h1 "Development Login"]
+                 [:ul (map user-selection ["developer" "alice" "bob"])]]])
+        (response)
+        (content-type "text/html; charset=utf-8"))))
 
 (defn- fake-logout [{session :session}]
   (-> (redirect "/")

--- a/test/clj/rems/test/handler.clj
+++ b/test/clj/rems/test/handler.clj
@@ -93,8 +93,7 @@
 (defn login
   "Logs in the given user by sending a request to the fake login."
   [ctx username]
-  (dispatch ctx (-> (request :get "/Shibboleth.sso/Login")
-                    (assoc :fake-username username))))
+  (dispatch ctx (-> (request :get "/Shibboleth.sso/Login" {:username username}))))
 
 (defn follow-redirect
   "Ensures the previous response in the context was a redirect and


### PR DESCRIPTION
`:fake-username` is not needed when the username can be given to the
fake login screen using the query parameter.