### PR TITLE
777 missing component ids

### DIFF
--- a/src/cljs/rems/application.cljs
+++ b/src/cljs/rems/application.cljs
@@ -664,7 +664,10 @@
                   [field (assoc (localize-item license)
                                 :validation (get-in validation-by-field-id [:license (:id license)])
                                 :readonly readonly?
-                                :approved (get licenses (:id license)))]))])]}]))
+                                :approved (let [licenses (if-not readonly?
+                                                           licenses
+                                                           (group-by :id (:licenses form)))]
+                                            (get licenses (:id license))))]))])]}]))
 
 (defn- info-field
   "A component that shows a readonly field with title and value.

--- a/src/cljs/rems/application.cljs
+++ b/src/cljs/rems/application.cljs
@@ -574,7 +574,7 @@
                               :name (str "license" id)
                               :disabled readonly
                               :class (when validation "is-invalid")
-                              :checked approved
+                              :default-checked approved
                               :on-change (set-license-approval id)}]
     [:span.form-check-label content]]
    [field-validation-message validation title]])


### PR DESCRIPTION
Fixes #777 

Also fixed a minor bug where an approved form didn't show the licenses as checked.

Use :default-value instead of :value, to get around warning about controlled vs uncontrolled components. This _seems_ to be the way to go, though to be honest I'm not a 100% sure.