### PR TITLE
Scripting hooks

### DIFF
--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -22,8 +22,6 @@ function logIt(e) {
   console.log(e);
 }
 
-window.rems = {};
-window.rems.hooks = {};
 window.rems.hooks.get = logIt;
 window.rems.hooks.put = logIt;
 window.rems.hooks.navigate = logIt;

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -1,0 +1,28 @@
+# Hooks
+
+## Extra scripts
+
+You can configure REMS to include extra script files by defining configuration
+
+```clj
+ :extra-scripts {:root "/tmp" :files ["/scripts/foo.js"]}
+```
+
+There you can for example initialize your analytics scripts.
+
+## Event hooks
+
+If you want to hook code into additional events you can include a script file like the following. REMS will attempt to call hooks for `get`, `put` and `navigate` events, if they exist.
+
+```js
+function logIt(e) {
+  // e.g. call your analytics solution here
+  console.log(e);
+}
+
+window.rems = {};
+window.rems.hooks = {};
+window.rems.hooks.get = logIt;
+window.rems.hooks.put = logIt;
+window.rems.hooks.navigate = logIt;
+```

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -2,11 +2,13 @@
 
 ## Extra scripts
 
-You can configure REMS to include extra script files by defining configuration
+You can configure REMS to include extra script files by defining configuration such as:
 
 ```clj
  :extra-scripts {:root "/tmp" :files ["/scripts/foo.js"]}
 ```
+
+This means the script will be served from `/tmp/scripts/foo.js` on your local filesystem. The browser sees only the `/scripts/foo.js` part.
 
 There you can for example initialize your analytics scripts.
 
@@ -26,3 +28,9 @@ window.rems.hooks.get = logIt;
 window.rems.hooks.put = logIt;
 window.rems.hooks.navigate = logIt;
 ```
+
+`window.rems.hooks.get` is called when more data is fetched from the API.
+`window.rems.hooks.put` is called when a command is sent to the API.
+`window.rems.hooks.navigate` is called whenever the Single-Page App changes page i.e. route.
+
+All callbacks get the request path as first parameter. Both `get` and `put` callbacks get an additional parameter that is a map containing other request parameters. You can find query parameters and such from there.

--- a/env/dev/resources/config.edn
+++ b/env/dev/resources/config.edn
@@ -15,6 +15,9 @@
  :ldap {:connection {:host "localhost:2636"
                      :ssl? true}
         :search-root "dc=Suivohtor,dc=local"}
+ ;; optional extra script files loaded when UI loads
+ ;; :extra-scripts {:root "/tmp" :files ["/scripts/foo.js"]}
+
  :extra-pages [;; example of internal page with translation in localization files
                ;; {:id "about" :url "/about" :translation-key :t.navigation/about}
 

--- a/src/clj/rems/layout.clj
+++ b/src/clj/rems/layout.clj
@@ -9,6 +9,18 @@
             [ring.middleware.anti-forgery :refer [*anti-forgery-token*]]
             [ring.util.http-response :as response]))
 
+(defn initialize-hooks []
+  [:script {:type "text/javascript"}
+   "
+window.rems = {
+  hooks: {
+    get: function () {},
+    put: function () {},
+    navigate: function () {}
+  }
+};
+"])
+
 (defn- page-template
   [content]
   (html5 [:html
@@ -28,6 +40,7 @@
            (include-js "/assets/popper.js/dist/umd/popper.min.js")
            (include-js "/assets/tether/dist/js/tether.min.js")
            (include-js "/assets/bootstrap/js/bootstrap.min.js")
+           (initialize-hooks)
            (for [extra-script (get-in env [:extra-scripts :files])]
              (include-js extra-script))
            content]]))

--- a/src/clj/rems/layout.clj
+++ b/src/clj/rems/layout.clj
@@ -1,6 +1,7 @@
 (ns rems.layout
   (:require [cheshire.core :as cheshire]
             [hiccup.page :refer [html5 include-css include-js]]
+            [rems.config :refer [env]]
             [rems.context :as context]
             [rems.db.users :as users]
             [rems.text :refer [text]]
@@ -27,6 +28,8 @@
            (include-js "/assets/popper.js/dist/umd/popper.min.js")
            (include-js "/assets/tether/dist/js/tether.min.js")
            (include-js "/assets/bootstrap/js/bootstrap.min.js")
+           (for [extra-script (get-in env [:extra-scripts :files])]
+             (include-js extra-script))
            content]]))
 
 (defn render

--- a/src/cljs/rems/actions.cljs
+++ b/src/cljs/rems/actions.cljs
@@ -1,25 +1,18 @@
 (ns rems.actions
   "The /actions page that shows a list of applications you can act on."
-  (:require [ajax.core :refer [GET]]
-            [clojure.string :as str]
+  (:require [clojure.string :as str]
             [re-frame.core :as rf]
             [rems.application-list :as application-list]
             [rems.collapsible :as collapsible]
             [rems.guide-functions]
             [rems.text :refer [localize-state localize-time text]]
-            [rems.util :refer [redirect-when-unauthorized]]))
+            [rems.util :refer [fetch]]))
 
 (defn- fetch-actions []
-  (GET "/api/actions/" {:handler #(rf/dispatch [::fetch-actions-result %])
-                        :error-handler redirect-when-unauthorized
-                        :response-format :json
-                        :keywords? true}))
+  (fetch "/api/actions/" {:handler #(rf/dispatch [::fetch-actions-result %])}))
 
 (defn- fetch-handled-actions []
-  (GET "/api/actions/handled" {:handler #(rf/dispatch [::fetch-handled-actions-result %])
-                               :error-handler redirect-when-unauthorized
-                               :response-format :json
-                               :keywords? true}))
+  (fetch "/api/actions/handled" {:handler #(rf/dispatch [::fetch-handled-actions-result %])}))
 
 (rf/reg-fx
  ::fetch-actions

--- a/src/cljs/rems/administration.cljs
+++ b/src/cljs/rems/administration.cljs
@@ -102,20 +102,17 @@
  (fn [db _]
    (::forms db)))
 
-(defn- simple-fetch [path dispatch]
-  (fetch path {:handler dispatch}))
-
 (defn- fetch-catalogue []
-  (simple-fetch "/api/catalogue-items/" #(rf/dispatch [::catalogue %])))
+  (fetch "/api/catalogue-items/" {:handler #(rf/dispatch [::catalogue %])}))
 
 (defn- fetch-workflows []
-  (simple-fetch "/api/workflows/?active=true" #(rf/dispatch [::set-workflows %])))
+  (fetch "/api/workflows/?active=true" {:handler #(rf/dispatch [::set-workflows %])}))
 
 (defn- fetch-resources []
-  (simple-fetch "/api/resources/?active=true" #(rf/dispatch [::set-resources %])))
+  (fetch "/api/resources/?active=true" {:handler #(rf/dispatch [::set-resources %])}))
 
 (defn- fetch-forms []
-  (simple-fetch "/api/forms/?active=true" #(rf/dispatch [::set-forms %])))
+  (fetch "/api/forms/?active=true" {:handler #(rf/dispatch [::set-forms %])}))
 
 (defn- update-catalogue-item [id state]
   (put! "/api/catalogue-items/update" {:params {:id id :state state}

--- a/src/cljs/rems/applications.cljs
+++ b/src/cljs/rems/applications.cljs
@@ -1,15 +1,11 @@
 (ns rems.applications
-  (:require [ajax.core :refer [GET]]
-            [re-frame.core :as rf]
+  (:require [re-frame.core :as rf]
             [rems.application-list :as application-list]
             [rems.text :refer [localize-state localize-time text]]
-            [rems.util :refer [redirect-when-unauthorized]]))
+            [rems.util :refer [fetch]]))
 
 (defn- fetch-my-applications []
-  (GET "/api/applications/" {:handler #(rf/dispatch [::fetch-my-applications %])
-                             :error-handler redirect-when-unauthorized
-                             :response-format :json
-                             :keywords? true}))
+  (fetch "/api/applications/" {:handler #(rf/dispatch [::fetch-my-applications %])}))
 
 (rf/reg-event-db
  ::fetch-my-applications

--- a/src/cljs/rems/catalogue.cljs
+++ b/src/cljs/rems/catalogue.cljs
@@ -47,7 +47,7 @@
     ::fetch-catalogue []}))
 
 (defn- fetch-catalogue []
-  (fetch "/api/catalogue/" {:handler #(rf/dispatch [::catalogue %])}))
+  (fetch "/api/catalogue/" {:handler #(rf/dispatch [::fetch-catalogue-result %])}))
 
 (rf/reg-fx
  ::fetch-catalogue

--- a/src/cljs/rems/catalogue.cljs
+++ b/src/cljs/rems/catalogue.cljs
@@ -1,6 +1,5 @@
 (ns rems.catalogue
-  (:require [ajax.core :refer [GET]]
-            [re-frame.core :as rf]
+  (:require [re-frame.core :as rf]
             [rems.atoms :refer [external-link]]
             [rems.cart :as cart]
             [rems.db.catalogue :refer [disabled-catalogue-item?
@@ -10,7 +9,7 @@
             [rems.guide-functions]
             [rems.table :as table]
             [rems.text :refer [text]]
-            [rems.util :refer [redirect-when-unauthorized]])
+            [rems.util :refer [fetch]])
   (:require-macros [rems.guide-macros :refer [component-info example]]))
 
 (rf/reg-event-db
@@ -59,10 +58,7 @@
    {:class "catalogue"}])
 
 (defn- fetch-catalogue []
-  (GET "/api/catalogue/" {:handler #(rf/dispatch [::catalogue %])
-                          :error-handler redirect-when-unauthorized
-                          :response-format :json
-                          :keywords? true}))
+  (fetch "/api/catalogue/" {:handler #(rf/dispatch [::catalogue %])}))
 
 (defn catalogue-page []
   (fetch-catalogue)

--- a/src/cljs/rems/config.cljs
+++ b/src/cljs/rems/config.cljs
@@ -1,6 +1,6 @@
 (ns rems.config
-  (:require [ajax.core :refer [GET]]
-            [re-frame.core :as rf]))
+  (:require [re-frame.core :as rf]
+            [rems.util :refer [fetch]]))
 
 (rf/reg-event-db
   ::loaded-config
@@ -14,6 +14,4 @@
     (:config db)))
 
 (defn fetch-config! []
-  (GET "/api/config" {:handler #(rf/dispatch [:rems.config/loaded-config %])
-                      :response-format :transit
-                      :keywords? true}))
+  (fetch "/api/config" {:handler #(rf/dispatch [:rems.config/loaded-config %])}))

--- a/src/cljs/rems/navbar.cljs
+++ b/src/cljs/rems/navbar.cljs
@@ -1,6 +1,5 @@
 (ns rems.navbar
-  (:require [ajax.core :refer [GET]]
-            [re-frame.core :as rf]
+  (:require [re-frame.core :as rf]
             [rems.atoms :as atoms]
             [rems.language-switcher :refer [language-switcher]]
             [rems.text :refer [text]])

--- a/src/cljs/rems/spa.cljs
+++ b/src/cljs/rems/spa.cljs
@@ -254,8 +254,7 @@
     (events/listen
      HistoryEventType/NAVIGATE
      (fn [event]
-       (when (and js/window.rems js/window.rems.hooks js/window.rems.hooks.navigate)
-         (js/window.rems.hooks.navigate (.-token event)))
+       (js/window.rems.hooks.navigate (.-token event))
        (secretary/dispatch! (.-token event))))
     (.setEnabled true)))
 

--- a/src/cljs/rems/spa.cljs
+++ b/src/cljs/rems/spa.cljs
@@ -5,7 +5,6 @@
             [goog.events :as events]
             [goog.history.EventType :as HistoryEventType]
             [markdown.core :refer [md->html]]
-            [ajax.core :refer [GET]]
             [rems.actions :refer [actions-page fetch-actions]]
             [rems.administration :refer [administration-page create-catalogue-item-page]]
             [rems.ajax :refer [load-interceptors!]]
@@ -19,7 +18,7 @@
             [rems.guide-page :refer [guide-page]]
             [rems.navbar :as nav]
             [rems.text :refer [text]]
-            [rems.util :refer [dispatch!]])
+            [rems.util :refer [dispatch! fetch]])
   (:import goog.History))
 
 ;;; subscriptions
@@ -251,6 +250,8 @@
     (events/listen
      HistoryEventType/NAVIGATE
      (fn [event]
+       (when (and js/window.rems js/window.rems.hooks js/window.rems.hooks.navigate)
+         (js/window.rems.hooks.navigate (.-token event)))
        (secretary/dispatch! (.-token event))))
     (.setEnabled true)))
 
@@ -273,14 +274,10 @@
                                        user-and-roles)])))
 
 (defn fetch-translations! []
-  (GET "/api/translations" {:handler #(rf/dispatch [:loaded-translations %])
-                            :response-format :json
-                            :keywords? true}))
+  (fetch "/api/translations" {:handler #(rf/dispatch [:loaded-translations %])}))
 
 (defn fetch-theme! []
-  (GET "/api/theme" {:handler #(rf/dispatch [:loaded-theme %])
-                     :response-format :json
-                     :keywords? true}))
+  (fetch "/api/theme" {:handler #(rf/dispatch [:loaded-theme %])}))
 
 (defn mount-components []
   (rf/clear-subscription-cache!)

--- a/src/cljs/rems/util.cljs
+++ b/src/cljs/rems/util.cljs
@@ -48,7 +48,7 @@
   Additionally calls event hooks."
   [url opts]
   (when (and js/window.rems js/window.rems.hooks js/window.rems.hooks.get)
-    (js/window.rems.hooks.get url))
+    (js/window.rems.hooks.get url (clj->js opts)))
   (GET url (merge {:error-handler (wrap-default-error-handler (:error-handler opts))
                    :response-format :transit}
                   opts)))
@@ -61,7 +61,7 @@
   Additionally calls event hooks."
   [url opts]
   (when (and js/window.rems js/window.rems.hooks js/window.rems.hooks.put)
-    (js/window.rems.hooks.put url))
+    (js/window.rems.hooks.put url (clj->js opts)))
   (PUT url (merge {:error-handler (wrap-default-error-handler (:error-handler opts))
                    :format :json
                    :response-format :transit}

--- a/src/cljs/rems/util.cljs
+++ b/src/cljs/rems/util.cljs
@@ -47,8 +47,7 @@
 
   Additionally calls event hooks."
   [url opts]
-  (when (and js/window.rems js/window.rems.hooks js/window.rems.hooks.get)
-    (js/window.rems.hooks.get url (clj->js opts)))
+  (js/window.rems.hooks.get url (clj->js opts))
   (GET url (merge {:error-handler (wrap-default-error-handler (:error-handler opts))
                    :response-format :transit}
                   opts)))
@@ -60,8 +59,7 @@
 
   Additionally calls event hooks."
   [url opts]
-  (when (and js/window.rems js/window.rems.hooks js/window.rems.hooks.put)
-    (js/window.rems.hooks.put url (clj->js opts)))
+  (js/window.rems.hooks.put url (clj->js opts))
   (PUT url (merge {:error-handler (wrap-default-error-handler (:error-handler opts))
                    :format :json
                    :response-format :transit}

--- a/src/cljs/rems/util.cljs
+++ b/src/cljs/rems/util.cljs
@@ -1,5 +1,6 @@
 (ns rems.util
-  (:require [re-frame.core :as rf]))
+  (:require  [ajax.core :refer [GET PUT]]
+             [re-frame.core :as rf]))
 
 (defn select-vals
   "Select values in map `m` specified by given keys `ks`.
@@ -33,3 +34,35 @@
   (when (= 401 status)
     (let [current-url (.. js/window -location -href)]
       (rf/dispatch [:unauthorized! current-url]))))
+
+(defn- wrap-default-error-handler [handler]
+  (fn [err]
+    (redirect-when-unauthorized err)
+    (when handler (handler err))))
+
+(defn fetch
+  "Fetches data from the given url with optional map of options like #'ajax.core/GET.
+
+  Has sensible defaults with error handler, JSON and keywords.
+
+  Additionally calls event hooks."
+  [url opts]
+  (when (and js/window.rems js/window.rems.hooks js/window.rems.hooks.get)
+    (js/window.rems.hooks.get url))
+  (GET url (merge {:error-handler (wrap-default-error-handler (:error-handler opts))
+                   :response-format :transit}
+                  opts)))
+
+(defn put!
+  "Dispatches a command to the given url with optional map of options like #'ajax.core/PUT.
+
+  Has sensible defaults with error handler, JSON and keywords.
+
+  Additionally calls event hooks."
+  [url opts]
+  (when (and js/window.rems js/window.rems.hooks js/window.rems.hooks.put)
+    (js/window.rems.hooks.put url))
+  (PUT url (merge {:error-handler (wrap-default-error-handler (:error-handler opts))
+                   :format :json
+                   :response-format :transit}
+                  opts)))

--- a/test/clj/rems/test/api/applications.clj
+++ b/test/clj/rems/test/api/applications.clj
@@ -15,12 +15,26 @@
   (testing "fetch applications"
     (let [api-key "42"
           user-id "developer"]
-      (let [data (-> (request :get "/api/applications")
-                     (authenticate api-key user-id)
-                     app
-                     read-body)]
-        (is (= [1 2 3 4 5 6 7] (map :id (sort-by :id data)))))))
+      (testing "regular fetch"
+        (let [response (-> (request :get "/api/applications")
+                           (authenticate api-key user-id)
+                           (header "Accept" "application/json")
+                           app)
+              data (read-body response)]
+          (is (response-is-ok? response))
+          (is (= "application/json; charset=utf-8" (get-in response [:headers "Content-Type"])))
+          (is (= [1 2 3 4 5 6 7] (map :id (sort-by :id data))))))
+      (testing "transit support"
+        (let [response (-> (request :get "/api/applications")
+                           (authenticate api-key user-id)
+                           (header "Accept" "application/transit+json")
+                           app)
+              data (read-body response)]
+          (is (response-is-ok? response))
+          (is (= "application/transit+json; charset=utf-8" (get-in response [:headers "Content-Type"])))
+          (is (= 7 (count data))))))))
 
+(deftest applications-api-command-test
   (let [api-key "42"
         user-id "alice"
         another-user "alice_smith"


### PR DESCRIPTION
Implement hooks for custom scripts and documentation for it.

- injecting script files is done through configuration at the server side through `:extra-scripts`
- refactors all ajax `GET` and `PUT` calls into `fetch` and `put!` utility functions that DRYs commonly used parameters
- `window.rems.hooks` is checked for potential callback hooks
- `window.rems.hooks.get` is for data loading requests via `fetch`
- `window.rems.hooks.put` is for command requests via `put!`
- `window.rems.hooks.navigate` is for SPA navigation events

Closes #591 