### PR TITLE
fix: review and 3rd-party review button rendering issues

### DIFF
--- a/src/cljs/rems/application.cljs
+++ b/src/cljs/rems/application.cljs
@@ -657,9 +657,9 @@
                            [return-button]
                            [review-request-button]
                            [approve-button]])
-                        (when (= "normal" (:review-type app))
+                        (when (= :normal (:review-type app))
                           [[review-button]])
-                        (when (= "third-party" (:review-type app))
+                        (when (= :third-party (:review-type app))
                           [[third-party-review-button]]))]
     (if (empty? buttons)
       [:div]


### PR DESCRIPTION
Fixes #670 where reviewers and 3rd-party reviewers can't submit reviews. Test could be added to check these cases when #694 is merged. 