### PR TITLE
Link to commits until release

### DIFF
--- a/src/clj/rems/read_gitlog.clj
+++ b/src/clj/rems/read_gitlog.clj
@@ -5,7 +5,7 @@
 
 (def ^:private version-description-file "git-describe.txt")
 (def ^:private version-revision-file "git-revision.txt")
-(def ^:private repo-url "https://github.com/CSCfi/rems/commit/")
+(def ^:private repo-url "https://github.com/CSCfi/rems/commits/")
 
 (defn- read-file [name]
   (some-> name


### PR DESCRIPTION
Previous link is to the last commit but we can link to a list of commits until the last commit.