### PR TITLE
Fix workflow editor

### DIFF
--- a/src/clj/rems/api/workflows.clj
+++ b/src/clj/rems/api/workflows.clj
@@ -8,16 +8,18 @@
             [schema.core :as s])
   (:import (org.joda.time DateTime)))
 
+(def UserId s/Str)
+
 (s/defschema Actor
-  {:actoruserid s/Str
+  {:actoruserid UserId
    :round s/Num
    :role (s/enum "approver" "reviewer")})
 
 (s/defschema Workflow
   {:id s/Num
    :organization s/Str
-   :owneruserid s/Str
-   :modifieruserid s/Str
+   :owneruserid UserId
+   :modifieruserid UserId
    :title s/Str
    :final-round s/Num
    :workflow s/Any
@@ -46,9 +48,9 @@
   {:organization s/Str
    :title s/Str
    :type s/Keyword
-   (s/optional-key :handlers) [{:userid s/Str}]
+   (s/optional-key :handlers) [UserId]
    (s/optional-key :rounds) [{:type (s/enum :approval :review)
-                              :actors [{:userid s/Str}]}]})
+                              :actors [UserId]}]})
 
 (s/defschema CreateWorkflowResponse
   {:id s/Num})
@@ -62,6 +64,7 @@
   (doall
    (for [wf (workflow/get-workflows filters)]
      (assoc (format-workflow wf)
+            ;; TODO should this be in db.workflow?
             :actors (db/get-workflow-actors {:wfid (:id wf)})))))
 
 (def workflows-api

--- a/src/clj/rems/db/workflow.clj
+++ b/src/clj/rems/db/workflow.clj
@@ -41,8 +41,8 @@
     (doseq [[round-index round] (map-indexed vector rounds)]
       (doseq [actor (:actors round)]
         (case (:type round)
-          :approval (actors/add-approver! wfid (:userid actor) round-index)
-          :review (actors/add-reviewer! wfid (:userid actor) round-index))))
+          :approval (actors/add-approver! wfid actor round-index)
+          :review (actors/add-reviewer! wfid actor round-index))))
     {:id wfid}))
 
 (defn create-workflow! [command]

--- a/src/cljs/rems/administration/workflow.cljs
+++ b/src/cljs/rems/administration/workflow.cljs
@@ -54,12 +54,8 @@
          :rounds (every? valid-round? (:rounds request))
          nil false)))
 
-(defn- build-request-user [actor]
-  {:userid (:userid actor)})
-
 (defn- build-request-round [round]
-  {:type (:type round)
-   :actors (map build-request-user (:actors round))})
+  (select-keys round [:type :actors]))
 
 (defn build-request [form]
   (let [request {:organization (:organization form)
@@ -67,7 +63,7 @@
                  :type (:type form)}
         request (case (:type form)
                   :auto-approve request
-                  :dynamic (assoc request :handlers (map build-request-user (:handlers form)))
+                  :dynamic (assoc request :handlers (:handlers form))
                   :rounds (assoc request :rounds (map build-request-round (:rounds form))))]
     (when (valid-request? request)
       request)))

--- a/test/clj/rems/test/api/workflows.clj
+++ b/test/clj/rems/test/api/workflows.clj
@@ -35,10 +35,9 @@
                                    :title "workflow title"
                                    :type :rounds
                                    :rounds [{:type :review
-                                             :actors [{:userid "alice"}
-                                                      {:userid "bob"}]}
+                                             :actors ["alice" "bob"]}
                                             {:type :approval
-                                             :actors [{:userid "carl"}]}]})
+                                             :actors ["carl"]}]})
                        (authenticate "42" "owner")
                        app)
           body (read-body response)
@@ -91,8 +90,7 @@
                        (json-body {:organization "abc"
                                    :title "dynamic workflow"
                                    :type :dynamic
-                                   :handlers [{:userid "bob"}
-                                              {:userid "carl"}]})
+                                   :handlers ["bob" "carl"]})
                        (authenticate "42" "owner")
                        app)
           body (read-body response)
@@ -110,8 +108,7 @@
                   :organization "abc"
                   :title "dynamic workflow"
                   :workflow {:type "workflow/dynamic"
-                             :handlers [{:userid "bob"}
-                                        {:userid "carl"}]}}
+                             :handlers ["bob" "carl"]}}
                  (select-keys workflow [:id :organization :title :workflow]))))))))
 
 (deftest workflows-api-filtering-test
@@ -144,7 +141,7 @@
                                      :title "workflow title"
                                      :type :rounds
                                      :rounds [{:type :approval
-                                               :actors [{:userid "bob"}]}]})
+                                               :actors ["bob"]}]})
                          app)]
         (is (response-is-forbidden? response))
         (is (= "<h1>Invalid anti-forgery token</h1>" (read-body response))))))
@@ -162,7 +159,7 @@
                                      :title "workflow title"
                                      :type :rounds
                                      :rounds [{:type :approval
-                                               :actors [{:userid "bob"}]}]})
+                                               :actors ["bob"]}]})
                          (authenticate "42" "alice")
                          app)]
         (is (response-is-unauthorized? response))

--- a/test/cljs/rems/test/administration/workflow.cljs
+++ b/test/cljs/rems/test/administration/workflow.cljs
@@ -33,14 +33,12 @@
     (let [form {:organization "abc"
                 :title "workflow title"
                 :type :dynamic
-                :handlers [{:userid "bob"}
-                           {:userid "carl"}]}]
+                :handlers ["bob" "carl"]}]
       (testing "valid form"
         (is (= {:organization "abc"
                 :title "workflow title"
                 :type :dynamic
-                :handlers [{:userid "bob"}
-                           {:userid "carl"}]}
+                :handlers ["bob" "carl"]}
                (build-request form))))
       (testing "missing handlers"
         (is (nil? (build-request (assoc-in form [:handlers] [])))))))
@@ -50,19 +48,17 @@
                 :title "workflow title"
                 :type :rounds
                 :rounds [{:type :review
-                          :actors [{:userid "alice"}
-                                   {:userid "bob"}]}
+                          :actors ["alice" "bob"]}
                          {:type :approval
-                          :actors [{:userid "carl"}]}]}]
+                          :actors ["carl"]}]}]
       (testing "valid form"
         (is (= {:organization "abc"
                 :title "workflow title"
                 :type :rounds
                 :rounds [{:type :review
-                          :actors [{:userid "alice"}
-                                   {:userid "bob"}]}
+                          :actors ["alice" "bob"]}
                          {:type :approval
-                          :actors [{:userid "carl"}]}]}
+                          :actors ["carl"]}]}
                (build-request form))))
       (testing "missing round type"
         (is (nil? (build-request (assoc-in form [:rounds 0 :type] nil)))))


### PR DESCRIPTION
Workflow editors saved `{:userid "foo"}` into `:handlers` whereas other code expected straight user ids. I removed the unnecessary wrapper map.