### PR TITLE
Remove unboxed math warnings

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -129,7 +129,7 @@
 
    :project/dev {:dependencies [[binaryage/devtools "0.9.10"]
                                 [com.cemerick/piggieback "0.2.2"]
-                                [macroz/core.rrb-vector "0.0.14"]
+                                [macroz/core.rrb-vector "0.0.14.1"]
                                 [doo "0.1.10" :exclusions [rrb-vector]]
                                 [eftest "0.5.2"]
                                 [figwheel-sidecar "0.5.16" :exclusions [org.clojure/tools.nrepl org.clojure/core.async com.fasterxml.jackson.core/jackson-core]]

--- a/project.clj
+++ b/project.clj
@@ -129,9 +129,7 @@
 
    :project/dev {:dependencies [[binaryage/devtools "0.9.10"]
                                 [com.cemerick/piggieback "0.2.2"]
-                                ;; https://github.com/emezeske/lein-cljsbuild/issues/469
-                                ;; rrb-vector doesn't compile cleanly on cljs right now, see
-                                [quantum/org.clojure.core.rrb-vector "0.0.12"]
+                                [org.clojure/core.rrb-vector "0.0.13"]
                                 [doo "0.1.10" :exclusions [rrb-vector]]
                                 [eftest "0.5.2"]
                                 [figwheel-sidecar "0.5.16" :exclusions [org.clojure/tools.nrepl org.clojure/core.async com.fasterxml.jackson.core/jackson-core]]

--- a/project.clj
+++ b/project.clj
@@ -129,7 +129,7 @@
 
    :project/dev {:dependencies [[binaryage/devtools "0.9.10"]
                                 [com.cemerick/piggieback "0.2.2"]
-                                [org.clojure/core.rrb-vector "0.0.13"]
+                                [macroz/core.rrb-vector "0.0.14"]
                                 [doo "0.1.10" :exclusions [rrb-vector]]
                                 [eftest "0.5.2"]
                                 [figwheel-sidecar "0.5.16" :exclusions [org.clojure/tools.nrepl org.clojure/core.async com.fasterxml.jackson.core/jackson-core]]


### PR DESCRIPTION
Should fix the extensive printing about unboxed math.

Done by a fork where I rename the `ranges` macro to `ranges-macro` so it does not conflict with the cljs `ranges` function.