### PR TITLE
Fix localize-time function when dealing with objects instead of strings

### DIFF
--- a/src/cljs/rems/text.cljs
+++ b/src/cljs/rems/text.cljs
@@ -54,7 +54,10 @@
 
 (defn localize-time [time]
   (when time
-    (format/unparse-local time-format (time/to-default-time-zone (format/parse time)))))
+    (let [time (or (when (string? time)
+                     (format/parse time))
+                   time)]
+      (format/unparse-local time-format (time/to-default-time-zone time)))))
 
 (defn localize-item
   ([item]

--- a/src/cljs/rems/text.cljs
+++ b/src/cljs/rems/text.cljs
@@ -54,9 +54,7 @@
 
 (defn localize-time [time]
   (when time
-    (let [time (or (when (string? time)
-                     (format/parse time))
-                   time)]
+    (let [time (if (string? time) (format/parse time) time)]
       (format/unparse-local time-format (time/to-default-time-zone time)))))
 
 (defn localize-item

--- a/src/cljs/rems/text.cljs
+++ b/src/cljs/rems/text.cljs
@@ -53,8 +53,8 @@
   (format/formatter "yyyy-MM-dd HH:mm" (time/default-time-zone)))
 
 (defn localize-time [time]
-  (when time
-    (let [time (if (string? time) (format/parse time) time)]
+  (let [time (if (string? time) (format/parse time) time)]
+    (when time
       (format/unparse-local time-format (time/to-default-time-zone time)))))
 
 (defn localize-item

--- a/test/cljs/rems/test/text.cljs
+++ b/test/cljs/rems/test/text.cljs
@@ -1,0 +1,15 @@
+(ns rems.test.util
+  (:require [cljs.test :refer-macros [deftest is testing]]
+            [cljs-time.core :as time]
+            [cljs-time.format :as format]
+            [rems.text :refer [time-format localize-time]]))
+
+(def test-time #inst "1980-01-02T13:45:00.000Z")
+
+(defn expected-time  [time]
+  (format/unparse-local time-format (time/to-default-time-zone time)))
+
+(deftest localize-time-test
+  (is (= (expected-time test-time) (localize-time "1980-01-02T13:45:00.000Z")))
+  (is (= (expected-time (time/now)) (localize-time "")))
+  (is (= (expected-time test-time) (localize-time #inst "1980-01-02T13:45:00.000Z"))))

--- a/test/cljs/rems/test/text.cljs
+++ b/test/cljs/rems/test/text.cljs
@@ -6,10 +6,14 @@
 
 (def test-time #inst "1980-01-02T13:45:00.000Z")
 
-(defn expected-time  [time]
+(defn expected-time 
+  "Return a given time as a local DateTime instance formatted by rems.text/time-format.
+   Note that exact time checking would make the tests break when run from a different timezone."
+  [time]
   (format/unparse-local time-format (time/to-default-time-zone time)))
 
 (deftest localize-time-test
   (is (= (expected-time test-time) (localize-time "1980-01-02T13:45:00.000Z")))
-  (is (= (expected-time (time/now)) (localize-time "")))
-  (is (= (expected-time test-time) (localize-time #inst "1980-01-02T13:45:00.000Z"))))
+  (is (= nil (localize-time "")))
+  (is (= (expected-time test-time) (localize-time #inst "1980-01-02T13:45:00.000Z")))
+  (is (= nil (localize-time nil))))


### PR DESCRIPTION
Fix bug where sometimes current time was shown instead of the actual time the event had occured.