### PR TITLE
Invalid reviewers

### DIFF
--- a/src/clj/rems/db/test_data.clj
+++ b/src/clj/rems/db/test_data.clj
@@ -30,7 +30,9 @@
   (roles/add-role! "carl" :reviewer)
   ;; a user to own things
   (users/add-user! "owner" (+fake-user-data+ "owner"))
-  (roles/add-role! "owner" :owner))
+  (roles/add-role! "owner" :owner)
+  ;; invalid user for tests
+  (db/add-user! {:user "invalid" :userattrs nil}))
 
 (defn- create-demo-users-and-roles! []
   ;; a user to own things

--- a/test/clj/rems/test/api/application.clj
+++ b/test/clj/rems/test/api/application.clj
@@ -349,6 +349,13 @@
                    app
                    read-body
                    :id)]
+    (testing "fetch reviewers"
+      (let [reviewers (-> (request :get (str "/api/application/reviewers"))
+                          (authenticate api-key approver)
+                          app
+                          read-body)]
+        (is (= ["alice" "bob" "carl" "developer" "owner"] (sort (map :userid reviewers))))
+        (is (not (contains? (set (map :userid reviewers)) "invalid")))))
     (testing "send review request"
       (is (= 200
              (-> (request :put (str "/api/application/review_request"))

--- a/test/clj/rems/test/api/application.clj
+++ b/test/clj/rems/test/api/application.clj
@@ -482,6 +482,16 @@
         (is (= "invalid api key" body))))))
 
 (deftest application-api-security-test
+  (testing "fetch application without authentication"
+    (let [response (-> (request :get (str "/api/application/1"))
+                       app)
+          body (read-body response)]
+      (is (= body "unauthorized"))))
+  (testing "fetch reviewers without authentication"
+    (let [response (-> (request :get (str "/api/application/reviewers"))
+                       app)
+          body (read-body response)]
+      (is (= body "unauthorized"))))
   (testing "save without authentication"
     (let [response (-> (request :put (str "/api/application/save"))
                        (json-body {:command "save"


### PR DESCRIPTION
Removes invalid reviewers from third party reviewers list. Additionally checks the reviewers api security. Fixes #557 