### PR TITLE
make schema swagger-compatible again

### DIFF
--- a/src/clj/rems/api/schema.clj
+++ b/src/clj/rems/api/schema.clj
@@ -72,7 +72,7 @@
    (s/optional-key :can-withdraw?) s/Bool
    (s/optional-key :review) (s/enum :third-party)
    :catalogue-items [CatalogueItem]
-   (s/optional-key :review-type) (s/enum :normal :third-party nil)
+   (s/optional-key :review-type) (s/maybe (s/enum :normal :third-party))
    (s/optional-key :handled) DateTime})
 
 (def Entitlement


### PR DESCRIPTION
swagger doesn't support null in enums