### PR TITLE
.travis.yml: explicitly set dist: trusty

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: clojure
 lein: 2.6.1
+dist: trusty
 branches:
   only:
     - master


### PR DESCRIPTION
the previous default, precise, is being deprecated