### PR TITLE
Form styling

### DIFF
--- a/src/clj/rems/css/styles.clj
+++ b/src/clj/rems/css/styles.clj
@@ -403,6 +403,7 @@
    [(s/descendant :.card-header :a) {:color "inherit"}]
    ;; hax for opening misalignment
    [:.license-title {:margin-top (u/px 3)}]
+   [:.license-block {:color "#000"}]
    [:.collapsing {:-webkit-transition "height 0.1s linear"
                   :-o-transition "height 0.1s linear"
                   :transition "height 0.1s linear"}]

--- a/src/clj/rems/css/styles.clj
+++ b/src/clj/rems/css/styles.clj
@@ -336,6 +336,10 @@
    [:.upload-file {:display "inline-block"
                    :margin-right (u/px 10)}]
    [:textarea.form-control {:overflow "hidden"}]
+   [:div.form-control {:height "inherit"
+                       :white-space "pre-wrap"
+                       :border "none"
+                       :background-color "rgba(0,0,0,.01)"}]
    [:form.inline
     :.form-actions.inline
     {:display :inline-block}
@@ -359,10 +363,10 @@
     (s/> :.commands "*:not(:first-child)")
     {:margin-left (u/em 0.5)}]
 
-                                        ; form inputs
+   ;; form inputs
    ["input[type=date].form-control" {:width (u/em 12)}]
 
-                                        ; workflow editor
+   ;; workflow editor
    [:.workflow-round dashed-form-group
     [:h2 {:font-weight 500
           :font-size (u/rem 1.4)}]]
@@ -374,7 +378,7 @@
    [:.new-workflow-round {:text-align "center"}]
    [:.remove-workflow-round {:float "right"}]
 
-                                        ; form editor
+   ;; form editor
    [:.form-item dashed-form-group]
    [:.form-item-controls {:float "right"}
     [:* {:margin-left (u/em 0.25)}]]
@@ -397,7 +401,7 @@
                      :width "inherit"}]
    [:.card-header.clickable {:cursor "pointer"}]
    [(s/descendant :.card-header :a) {:color "inherit"}]
-                                        ;hax for opening misalignment
+   ;; hax for opening misalignment
    [:.license-title {:margin-top (u/px 3)}]
    [:.collapsing {:-webkit-transition "height 0.1s linear"
                   :-o-transition "height 0.1s linear"
@@ -465,7 +469,7 @@
 
    (generate-phase-styles)
    [(s/descendant :.document :h3) {:margin-top (u/rem 4)}]
-                                        ;These must be last as the parsing fails when the first non-standard element is met
+   ;; These must be last as the parsing fails when the first non-standard element is met
    (generate-form-placeholder-styles)))
 
 (defstate screen :start (g/css {:pretty-print? false} (build-screen)))

--- a/src/clj/rems/css/styles.clj
+++ b/src/clj/rems/css/styles.clj
@@ -403,7 +403,8 @@
    [(s/descendant :.card-header :a) {:color "inherit"}]
    ;; hax for opening misalignment
    [:.license-title {:margin-top (u/px 3)}]
-   [:.license-block {:color "#000"}]
+   [:.license-block {:color "#000"
+                     :white-space "pre-wrap"}]
    [:.collapsing {:-webkit-transition "height 0.1s linear"
                   :-o-transition "height 0.1s linear"
                   :transition "height 0.1s linear"}]

--- a/src/cljs/rems/application.cljs
+++ b/src/cljs/rems/application.cljs
@@ -350,7 +350,6 @@
                            :placeholder inputprompt
                            :class (when validation "is-invalid")
                            :value value
-                           :readOnly readonly
                            :on-change (set-field-value id)}])])
 
 (defn- texta-field
@@ -400,7 +399,6 @@
                            :class (when validation "is-invalid")
                            ;; using :value would reset user input while the user is typing, thus making the component unusable
                            :defaultValue value
-                           :readOnly readonly
                            :min min
                            :max max
                            :on-change (set-field-value id)}])])

--- a/src/cljs/rems/application.cljs
+++ b/src/cljs/rems/application.cljs
@@ -241,8 +241,7 @@
                        (if (:success resp)
                          (do (save-attachment (:id resp) field-id form-data description)
                              (rf/dispatch [::set-status {:status :saved
-                                                         :description description ; TODO here should be saving?
-                                                         }])
+                                                         :description description}]) ; TODO here should be saving?
                              ;; HACK: we both set the location, and fire a fetch-application event
                              ;; because if the location didn't change, secretary won't fire the event
                              (navigate-to (:id resp))
@@ -251,8 +250,7 @@
                                                      :description description ; TODO here should be saving?
                                                      :validation (:validation resp)}])))
             :error-handler (fn [_] (rf/dispatch [::set-status {:status :failed
-                                                               :description description ; TODO here should be saving?
-                                                               }]))
+                                                               :description description}])) ; TODO here should be saving?
             :params payload})))
 
 (rf/reg-event-fx
@@ -334,59 +332,78 @@
    field-component
    [field-validation-message validation title]])
 
+(defn- read-only-field [{:keys [id value]}]
+  (let [value (if (str/blank? value)
+                " " ;; prevent the element from being collapsed
+                (str/trim value))]
+    [:div.form-control {:id id} value]))
+
 (defn- text-field
   [{:keys [title id inputprompt readonly optional value validation] :as opts}]
   [basic-field opts
-   [:input.form-control {:type "text"
-                         :id (id-to-name id)
-                         :name (id-to-name id)
-                         :placeholder inputprompt
-                         :class (when validation "is-invalid")
-                         :value value
-                         :readOnly readonly
-                         :on-change (set-field-value id)}]])
+   (if readonly
+     [read-only-field {:id (id-to-name id)
+                       :value value}]
+     [:input.form-control {:type "text"
+                           :id (id-to-name id)
+                           :name (id-to-name id)
+                           :placeholder inputprompt
+                           :class (when validation "is-invalid")
+                           :value value
+                           :readOnly readonly
+                           :on-change (set-field-value id)}])])
 
 (defn- texta-field
   [{:keys [title id inputprompt readonly optional value validation] :as opts}]
   [basic-field opts
-   [textarea {:id (id-to-name id)
-              :name (id-to-name id)
-              :placeholder inputprompt
-              :class (if validation "form-control is-invalid" "form-control")
-              :value value
-              :readOnly readonly
-              :on-change (set-field-value id)}]])
+   (if readonly
+     [read-only-field {:id (id-to-name id)
+                       :value value}]
+     [textarea {:id (id-to-name id)
+                :name (id-to-name id)
+                :placeholder inputprompt
+                :class (if validation "form-control is-invalid" "form-control")
+                :value value
+                :on-change (set-field-value id)}])])
 
 (defn attachment-field
   [{:keys [title id readonly optional value validation app-id] :as opts}]
-  [basic-field opts
-   [:div
-    (when (not readonly)
-      [:div.upload-file
-       [:input {:style {:display "none"}
-                :type "file"
-                :id (id-to-name id)
-                :name (id-to-name id)
-                :accept ".pdf, .doc, .docx, .ppt, .pptx, .txt, image/*"
-                :class (when validation "is-invalid")
-                :disabled readonly
-                :on-change (set-attachment id title)}]
-       [:button.btn.btn-secondary {:on-click (fn [e] (.click (.getElementById js/document (id-to-name id))))} (text :t.form/upload)]])
-    (when (not-empty value)
-      [:a {:href (str "/api/applications/attachments/?application-id=" app-id "&field-id=" id) :target "_blank"} value])]])
+  (let [download-link (when (not-empty value)
+                        [:a {:href (str "/api/applications/attachments/?application-id=" app-id "&field-id=" id)
+                             :target "_blank"}
+                         value])]
+    [basic-field opts
+     (if readonly
+       [:div.form-control
+        (or download-link " ")] ;; prevent the element from being collapsed
+       [:div
+        [:div.upload-file
+         [:input {:style {:display "none"}
+                  :type "file"
+                  :id (id-to-name id)
+                  :name (id-to-name id)
+                  :accept ".pdf, .doc, .docx, .ppt, .pptx, .txt, image/*"
+                  :class (when validation "is-invalid")
+                  :on-change (set-attachment id title)}]
+         [:button.btn.btn-secondary {:on-click (fn [e] (.click (.getElementById js/document (id-to-name id))))}
+          (text :t.form/upload)]]
+        download-link])]))
 
 (defn- date-field
   [{:keys [title id readonly optional value min max validation] :as opts}]
   [basic-field opts
-   [:input.form-control {:type "date"
-                         :name (id-to-name id)
-                         :class (when validation "is-invalid")
-                         ;; using :value would reset user input while the user is typing, thus making the component unusable
-                         :defaultValue value
-                         :readOnly readonly
-                         :min min
-                         :max max
-                         :on-change (set-field-value id)}]])
+   (if readonly
+     [read-only-field {:id (id-to-name id)
+                       :value value}] ;; TODO: format in user locale
+     [:input.form-control {:type "date"
+                           :name (id-to-name id)
+                           :class (when validation "is-invalid")
+                           ;; using :value would reset user input while the user is typing, thus making the component unusable
+                           :defaultValue value
+                           :readOnly readonly
+                           :min min
+                           :max max
+                           :on-change (set-field-value id)}])])
 
 (defn- label [{title :title}]
   [:div.form-group
@@ -462,8 +479,7 @@
   [modal/notification {:title (:description state)
                        :content (or content [status-widget (:status state) (:error state)])
                        :on-close #(rf/dispatch [::set-status nil])
-                       :shade? true
-                       }])
+                       :shade? true}])
 
 (defn- button-wrapper [{:keys [id text class on-click]}]
   [:button.btn.mr-3
@@ -524,7 +540,7 @@
   [title value]
   [:div.form-group
    [:label title]
-   [:input.form-control {:type "text" :defaultValue value :readOnly true}]])
+   [:div.form-control value]])
 
 (defn- format-event [event]
   {:userid (:userid event)
@@ -1054,6 +1070,12 @@
             [:form
              [field {:type "text" :title "Title" :inputprompt "prompt"
                      :validation {:key :t.form.validation.required}}]])
+   (example "non-editable field of type \"text\" without text"
+            [:form
+             [field {:type "text" :title "Title" :inputprompt "prompt" :readonly true}]])
+   (example "non-editable field of type \"text\" with text"
+            [:form
+             [field {:type "text" :title "Title" :inputprompt "prompt" :readonly true :value "Lorem ipsum dolor sit amet"}]])
    (example "field of type \"texta\""
             [:form
              [field {:type "texta" :title "Title" :inputprompt "prompt"}]])
@@ -1061,15 +1083,33 @@
             [:form
              [field {:type "texta" :title "Title" :inputprompt "prompt"
                      :validation {:key :t.form.validation.required}}]])
-   (example "editable field of type \"attachment\""
+   (example "non-editable field of type \"texta\""
+            [:form
+             [field {:type "texta" :title "Title" :inputprompt "prompt" :readonly true :value "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam vehicula malesuada gravida. Nulla in massa eget quam porttitor consequat id egestas urna. Aliquam non pharetra dolor. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Sed quis ante at nunc convallis aliquet at quis ligula. Aliquam accumsan consectetur risus. Quisque semper turpis a erat dapibus iaculis.\n\nCras sit amet laoreet lectus. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos. Phasellus vestibulum a metus in laoreet. Phasellus eleifend eget dui vitae tincidunt. Aenean eu sapien sed nibh viverra facilisis in ac nulla. Integer quis odio eu sapien porta interdum in eu nulla. Sed sodales efficitur diam, vel iaculis ante bibendum vel. Praesent pretium ut lorem sit amet viverra. Etiam luctus nisi eget pharetra rutrum.\n"}]])
+   (example "field of type \"attachment\""
             [:form
              [field {:type "attachment" :title "Title"}]])
+   (example "field of type \"attachment\", file uploaded"
+            [:form
+             [field {:type "attachment" :title "Title" :value "test.txt"}]])
    (example "non-editable field of type \"attachment\""
+            [:form
+             [field {:type "attachment" :title "Title" :readonly true}]])
+   (example "non-editable field of type \"attachment\", file uploaded"
             [:form
              [field {:type "attachment" :title "Title" :readonly true :value "test.txt"}]])
    (example "field of type \"date\""
             [:form
              [field {:type "date" :title "Title"}]])
+   (example "field of type \"date\" with value"
+            [:form
+             [field {:type "date" :title "Title" :value "2000-12-31"}]])
+   (example "non-editable field of type \"date\""
+            [:form
+             [field {:type "date" :title "Title" :readonly true :value ""}]])
+   (example "non-editable field of type \"date\" with value"
+            [:form
+             [field {:type "date" :title "Title" :readonly true :value "2000-12-31"}]])
    (example "optional field"
             [:form
              [field {:type "texta" :optional "true" :title "Title" :inputprompt "prompt"}]])

--- a/src/cljs/rems/application.cljs
+++ b/src/cljs/rems/application.cljs
@@ -416,18 +416,15 @@
 
 (defn- license [id title approved readonly validation content]
   [:div.license
-   [:div.row
-    [:div.col-1
-     [:input {:type "checkbox"
-              :name (str "license" id)
-              :disabled readonly
-              :class (when validation "is-invalid")
-              :checked approved
-              :on-change (set-license-approval id)}]]
-    [:div.col content]]
-   [:div.row
-    [:div.col
-     [field-validation-message validation title]]]])
+   [:div.form-check
+    [:input.form-check-input {:type "checkbox"
+                              :name (str "license" id)
+                              :disabled readonly
+                              :class (when validation "is-invalid")
+                              :checked approved
+                              :on-change (set-license-approval id)}]
+    [:span.form-check-label content]]
+   [field-validation-message validation title]])
 
 (defn- link-license
   [{:keys [title id textcontent readonly approved validation]}]

--- a/src/cljs/rems/application.cljs
+++ b/src/cljs/rems/application.cljs
@@ -443,7 +443,7 @@
                                    :aria-controls (str "collapse" id)}
       title " " [:i {:class "fa fa-ellipsis-h"}]]]
     [:div.collapse {:id (str "collapse" id)}
-     [:div.license-block textcontent]]]])
+     [:div.license-block (str/trim textcontent)]]]])
 
 (defn- unsupported-field
   [f]
@@ -1020,6 +1020,10 @@
        "sint occaecat cupidatat non proident, sunt in culpa qui officia "
        "deserunt mollit anim id est laborum."))
 
+(def ^:private lipsum-short "Lorem ipsum dolor sit amet")
+
+(def ^:private lipsum-paragraphs "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam vehicula malesuada gravida. Nulla in massa eget quam porttitor consequat id egestas urna. Aliquam non pharetra dolor. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Sed quis ante at nunc convallis aliquet at quis ligula. Aliquam accumsan consectetur risus. Quisque semper turpis a erat dapibus iaculis.\n\nCras sit amet laoreet lectus. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos. Phasellus vestibulum a metus in laoreet. Phasellus eleifend eget dui vitae tincidunt. Aenean eu sapien sed nibh viverra facilisis in ac nulla. Integer quis odio eu sapien porta interdum in eu nulla. Sed sodales efficitur diam, vel iaculis ante bibendum vel. Praesent pretium ut lorem sit amet viverra. Etiam luctus nisi eget pharetra rutrum.\n\n")
+
 (defn guide []
   [:div
    (component-info info-field)
@@ -1072,7 +1076,7 @@
              [field {:type "text" :title "Title" :inputprompt "prompt" :readonly true}]])
    (example "non-editable field of type \"text\" with text"
             [:form
-             [field {:type "text" :title "Title" :inputprompt "prompt" :readonly true :value "Lorem ipsum dolor sit amet"}]])
+             [field {:type "text" :title "Title" :inputprompt "prompt" :readonly true :value lipsum-short}]])
    (example "field of type \"texta\""
             [:form
              [field {:type "texta" :title "Title" :inputprompt "prompt"}]])
@@ -1082,7 +1086,7 @@
                      :validation {:key :t.form.validation.required}}]])
    (example "non-editable field of type \"texta\""
             [:form
-             [field {:type "texta" :title "Title" :inputprompt "prompt" :readonly true :value "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam vehicula malesuada gravida. Nulla in massa eget quam porttitor consequat id egestas urna. Aliquam non pharetra dolor. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Sed quis ante at nunc convallis aliquet at quis ligula. Aliquam accumsan consectetur risus. Quisque semper turpis a erat dapibus iaculis.\n\nCras sit amet laoreet lectus. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos. Phasellus vestibulum a metus in laoreet. Phasellus eleifend eget dui vitae tincidunt. Aenean eu sapien sed nibh viverra facilisis in ac nulla. Integer quis odio eu sapien porta interdum in eu nulla. Sed sodales efficitur diam, vel iaculis ante bibendum vel. Praesent pretium ut lorem sit amet viverra. Etiam luctus nisi eget pharetra rutrum.\n"}]])
+             [field {:type "texta" :title "Title" :inputprompt "prompt" :readonly true :value lipsum-paragraphs}]])
    (example "field of type \"attachment\""
             [:form
              [field {:type "attachment" :title "Title"}]])
@@ -1126,10 +1130,10 @@
    (example "text license"
             [:form
              [field {:type "license" :id 1 :title "A Text License" :licensetype "text"
-                     :textcontent lipsum}]])
+                     :textcontent lipsum-paragraphs}]])
    (example "text license with validation error"
             [:form
-             [field {:type "license" :id 1 :title "A Text License" :licensetype "text" :textcontent lipsum
+             [field {:type "license" :id 1 :title "A Text License" :licensetype "text" :textcontent lipsum-paragraphs
                      :validation {:field {:title "A Text License"} :key :t.form.validation.required}}]])
 
    (component-info render-application)

--- a/src/cljs/rems/application.cljs
+++ b/src/cljs/rems/application.cljs
@@ -506,10 +506,8 @@
         readonly? (not editable?)]
     [collapsible/component
      {:id "form"
-      :class "slow"
-      :open? true
       :title (text :t.form/application)
-      :collapse
+      :always
       [:div
        (into [:div]
              (for [item (:items form)]

--- a/src/cljs/rems/collapsible.cljs
+++ b/src/cljs/rems/collapsible.cljs
@@ -24,8 +24,7 @@
    [:a.text-primary {:on-click #(do (.collapse (js/$ (str "#" id "collapse")) "hide")
                                     (.collapse (js/$ (str "#" id "more")) "show")
                                     (.collapse (js/$ (str "#" id "less")) "hide"))}
-    (text :t.collapse/show-less)]
-   ])
+    (text :t.collapse/show-less)]])
 
 (defn- block [id expanded callback content-always content-hideable]
   [:div.collapse-content


### PR DESCRIPTION
- read-only fields as divs instead of form elements, to prepare for showing diffs (#727)
- improve license styling
- remove "show less" for application body