### PR TITLE
Show app version in footer, link to github

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,4 +21,3 @@
 /.rebel_readline_history
 /package-lock.json
 /browsertest-errors
-/resources/git-describe.txt

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@
 /.rebel_readline_history
 /package-lock.json
 /browsertest-errors
+/resources/git-describe.txt

--- a/project.clj
+++ b/project.clj
@@ -106,6 +106,7 @@
   :profiles
   {:uberjar {:omit-source true
              :prep-tasks [["shell" "sh" "-c" "mkdir -p target/uberjar/resources && git describe --tags --long --always --dirty=-custom > target/uberjar/resources/git-describe.txt"]
+                          ["shell" "sh" "-c" "mkdir -p target/uberjar/resources && git rev-parse HEAD > target/uberjar/resources/git-revision.txt"]
                           "compile"
                           ["cljsbuild" "once" "min"]]
              :cljsbuild {:builds {:min {:source-paths ["src/cljc" "src/cljs"]

--- a/project.clj
+++ b/project.clj
@@ -105,7 +105,7 @@
 
   :profiles
   {:uberjar {:omit-source true
-             :prep-tasks [["shell" "sh" "-c" "mkdir -p target/uberjar/resources && git describe --always --dirty=-custom > target/uberjar/resources/git-describe.txt"]
+             :prep-tasks [["shell" "sh" "-c" "mkdir -p target/uberjar/resources && git describe --tags --long --always --dirty=-custom > target/uberjar/resources/git-describe.txt"]
                           "compile"
                           ["cljsbuild" "once" "min"]]
              :cljsbuild {:builds {:min {:source-paths ["src/cljc" "src/cljs"]

--- a/project.clj
+++ b/project.clj
@@ -105,8 +105,9 @@
 
   :profiles
   {:uberjar {:omit-source true
-             :prep-tasks [["shell" "sh" "-c" "mkdir -p target/uberjar/resources && git describe --tags --long --always --dirty=-custom > target/uberjar/resources/git-describe.txt"]
-                          ["shell" "sh" "-c" "mkdir -p target/uberjar/resources && git rev-parse HEAD > target/uberjar/resources/git-revision.txt"]
+             :prep-tasks [["shell" "sh" "-c" "mkdir -p target/uberjar/resources"]
+                          ["shell" "sh" "-c" "git describe --tags --long --always --dirty=-custom > target/uberjar/resources/git-describe.txt"]
+                          ["shell" "sh" "-c" "git rev-parse HEAD > target/uberjar/resources/git-revision.txt"]
                           "compile"
                           ["cljsbuild" "once" "min"]]
              :cljsbuild {:builds {:min {:source-paths ["src/cljc" "src/cljs"]

--- a/src/cljs/rems/read_gitlog.clj
+++ b/src/cljs/rems/read_gitlog.clj
@@ -4,8 +4,14 @@
 
 (defmacro read-current-version []
   (try
-    (-> "git-describe.txt"
-        io/resource
-        slurp
-        str/trim)
-    (catch java.io.IOException _ [])))
+    (let [full (-> "git-describe.txt"
+                   io/resource
+                   slurp
+                   str/trim)
+          [tag commits-since commit dirty] (str/split full #"-")]
+      {:full full
+       :tag tag
+       :commits-since commits-since
+       :commit commit
+       :dirty dirty})
+    (catch java.io.IOException _ "")))

--- a/src/cljs/rems/read_gitlog.clj
+++ b/src/cljs/rems/read_gitlog.clj
@@ -3,9 +3,9 @@
             [clojure.string :as str]
             [clojure.java.shell :as sh]))
 
-(def ^{:private true} version-description-file "git-describe.txt")
-(def ^{:private true} version-revision-file "git-revision.txt")
-(def ^{:private true} repo-url "https://github.com/CSCfi/rems/commit/")
+(def ^:private version-description-file "git-describe.txt")
+(def ^:private version-revision-file "git-revision.txt")
+(def ^:private repo-url "https://github.com/CSCfi/rems/commit/")
 
 (defn- read-file [name]
   (some-> name

--- a/src/cljs/rems/read_gitlog.clj
+++ b/src/cljs/rems/read_gitlog.clj
@@ -21,4 +21,4 @@
         {:version version
          :revision revision
          :repo-url repo-url}))
-    (catch java.io.IOException _ "")))
+    (catch java.io.IOException _ nil)))

--- a/src/cljs/rems/read_gitlog.clj
+++ b/src/cljs/rems/read_gitlog.clj
@@ -1,0 +1,11 @@
+(ns rems.read-gitlog
+  (:require [clojure.java.io :as io]
+            [clojure.string :as str]))
+
+(defmacro read-current-version []
+  (try
+    (-> "git-describe.txt"
+        io/resource
+        slurp
+        str/trim)
+    (catch java.io.IOException _ [])))

--- a/src/cljs/rems/read_gitlog.clj
+++ b/src/cljs/rems/read_gitlog.clj
@@ -1,17 +1,24 @@
 (ns rems.read-gitlog
   (:require [clojure.java.io :as io]
-            [clojure.string :as str]))
+            [clojure.string :as str]
+            [clojure.java.shell :as sh]))
+
+(def ^{:private true} version-description-file "git-describe.txt")
+(def ^{:private true} version-revision-file "git-revision.txt")
+(def ^{:private true} repo-url "https://github.com/CSCfi/rems/commit/")
+
+(defn- read-file [name]
+  (some-> name
+          io/resource
+          slurp
+          str/trim))
 
 (defmacro read-current-version []
   (try
-    (let [full (-> "git-describe.txt"
-                   io/resource
-                   slurp
-                   str/trim)
-          [tag commits-since commit dirty] (str/split full #"-")]
-      {:full full
-       :tag tag
-       :commits-since commits-since
-       :commit commit
-       :dirty dirty})
+    (let [version (read-file version-description-file)
+          revision (read-file version-revision-file)]
+      (when (and version revision)
+        {:version version
+         :revision revision
+         :repo-url repo-url}))
     (catch java.io.IOException _ "")))

--- a/src/cljs/rems/spa.cljs
+++ b/src/cljs/rems/spa.cljs
@@ -210,10 +210,10 @@
   [:footer.footer
    [:div.container [:nav.navbar
                     [:div.navbar-text (text :t/footer)]
-                    (let [{:keys [full commit]} (read-current-version)]
+                    (when-let [{:keys [version revision repo-url]} (read-current-version)]
                       [:div#footer-release-number
-                       [:a {:href (str "https://github.com/CSCfi/rems/commit/" commit)}
-                        full]])]]])
+                       [:a {:href (str repo-url revision)}
+                        version]])]]])
 
 (defn logo []
   [:div.logo [:div.container.img]])

--- a/src/cljs/rems/spa.cljs
+++ b/src/cljs/rems/spa.cljs
@@ -24,6 +24,7 @@
             [rems.navbar :as nav]
             [rems.text :refer [text]]
             [rems.util :refer [dispatch! fetch]])
+  (:require-macros [rems.read-gitlog :refer [read-current-version]])
   (:import goog.History))
 
 ;;; subscriptions
@@ -207,7 +208,9 @@
 
 (defn footer []
   [:footer.footer
-   [:div.container [:nav.navbar [:div.navbar-text (text :t/footer)]]]])
+   [:div.container [:nav.navbar
+                    [:div.navbar-text (text :t/footer)]
+                    [:div#footer-release-number (read-current-version)]]]])
 
 (defn logo []
   [:div.logo [:div.container.img]])

--- a/src/cljs/rems/spa.cljs
+++ b/src/cljs/rems/spa.cljs
@@ -210,7 +210,10 @@
   [:footer.footer
    [:div.container [:nav.navbar
                     [:div.navbar-text (text :t/footer)]
-                    [:div#footer-release-number (read-current-version)]]]])
+                    (let [{:keys [full commit]} (read-current-version)]
+                      [:div#footer-release-number
+                       [:a {:href (str "https://github.com/CSCfi/rems/commit/" commit)}
+                        full]])]]])
 
 (defn logo []
   [:div.logo [:div.container.img]])


### PR DESCRIPTION
Before building the uberjar, write a git description and revision number to text files. During macro compilation, those files are read, and then their contents are used in clojurescript to add a version string to the footer. The version string is a link to github.