### PR TITLE
Fix duplicate element IDs and remove action form duplication

### DIFF
--- a/src/cljs/rems/actions/action.cljs
+++ b/src/cljs/rems/actions/action.cljs
@@ -30,6 +30,16 @@
                 :value comment
                 :on-change on-comment}]]))
 
+(defn action-comment [{:keys [id label comment on-comment]}]
+  (let [id (str "comment-" id)]
+    [:div.form-group
+     [:label {:for id} label]
+     [textarea {:id id
+                :name id
+                :placeholder (text :t.actions/comment-placeholder)
+                :value comment
+                :on-change on-comment}]]))
+
 (defn action-form-view [id title comment-title buttons content comment on-comment]
   [:div.collapse {:id (action-collapse-id id) :data-parent "#actions-forms"}
    [:h4.mt-5 title]

--- a/src/cljs/rems/actions/action.cljs
+++ b/src/cljs/rems/actions/action.cljs
@@ -36,13 +36,12 @@
    content
    (into [:div.col.commands.mr-3 [cancel-action-button id]] buttons)])
 
-(defn action-button [id content on-click]
+(defn action-button [{:keys [id text class on-click]}]
   [:button.btn.mr-3
    {:id (str id "-action-button")
-    ;; TODO: decouple from action names
-    :class (if (contains? #{"approve" "approve-reject"} id) "btn-primary" "btn-secondary")
+    :class (or class "btn-secondary")
     :type "button"
     :data-toggle "collapse"
     :data-target (str "#" (action-collapse-id id))
     :on-click on-click}
-   (str content " ...")])
+   (str text " ...")])

--- a/src/cljs/rems/actions/action.cljs
+++ b/src/cljs/rems/actions/action.cljs
@@ -20,10 +20,10 @@
     :data-target (str "#" (action-collapse-id id))}
    (text :t.actions/cancel)])
 
-(defn- action-judge-comment [id label-title comment on-comment]
+(defn action-judge-comment [{:keys [id label comment on-comment]}]
   (let [id (str "judge-comment-" id)]
     [:div.form-group
-     [:label {:for id} label-title]
+     [:label {:for id} label]
      [textarea {:id id
                 :name id
                 :placeholder (text :t.actions/comment-placeholder)
@@ -40,10 +40,8 @@
                 :value comment
                 :on-change on-comment}]]))
 
-(defn action-form-view [id title comment-title buttons content comment on-comment]
+(defn action-form-view [id title buttons content]
   [:div.collapse {:id (action-collapse-id id) :data-parent "#actions-forms"}
    [:h4.mt-5 title]
    content
-   (when comment-title
-     [action-judge-comment id comment-title comment on-comment])
    (into [:div.col.commands.mr-3 [cancel-action-button id]] buttons)])

--- a/src/cljs/rems/actions/action.cljs
+++ b/src/cljs/rems/actions/action.cljs
@@ -9,21 +9,23 @@
 (defn button-wrapper [{:keys [id text class on-click]}]
   [:button.btn
    {:id id
-    :name id
     :class (or class :btn-secondary)
     :on-click on-click}
    text])
 
 (defn cancel-action-button [id]
   [:button.btn.btn-secondary
-   {:id (str "cancel-" id) :data-toggle "collapse" :data-target (str "#" (action-collapse-id id))}
+   {:id (str "cancel-" id)
+    :data-toggle "collapse"
+    :data-target (str "#" (action-collapse-id id))}
    (text :t.actions/cancel)])
 
 (defn- action-comment [label-title comment on-comment]
   [:div.form-group
    [:label {:for "judge-comment"} label-title]
    [textarea {:id "judge-comment"
-              :name "judge-comment" :placeholder (text :t.actions/comment-placeholder)
+              :name "judge-comment"
+              :placeholder (text :t.actions/comment-placeholder)
               :value comment
               :on-change on-comment}]])
 

--- a/src/cljs/rems/actions/action.cljs
+++ b/src/cljs/rems/actions/action.cljs
@@ -20,19 +20,20 @@
     :data-target (str "#" (action-collapse-id id))}
    (text :t.actions/cancel)])
 
-(defn- action-comment [label-title comment on-comment]
-  [:div.form-group
-   [:label {:for "judge-comment"} label-title]
-   [textarea {:id "judge-comment"
-              :name "judge-comment"
-              :placeholder (text :t.actions/comment-placeholder)
-              :value comment
-              :on-change on-comment}]])
+(defn- action-judge-comment [id label-title comment on-comment]
+  (let [id (str "judge-comment-" id)]
+    [:div.form-group
+     [:label {:for id} label-title]
+     [textarea {:id id
+                :name id
+                :placeholder (text :t.actions/comment-placeholder)
+                :value comment
+                :on-change on-comment}]]))
 
 (defn action-form-view [id title comment-title buttons content comment on-comment]
   [:div.collapse {:id (action-collapse-id id) :data-parent "#actions-forms"}
    [:h4.mt-5 title]
    content
    (when comment-title
-     [action-comment comment-title comment on-comment])
+     [action-judge-comment id comment-title comment on-comment])
    (into [:div.col.commands.mr-3 [cancel-action-button id]] buttons)])

--- a/src/cljs/rems/actions/action.cljs
+++ b/src/cljs/rems/actions/action.cljs
@@ -20,16 +20,6 @@
     :data-target (str "#" (action-collapse-id id))}
    (text :t.actions/cancel)])
 
-(defn action-judge-comment [{:keys [id label comment on-comment]}]
-  (let [id (str "judge-comment-" id)]
-    [:div.form-group
-     [:label {:for id} label]
-     [textarea {:id id
-                :name id
-                :placeholder (text :t.actions/comment-placeholder)
-                :value comment
-                :on-change #(on-comment (.. % -target -value))}]]))
-
 (defn action-comment [{:keys [id label comment on-comment]}]
   (let [id (str "comment-" id)]
     [:div.form-group

--- a/src/cljs/rems/actions/action.cljs
+++ b/src/cljs/rems/actions/action.cljs
@@ -28,7 +28,7 @@
                 :name id
                 :placeholder (text :t.actions/comment-placeholder)
                 :value comment
-                :on-change on-comment}]]))
+                :on-change #(on-comment (.. % -target -value))}]]))
 
 (defn action-comment [{:keys [id label comment on-comment]}]
   (let [id (str "comment-" id)]
@@ -38,7 +38,7 @@
                 :name id
                 :placeholder (text :t.actions/comment-placeholder)
                 :value comment
-                :on-change on-comment}]]))
+                :on-change #(on-comment (.. % -target -value))}]]))
 
 (defn action-form-view [id title buttons content]
   [:div.collapse {:id (action-collapse-id id) :data-parent "#actions-forms"}

--- a/src/cljs/rems/actions/action.cljs
+++ b/src/cljs/rems/actions/action.cljs
@@ -35,3 +35,14 @@
    [:h4.mt-5 title]
    content
    (into [:div.col.commands.mr-3 [cancel-action-button id]] buttons)])
+
+(defn action-button [id content on-click]
+  [:button.btn.mr-3
+   {:id (str id "-action-button")
+    ;; TODO: decouple from action names
+    :class (if (contains? #{"approve" "approve-reject"} id) "btn-primary" "btn-secondary")
+    :type "button"
+    :data-toggle "collapse"
+    :data-target (str "#" (action-collapse-id id))
+    :on-click on-click}
+   (str content " ...")])

--- a/src/cljs/rems/actions/approve_reject.cljs
+++ b/src/cljs/rems/actions/approve_reject.cljs
@@ -61,11 +61,11 @@
   [action-form-view "approve-reject"
    (text :t.actions/comment)
    nil
-   [[button-wrapper {:id "reject"
+   [[button-wrapper {:id "do-reject"
                      :text (text :t.actions/reject)
                      :class "btn-danger"
                      :on-click on-reject}]
-    [button-wrapper {:id "approve"
+    [button-wrapper {:id "do-approve"
                      :text (text :t.actions/approve)
                      :class "btn-success"
                      :on-click on-approve}]]
@@ -84,7 +84,7 @@
         description (text :t.actions/comment)
         state (r/atom nil)
         on-pending #(reset! state {:status :pending})
-        on-success #(reset! state {:status :saved })
+        on-success #(reset! state {:status :saved})
         on-error #(reset! state {:status :failed :error %})
         on-modal-close #(do (reset! state nil)
                             (on-finished))]

--- a/src/cljs/rems/actions/approve_reject.cljs
+++ b/src/cljs/rems/actions/approve_reject.cljs
@@ -71,7 +71,7 @@
    [action-comment {:id "approve-reject"
                     :label (text :t.form/add-comments-shown-to-applicant)
                     :comment comment
-                    :on-comment #(on-set-comment (.. % -target -value))}]])
+                    :on-comment on-set-comment}]])
 
 (defn approve-reject-form [application-id on-finished]
   (let [comment (rf/subscribe [::comment])

--- a/src/cljs/rems/actions/approve_reject.cljs
+++ b/src/cljs/rems/actions/approve_reject.cljs
@@ -3,7 +3,6 @@
             [reagent.core :as r]
             [rems.actions.action :refer [action-button action-form-view action-comment button-wrapper]]
             [rems.atoms :refer [textarea]]
-            [rems.autocomplete :as autocomplete]
             [rems.status-modal :refer [status-modal]]
             [rems.text :refer [text]]
             [rems.util :refer [fetch post!]]))
@@ -57,7 +56,7 @@
    {}))
 
 (defn approve-reject-action-button []
-  [action-button "approve-reject" (text :t.actions/approve-reject)])
+  [action-button "approve-reject" (text :t.actions/approve-reject) #(rf/dispatch [::open-form])])
 
 (defn approve-reject-view
   [{:keys [comment on-set-comment on-approve on-reject]}]

--- a/src/cljs/rems/actions/approve_reject.cljs
+++ b/src/cljs/rems/actions/approve_reject.cljs
@@ -60,11 +60,11 @@
   [{:keys [comment on-set-comment on-approve on-reject]}]
   [action-form-view "approve-reject"
    (text :t.actions/comment)
-   [[button-wrapper {:id "do-reject"
+   [[button-wrapper {:id "reject"
                      :text (text :t.actions/reject)
                      :class "btn-danger"
                      :on-click on-reject}]
-    [button-wrapper {:id "do-approve"
+    [button-wrapper {:id "approve"
                      :text (text :t.actions/approve)
                      :class "btn-success"
                      :on-click on-approve}]]

--- a/src/cljs/rems/actions/approve_reject.cljs
+++ b/src/cljs/rems/actions/approve_reject.cljs
@@ -58,7 +58,10 @@
 (def ^:private action-form-id "approve-reject")
 
 (defn approve-reject-action-button []
-  [action-button action-form-id (text :t.actions/approve-reject) #(rf/dispatch [::open-form])])
+  [action-button {:id action-form-id
+                  :text (text :t.actions/approve-reject)
+                  :class "btn-primary"
+                  :on-click #(rf/dispatch [::open-form])}])
 
 (defn approve-reject-view
   [{:keys [comment on-set-comment on-approve on-reject]}]

--- a/src/cljs/rems/actions/approve_reject.cljs
+++ b/src/cljs/rems/actions/approve_reject.cljs
@@ -70,9 +70,9 @@
                      :class "btn-success"
                      :on-click on-approve}]]
    [:div [:div.form-group
-          [:label {:for "comment"} (text :t.form/add-comments-shown-to-applicant)]
-          [textarea {:id "comment"
-                     :name "comment"
+          [:label {:for "comment-approve-reject"} (text :t.form/add-comments-shown-to-applicant)]
+          [textarea {:id "comment-approve-reject"
+                     :name "comment-approve-reject"
                      :placeholder (text :t.form/comment)
                      :value comment
                      :on-change #(on-set-comment (.. % -target -value))}]]]

--- a/src/cljs/rems/actions/approve_reject.cljs
+++ b/src/cljs/rems/actions/approve_reject.cljs
@@ -55,12 +55,14 @@
    (on-pending)
    {}))
 
+(def ^:private action-form-id "approve-reject")
+
 (defn approve-reject-action-button []
-  [action-button "approve-reject" (text :t.actions/approve-reject) #(rf/dispatch [::open-form])])
+  [action-button action-form-id (text :t.actions/approve-reject) #(rf/dispatch [::open-form])])
 
 (defn approve-reject-view
   [{:keys [comment on-set-comment on-approve on-reject]}]
-  [action-form-view "approve-reject"
+  [action-form-view action-form-id
    (text :t.actions/comment)
    [[button-wrapper {:id "reject"
                      :text (text :t.actions/reject)
@@ -70,7 +72,7 @@
                      :text (text :t.actions/approve)
                      :class "btn-success"
                      :on-click on-approve}]]
-   [action-comment {:id "approve-reject"
+   [action-comment {:id action-form-id
                     :label (text :t.form/add-comments-shown-to-applicant)
                     :comment comment
                     :on-comment on-set-comment}]])

--- a/src/cljs/rems/actions/approve_reject.cljs
+++ b/src/cljs/rems/actions/approve_reject.cljs
@@ -1,7 +1,7 @@
 (ns rems.actions.approve-reject
   (:require [re-frame.core :as rf]
             [reagent.core :as r]
-            [rems.actions.action :refer [action-form-view button-wrapper]]
+            [rems.actions.action :refer [action-form-view action-comment button-wrapper]]
             [rems.atoms :refer [textarea]]
             [rems.autocomplete :as autocomplete]
             [rems.status-modal :refer [status-modal]]
@@ -69,13 +69,10 @@
                      :text (text :t.actions/approve)
                      :class "btn-success"
                      :on-click on-approve}]]
-   [:div [:div.form-group
-          [:label {:for "comment-approve-reject"} (text :t.form/add-comments-shown-to-applicant)]
-          [textarea {:id "comment-approve-reject"
-                     :name "comment-approve-reject"
-                     :placeholder (text :t.form/comment)
-                     :value comment
-                     :on-change #(on-set-comment (.. % -target -value))}]]]
+   [action-comment {:id "approve-reject"
+                    :label (text :t.form/add-comments-shown-to-applicant)
+                    :comment comment
+                    :on-comment #(on-set-comment (.. % -target -value))}]
    nil
    nil])
 

--- a/src/cljs/rems/actions/approve_reject.cljs
+++ b/src/cljs/rems/actions/approve_reject.cljs
@@ -60,7 +60,6 @@
   [{:keys [comment on-set-comment on-approve on-reject]}]
   [action-form-view "approve-reject"
    (text :t.actions/comment)
-   nil
    [[button-wrapper {:id "do-reject"
                      :text (text :t.actions/reject)
                      :class "btn-danger"
@@ -72,9 +71,7 @@
    [action-comment {:id "approve-reject"
                     :label (text :t.form/add-comments-shown-to-applicant)
                     :comment comment
-                    :on-comment #(on-set-comment (.. % -target -value))}]
-   nil
-   nil])
+                    :on-comment #(on-set-comment (.. % -target -value))}]])
 
 (defn approve-reject-form [application-id on-finished]
   (let [comment (rf/subscribe [::comment])

--- a/src/cljs/rems/actions/approve_reject.cljs
+++ b/src/cljs/rems/actions/approve_reject.cljs
@@ -1,7 +1,7 @@
 (ns rems.actions.approve-reject
   (:require [re-frame.core :as rf]
             [reagent.core :as r]
-            [rems.actions.action :refer [action-form-view action-comment button-wrapper]]
+            [rems.actions.action :refer [action-button action-form-view action-comment button-wrapper]]
             [rems.atoms :refer [textarea]]
             [rems.autocomplete :as autocomplete]
             [rems.status-modal :refer [status-modal]]
@@ -55,6 +55,9 @@
                   :on-error on-error})
    (on-pending)
    {}))
+
+(defn approve-reject-action-button []
+  [action-button "approve-reject" (text :t.actions/approve-reject)])
 
 (defn approve-reject-view
   [{:keys [comment on-set-comment on-approve on-reject]}]

--- a/src/cljs/rems/actions/close.cljs
+++ b/src/cljs/rems/actions/close.cljs
@@ -42,7 +42,7 @@
   [{:keys [comment on-set-comment on-send]}]
   [action-form-view "close"
    (text :t.actions/close)
-   [[button-wrapper {:id "do-close"
+   [[button-wrapper {:id "close"
                      :text (text :t.actions/close)
                      :class "btn-danger"
                      :on-click on-send}]]

--- a/src/cljs/rems/actions/close.cljs
+++ b/src/cljs/rems/actions/close.cljs
@@ -42,7 +42,6 @@
   [{:keys [comment on-set-comment on-send]}]
   [action-form-view "close"
    (text :t.actions/close)
-   nil
    [[button-wrapper {:id "do-close"
                      :text (text :t.actions/close)
                      :class "btn-danger"
@@ -50,9 +49,7 @@
    [action-comment {:id "close"
                     :label (text :t.form/add-comments-not-shown-to-applicant)
                     :comment comment
-                    :on-comment #(on-set-comment (.. % -target -value))}]
-   nil
-   nil])
+                    :on-comment #(on-set-comment (.. % -target -value))}]])
 
 (defn close-form [application-id on-finished]
   (let [comment (rf/subscribe [::comment])

--- a/src/cljs/rems/actions/close.cljs
+++ b/src/cljs/rems/actions/close.cljs
@@ -43,7 +43,7 @@
   [action-form-view "close"
    (text :t.actions/close)
    nil
-   [[button-wrapper {:id "close"
+   [[button-wrapper {:id "do-close"
                      :text (text :t.actions/close)
                      :class "btn-danger"
                      :on-click on-send}]]
@@ -62,7 +62,7 @@
         description (text :t.actions/close)
         state (r/atom nil)
         on-pending #(reset! state {:status :pending})
-        on-success #(reset! state {:status :saved })
+        on-success #(reset! state {:status :saved})
         on-error #(reset! state {:status :failed :error %})
         on-modal-close #(do (reset! state nil)
                             (on-finished))]

--- a/src/cljs/rems/actions/close.cljs
+++ b/src/cljs/rems/actions/close.cljs
@@ -1,7 +1,7 @@
 (ns rems.actions.close
   (:require [re-frame.core :as rf]
             [reagent.core :as r]
-            [rems.actions.action :refer [action-form-view button-wrapper]]
+            [rems.actions.action :refer [action-form-view action-comment button-wrapper]]
             [rems.atoms :refer [textarea]]
             [rems.autocomplete :as autocomplete]
             [rems.status-modal :refer [status-modal]]
@@ -47,13 +47,10 @@
                      :text (text :t.actions/close)
                      :class "btn-danger"
                      :on-click on-send}]]
-   [:div [:div.form-group
-          [:label {:for "comment-close"} (text :t.form/add-comments-not-shown-to-applicant)]
-          [textarea {:id "comment-close"
-                     :name "comment-close"
-                     :placeholder (text :t.form/comment)
-                     :value comment
-                     :on-change #(on-set-comment (.. % -target -value))}]]]
+   [action-comment {:id "close"
+                    :label (text :t.form/add-comments-not-shown-to-applicant)
+                    :comment comment
+                    :on-comment #(on-set-comment (.. % -target -value))}]
    nil
    nil])
 

--- a/src/cljs/rems/actions/close.cljs
+++ b/src/cljs/rems/actions/close.cljs
@@ -48,9 +48,9 @@
                      :class "btn-danger"
                      :on-click on-send}]]
    [:div [:div.form-group
-          [:label {:for "comment"} (text :t.form/add-comments-not-shown-to-applicant)]
-          [textarea {:id "comment"
-                     :name "comment"
+          [:label {:for "comment-close"} (text :t.form/add-comments-not-shown-to-applicant)]
+          [textarea {:id "comment-close"
+                     :name "comment-close"
                      :placeholder (text :t.form/comment)
                      :value comment
                      :on-change #(on-set-comment (.. % -target -value))}]]]

--- a/src/cljs/rems/actions/close.cljs
+++ b/src/cljs/rems/actions/close.cljs
@@ -37,18 +37,20 @@
    (on-pending)
    {}))
 
+(def ^:private action-form-id "close")
+
 (defn close-action-button []
-  [action-button "close" (text :t.actions/close) #(rf/dispatch [::open-form])])
+  [action-button action-form-id (text :t.actions/close) #(rf/dispatch [::open-form])])
 
 (defn close-view
   [{:keys [comment on-set-comment on-send]}]
-  [action-form-view "close"
+  [action-form-view action-form-id
    (text :t.actions/close)
    [[button-wrapper {:id "close"
                      :text (text :t.actions/close)
                      :class "btn-danger"
                      :on-click on-send}]]
-   [action-comment {:id "close"
+   [action-comment {:id action-form-id
                     :label (text :t.form/add-comments-not-shown-to-applicant)
                     :comment comment
                     :on-comment on-set-comment}]])

--- a/src/cljs/rems/actions/close.cljs
+++ b/src/cljs/rems/actions/close.cljs
@@ -40,7 +40,9 @@
 (def ^:private action-form-id "close")
 
 (defn close-action-button []
-  [action-button action-form-id (text :t.actions/close) #(rf/dispatch [::open-form])])
+  [action-button {:id action-form-id
+                  :text (text :t.actions/close)
+                  :on-click #(rf/dispatch [::open-form])}])
 
 (defn close-view
   [{:keys [comment on-set-comment on-send]}]

--- a/src/cljs/rems/actions/close.cljs
+++ b/src/cljs/rems/actions/close.cljs
@@ -1,9 +1,8 @@
 (ns rems.actions.close
   (:require [re-frame.core :as rf]
             [reagent.core :as r]
-            [rems.actions.action :refer [action-form-view action-comment button-wrapper]]
+            [rems.actions.action :refer [action-button action-form-view action-comment button-wrapper]]
             [rems.atoms :refer [textarea]]
-            [rems.autocomplete :as autocomplete]
             [rems.status-modal :refer [status-modal]]
             [rems.text :refer [text]]
             [rems.util :refer [fetch post!]]))
@@ -37,6 +36,9 @@
                  :on-error on-error})
    (on-pending)
    {}))
+
+(defn close-action-button []
+  [action-button "close" (text :t.actions/close) #(rf/dispatch [::open-form])])
 
 (defn close-view
   [{:keys [comment on-set-comment on-send]}]

--- a/src/cljs/rems/actions/close.cljs
+++ b/src/cljs/rems/actions/close.cljs
@@ -49,7 +49,7 @@
    [action-comment {:id "close"
                     :label (text :t.form/add-comments-not-shown-to-applicant)
                     :comment comment
-                    :on-comment #(on-set-comment (.. % -target -value))}]])
+                    :on-comment on-set-comment}]])
 
 (defn close-form [application-id on-finished]
   (let [comment (rf/subscribe [::comment])

--- a/src/cljs/rems/actions/comment.cljs
+++ b/src/cljs/rems/actions/comment.cljs
@@ -42,16 +42,13 @@
   [{:keys [comment on-set-comment on-send]}]
   [action-form-view "comment"
    (text :t.actions/comment)
-   nil
    [[button-wrapper {:id "do-comment"
                      :text (text :t.actions/comment)
                      :on-click on-send}]]
    [action-comment {:id "comment"
                     :label (text :t.form/add-comments-not-shown-to-applicant)
                     :comment comment
-                    :on-comment #(on-set-comment (.. % -target -value))}]
-   nil
-   nil])
+                    :on-comment #(on-set-comment (.. % -target -value))}]])
 
 (defn comment-form [application-id on-finished]
   (let [comment (rf/subscribe [::comment])

--- a/src/cljs/rems/actions/comment.cljs
+++ b/src/cljs/rems/actions/comment.cljs
@@ -1,7 +1,7 @@
 (ns rems.actions.comment
   (:require [re-frame.core :as rf]
             [reagent.core :as r]
-            [rems.actions.action :refer [action-form-view button-wrapper]]
+            [rems.actions.action :refer [action-form-view action-comment button-wrapper]]
             [rems.atoms :refer [textarea]]
             [rems.autocomplete :as autocomplete]
             [rems.status-modal :refer [status-modal]]
@@ -46,13 +46,10 @@
    [[button-wrapper {:id "do-comment"
                      :text (text :t.actions/comment)
                      :on-click on-send}]]
-   [:div [:div.form-group
-          [:label {:for "comment-comment"} (text :t.form/add-comments-not-shown-to-applicant)]
-          [textarea {:id "comment-comment"
-                     :name "comment-comment"
-                     :placeholder (text :t.form/comment)
-                     :value comment
-                     :on-change #(on-set-comment (.. % -target -value))}]]]
+   [action-comment {:id "comment"
+                    :label (text :t.form/add-comments-not-shown-to-applicant)
+                    :comment comment
+                    :on-comment #(on-set-comment (.. % -target -value))}]
    nil
    nil])
 

--- a/src/cljs/rems/actions/comment.cljs
+++ b/src/cljs/rems/actions/comment.cljs
@@ -42,7 +42,7 @@
   [{:keys [comment on-set-comment on-send]}]
   [action-form-view "comment"
    (text :t.actions/comment)
-   [[button-wrapper {:id "do-comment"
+   [[button-wrapper {:id "comment"
                      :text (text :t.actions/comment)
                      :on-click on-send}]]
    [action-comment {:id "comment"

--- a/src/cljs/rems/actions/comment.cljs
+++ b/src/cljs/rems/actions/comment.cljs
@@ -40,7 +40,9 @@
 (def ^:private action-form-id "comment")
 
 (defn comment-action-button []
-  [action-button action-form-id (text :t.actions/comment) #(rf/dispatch [::open-form])])
+  [action-button {:id action-form-id
+                  :text (text :t.actions/comment)
+                  :on-click #(rf/dispatch [::open-form])}])
 
 (defn comment-view
   [{:keys [comment on-set-comment on-send]}]

--- a/src/cljs/rems/actions/comment.cljs
+++ b/src/cljs/rems/actions/comment.cljs
@@ -1,9 +1,8 @@
 (ns rems.actions.comment
   (:require [re-frame.core :as rf]
             [reagent.core :as r]
-            [rems.actions.action :refer [action-form-view action-comment button-wrapper]]
+            [rems.actions.action :refer [action-button action-form-view action-comment button-wrapper]]
             [rems.atoms :refer [textarea]]
-            [rems.autocomplete :as autocomplete]
             [rems.status-modal :refer [status-modal]]
             [rems.text :refer [text]]
             [rems.util :refer [fetch post!]]))
@@ -37,6 +36,9 @@
                    :on-error on-error})
    (on-pending)
    {}))
+
+(defn comment-action-button []
+  [action-button "comment" (text :t.actions/comment) #(rf/dispatch [::open-form])])
 
 (defn comment-view
   [{:keys [comment on-set-comment on-send]}]

--- a/src/cljs/rems/actions/comment.cljs
+++ b/src/cljs/rems/actions/comment.cljs
@@ -47,9 +47,9 @@
                      :text (text :t.actions/comment)
                      :on-click on-send}]]
    [:div [:div.form-group
-          [:label {:for "comment"} (text :t.form/add-comments-not-shown-to-applicant)]
-          [textarea {:id "comment"
-                     :name "comment"
+          [:label {:for "comment-comment"} (text :t.form/add-comments-not-shown-to-applicant)]
+          [textarea {:id "comment-comment"
+                     :name "comment-comment"
                      :placeholder (text :t.form/comment)
                      :value comment
                      :on-change #(on-set-comment (.. % -target -value))}]]]

--- a/src/cljs/rems/actions/comment.cljs
+++ b/src/cljs/rems/actions/comment.cljs
@@ -43,9 +43,9 @@
   [action-form-view "comment"
    (text :t.actions/comment)
    nil
-   [[button-wrapper {:id "comment"
-                    :text (text :t.actions/comment)
-                    :on-click on-send}]]
+   [[button-wrapper {:id "do-comment"
+                     :text (text :t.actions/comment)
+                     :on-click on-send}]]
    [:div [:div.form-group
           [:label {:for "comment"} (text :t.form/add-comments-not-shown-to-applicant)]
           [textarea {:id "comment"
@@ -61,7 +61,7 @@
         description (text :t.actions/comment)
         state (r/atom nil)
         on-pending #(reset! state {:status :pending})
-        on-success #(reset! state {:status :saved })
+        on-success #(reset! state {:status :saved})
         on-error #(reset! state {:status :failed :error %})
         on-modal-close #(do (reset! state nil)
                             (on-finished))]

--- a/src/cljs/rems/actions/comment.cljs
+++ b/src/cljs/rems/actions/comment.cljs
@@ -37,18 +37,20 @@
    (on-pending)
    {}))
 
+(def ^:private action-form-id "comment")
+
 (defn comment-action-button []
-  [action-button "comment" (text :t.actions/comment) #(rf/dispatch [::open-form])])
+  [action-button action-form-id (text :t.actions/comment) #(rf/dispatch [::open-form])])
 
 (defn comment-view
   [{:keys [comment on-set-comment on-send]}]
-  [action-form-view "comment"
+  [action-form-view action-form-id
    (text :t.actions/comment)
    [[button-wrapper {:id "comment"
                      :text (text :t.actions/comment)
                      :class "btn-primary"
                      :on-click on-send}]]
-   [action-comment {:id "comment"
+   [action-comment {:id action-form-id
                     :label (text :t.form/add-comments-not-shown-to-applicant)
                     :comment comment
                     :on-comment on-set-comment}]])

--- a/src/cljs/rems/actions/comment.cljs
+++ b/src/cljs/rems/actions/comment.cljs
@@ -48,7 +48,7 @@
    [action-comment {:id "comment"
                     :label (text :t.form/add-comments-not-shown-to-applicant)
                     :comment comment
-                    :on-comment #(on-set-comment (.. % -target -value))}]])
+                    :on-comment on-set-comment}]])
 
 (defn comment-form [application-id on-finished]
   (let [comment (rf/subscribe [::comment])

--- a/src/cljs/rems/actions/comment.cljs
+++ b/src/cljs/rems/actions/comment.cljs
@@ -44,6 +44,7 @@
    (text :t.actions/comment)
    [[button-wrapper {:id "comment"
                      :text (text :t.actions/comment)
+                     :class "btn-primary"
                      :on-click on-send}]]
    [action-comment {:id "comment"
                     :label (text :t.form/add-comments-not-shown-to-applicant)

--- a/src/cljs/rems/actions/decide.cljs
+++ b/src/cljs/rems/actions/decide.cljs
@@ -45,11 +45,11 @@
   [action-form-view "decide"
    (text :t.actions/decide)
    nil
-   [[button-wrapper {:id "decide"
+   [[button-wrapper {:id "do-decide-reject"
                      :text (text :t.actions/reject)
                      :class "btn-danger"
                      :on-click #(on-send :rejected)}]
-    [button-wrapper {:id "decide"
+    [button-wrapper {:id "do-decide-approve"
                      :text (text :t.actions/approve)
                      :class "btn-success"
                      :on-click #(on-send :approved)}]]
@@ -68,7 +68,7 @@
         description (text :t.actions/decide)
         state (r/atom nil)
         on-pending #(reset! state {:status :pending})
-        on-success #(reset! state {:status :saved })
+        on-success #(reset! state {:status :saved})
         on-error #(reset! state {:status :failed :error %})
         on-modal-close #(do (reset! state nil)
                             (on-finished))]

--- a/src/cljs/rems/actions/decide.cljs
+++ b/src/cljs/rems/actions/decide.cljs
@@ -44,7 +44,6 @@
   [{:keys [comment on-set-comment on-send]}]
   [action-form-view "decide"
    (text :t.actions/decide)
-   nil
    [[button-wrapper {:id "do-decide-reject"
                      :text (text :t.actions/reject)
                      :class "btn-danger"
@@ -56,9 +55,7 @@
    [action-comment {:id "decide"
                     :label (text :t.form/add-comments-not-shown-to-applicant)
                     :comment comment
-                    :on-comment #(on-set-comment (.. % -target -value))}]
-   nil
-   nil])
+                    :on-comment #(on-set-comment (.. % -target -value))}]])
 
 (defn decide-form [application-id on-finished]
   (let [comment (rf/subscribe [::comment])

--- a/src/cljs/rems/actions/decide.cljs
+++ b/src/cljs/rems/actions/decide.cljs
@@ -42,7 +42,9 @@
 (def ^:private action-form-id "decide")
 
 (defn decide-action-button []
-  [action-button action-form-id (text :t.actions/decide) #(rf/dispatch [::open-form])])
+  [action-button {:id action-form-id
+                  :text (text :t.actions/decide)
+                  :on-click #(rf/dispatch [::open-form])}])
 
 (defn decide-view
   [{:keys [comment on-set-comment on-send]}]

--- a/src/cljs/rems/actions/decide.cljs
+++ b/src/cljs/rems/actions/decide.cljs
@@ -54,9 +54,9 @@
                      :class "btn-success"
                      :on-click #(on-send :approved)}]]
    [:div [:div.form-group
-          [:label {:for "comment"} (text :t.form/add-comments-not-shown-to-applicant)]
-          [textarea {:id "comment"
-                     :name "comment"
+          [:label {:for "comment-decide"} (text :t.form/add-comments-not-shown-to-applicant)]
+          [textarea {:id "comment-decide"
+                     :name "comment-decide"
                      :placeholder (text :t.form/comment)
                      :value comment
                      :on-change #(on-set-comment (.. % -target -value))}]]]

--- a/src/cljs/rems/actions/decide.cljs
+++ b/src/cljs/rems/actions/decide.cljs
@@ -44,11 +44,11 @@
   [{:keys [comment on-set-comment on-send]}]
   [action-form-view "decide"
    (text :t.actions/decide)
-   [[button-wrapper {:id "do-decide-reject"
+   [[button-wrapper {:id "decide-reject"
                      :text (text :t.actions/reject)
                      :class "btn-danger"
                      :on-click #(on-send :rejected)}]
-    [button-wrapper {:id "do-decide-approve"
+    [button-wrapper {:id "decide-approve"
                      :text (text :t.actions/approve)
                      :class "btn-success"
                      :on-click #(on-send :approved)}]]

--- a/src/cljs/rems/actions/decide.cljs
+++ b/src/cljs/rems/actions/decide.cljs
@@ -55,7 +55,7 @@
    [action-comment {:id "decide"
                     :label (text :t.form/add-comments-not-shown-to-applicant)
                     :comment comment
-                    :on-comment #(on-set-comment (.. % -target -value))}]])
+                    :on-comment on-set-comment}]])
 
 (defn decide-form [application-id on-finished]
   (let [comment (rf/subscribe [::comment])

--- a/src/cljs/rems/actions/decide.cljs
+++ b/src/cljs/rems/actions/decide.cljs
@@ -1,9 +1,8 @@
 (ns rems.actions.decide
   (:require [re-frame.core :as rf]
             [reagent.core :as r]
-            [rems.actions.action :refer [action-form-view action-comment button-wrapper]]
+            [rems.actions.action :refer [action-button action-form-view action-comment button-wrapper]]
             [rems.atoms :refer [textarea]]
-            [rems.autocomplete :as autocomplete]
             [rems.status-modal :refer [status-modal]]
             [rems.text :refer [text]]
             [rems.util :refer [fetch post!]]))
@@ -39,6 +38,9 @@
                   :on-error on-error})
    (on-pending)
    {}))
+
+(defn decide-action-button []
+  [action-button "decide" (text :t.actions/decide) #(rf/dispatch [::open-form])])
 
 (defn decide-view
   [{:keys [comment on-set-comment on-send]}]

--- a/src/cljs/rems/actions/decide.cljs
+++ b/src/cljs/rems/actions/decide.cljs
@@ -1,7 +1,7 @@
 (ns rems.actions.decide
   (:require [re-frame.core :as rf]
             [reagent.core :as r]
-            [rems.actions.action :refer [action-form-view button-wrapper]]
+            [rems.actions.action :refer [action-form-view action-comment button-wrapper]]
             [rems.atoms :refer [textarea]]
             [rems.autocomplete :as autocomplete]
             [rems.status-modal :refer [status-modal]]
@@ -53,13 +53,10 @@
                      :text (text :t.actions/approve)
                      :class "btn-success"
                      :on-click #(on-send :approved)}]]
-   [:div [:div.form-group
-          [:label {:for "comment-decide"} (text :t.form/add-comments-not-shown-to-applicant)]
-          [textarea {:id "comment-decide"
-                     :name "comment-decide"
-                     :placeholder (text :t.form/comment)
-                     :value comment
-                     :on-change #(on-set-comment (.. % -target -value))}]]]
+   [action-comment {:id "decide"
+                    :label (text :t.form/add-comments-not-shown-to-applicant)
+                    :comment comment
+                    :on-comment #(on-set-comment (.. % -target -value))}]
    nil
    nil])
 

--- a/src/cljs/rems/actions/decide.cljs
+++ b/src/cljs/rems/actions/decide.cljs
@@ -39,12 +39,14 @@
    (on-pending)
    {}))
 
+(def ^:private action-form-id "decide")
+
 (defn decide-action-button []
-  [action-button "decide" (text :t.actions/decide) #(rf/dispatch [::open-form])])
+  [action-button action-form-id (text :t.actions/decide) #(rf/dispatch [::open-form])])
 
 (defn decide-view
   [{:keys [comment on-set-comment on-send]}]
-  [action-form-view "decide"
+  [action-form-view action-form-id
    (text :t.actions/decide)
    [[button-wrapper {:id "decide-reject"
                      :text (text :t.actions/reject)
@@ -54,7 +56,7 @@
                      :text (text :t.actions/approve)
                      :class "btn-success"
                      :on-click #(on-send :approved)}]]
-   [action-comment {:id "decide"
+   [action-comment {:id action-form-id
                     :label (text :t.form/add-comments-not-shown-to-applicant)
                     :comment comment
                     :on-comment on-set-comment}]])

--- a/src/cljs/rems/actions/request_comment.cljs
+++ b/src/cljs/rems/actions/request_comment.cljs
@@ -96,6 +96,7 @@
    (text :t.actions/request-comment)
    [[button-wrapper {:id "request-comment"
                      :text (text :t.actions/request-comment)
+                     :class "btn-primary"
                      :on-click on-send}]]
    [:div
     [action-comment {:id "request-comment"

--- a/src/cljs/rems/actions/request_comment.cljs
+++ b/src/cljs/rems/actions/request_comment.cljs
@@ -95,9 +95,9 @@
   [action-form-view "request-comment"
    (text :t.actions/request-comment)
    nil
-   [[button-wrapper {:id "request-comment"
-                    :text (text :t.actions/request-comment)
-                    :on-click on-send}]]
+   [[button-wrapper {:id "do-request-comment"
+                     :text (text :t.actions/request-comment)
+                     :on-click on-send}]]
    [:div [:div.form-group
           [:label {:for "comment"} (text :t.form/add-comments-not-shown-to-applicant)]
           [textarea {:id "comment"
@@ -127,7 +127,7 @@
         description (text :t.actions/request-comment)
         state (r/atom nil)
         on-pending #(reset! state {:status :pending})
-        on-success #(reset! state {:status :saved })
+        on-success #(reset! state {:status :saved})
         on-error #(reset! state {:status :failed :error %})
         on-modal-close #(do (reset! state nil)
                             (on-finished))]

--- a/src/cljs/rems/actions/request_comment.cljs
+++ b/src/cljs/rems/actions/request_comment.cljs
@@ -101,7 +101,7 @@
     [action-comment {:id "request-comment"
                      :label (text :t.form/add-comments-not-shown-to-applicant)
                      :comment comment
-                     :on-comment #(on-set-comment (.. % -target -value))}]
+                     :on-comment on-set-comment}]
     [:div.form-group
      [:label (text :t.actions/request-selection)]
      [autocomplete/component

--- a/src/cljs/rems/actions/request_comment.cljs
+++ b/src/cljs/rems/actions/request_comment.cljs
@@ -1,7 +1,7 @@
 (ns rems.actions.request-comment
   (:require [re-frame.core :as rf]
             [reagent.core :as r]
-            [rems.actions.action :refer [action-form-view button-wrapper]]
+            [rems.actions.action :refer [action-form-view action-comment button-wrapper]]
             [rems.atoms :refer [textarea]]
             [rems.autocomplete :as autocomplete]
             [rems.status-modal :refer [status-modal]]
@@ -98,13 +98,11 @@
    [[button-wrapper {:id "do-request-comment"
                      :text (text :t.actions/request-comment)
                      :on-click on-send}]]
-   [:div [:div.form-group
-          [:label {:for "comment-request-comment"} (text :t.form/add-comments-not-shown-to-applicant)]
-          [textarea {:id "comment-request-comment"
-                     :name "comment-request-comment"
-                     :placeholder (text :t.form/comment)
-                     :value comment
-                     :on-change #(on-set-comment (.. % -target -value))}]]
+   [:div
+    [action-comment {:id "request-comment"
+                     :label (text :t.form/add-comments-not-shown-to-applicant)
+                     :comment comment
+                     :on-comment #(on-set-comment (.. % -target -value))}]
     [:div.form-group
      [:label (text :t.actions/request-selection)]
      [autocomplete/component

--- a/src/cljs/rems/actions/request_comment.cljs
+++ b/src/cljs/rems/actions/request_comment.cljs
@@ -90,19 +90,21 @@
    (on-pending)
    {}))
 
+(def ^:private action-form-id "request-comment")
+
 (defn request-comment-action-button []
-  [action-button "request-comment" (text :t.actions/request-comment) #(rf/dispatch [::open-form])])
+  [action-button action-form-id (text :t.actions/request-comment) #(rf/dispatch [::open-form])])
 
 (defn request-comment-view
   [{:keys [selected-commenters potential-commenters comment on-set-comment on-add-commenter on-remove-commenter on-send]}]
-  [action-form-view "request-comment"
+  [action-form-view action-form-id
    (text :t.actions/request-comment)
    [[button-wrapper {:id "request-comment"
                      :text (text :t.actions/request-comment)
                      :class "btn-primary"
                      :on-click on-send}]]
    [:div
-    [action-comment {:id "request-comment"
+    [action-comment {:id action-form-id
                      :label (text :t.form/add-comments-not-shown-to-applicant)
                      :comment comment
                      :on-comment on-set-comment}]

--- a/src/cljs/rems/actions/request_comment.cljs
+++ b/src/cljs/rems/actions/request_comment.cljs
@@ -93,7 +93,9 @@
 (def ^:private action-form-id "request-comment")
 
 (defn request-comment-action-button []
-  [action-button action-form-id (text :t.actions/request-comment) #(rf/dispatch [::open-form])])
+  [action-button {:id action-form-id
+                  :text (text :t.actions/request-comment)
+                  :on-click #(rf/dispatch [::open-form])}])
 
 (defn request-comment-view
   [{:keys [selected-commenters potential-commenters comment on-set-comment on-add-commenter on-remove-commenter on-send]}]

--- a/src/cljs/rems/actions/request_comment.cljs
+++ b/src/cljs/rems/actions/request_comment.cljs
@@ -99,9 +99,9 @@
                      :text (text :t.actions/request-comment)
                      :on-click on-send}]]
    [:div [:div.form-group
-          [:label {:for "comment"} (text :t.form/add-comments-not-shown-to-applicant)]
-          [textarea {:id "comment"
-                     :name "comment"
+          [:label {:for "comment-request-comment"} (text :t.form/add-comments-not-shown-to-applicant)]
+          [textarea {:id "comment-request-comment"
+                     :name "comment-request-comment"
                      :placeholder (text :t.form/comment)
                      :value comment
                      :on-change #(on-set-comment (.. % -target -value))}]]

--- a/src/cljs/rems/actions/request_comment.cljs
+++ b/src/cljs/rems/actions/request_comment.cljs
@@ -94,7 +94,7 @@
   [{:keys [selected-commenters potential-commenters comment on-set-comment on-add-commenter on-remove-commenter on-send]}]
   [action-form-view "request-comment"
    (text :t.actions/request-comment)
-   [[button-wrapper {:id "do-request-comment"
+   [[button-wrapper {:id "request-comment"
                      :text (text :t.actions/request-comment)
                      :on-click on-send}]]
    [:div

--- a/src/cljs/rems/actions/request_comment.cljs
+++ b/src/cljs/rems/actions/request_comment.cljs
@@ -94,7 +94,6 @@
   [{:keys [selected-commenters potential-commenters comment on-set-comment on-add-commenter on-remove-commenter on-send]}]
   [action-form-view "request-comment"
    (text :t.actions/request-comment)
-   nil
    [[button-wrapper {:id "do-request-comment"
                      :text (text :t.actions/request-comment)
                      :on-click on-send}]]
@@ -114,9 +113,7 @@
        :item->value identity
        :search-fields [:name :email]
        :add-fn on-add-commenter
-       :remove-fn on-remove-commenter}]]]
-   nil
-   nil])
+       :remove-fn on-remove-commenter}]]]])
 
 (defn request-comment-form [application-id on-finished]
   (let [selected-commenters (rf/subscribe [::selected-commenters])

--- a/src/cljs/rems/actions/request_comment.cljs
+++ b/src/cljs/rems/actions/request_comment.cljs
@@ -1,7 +1,7 @@
 (ns rems.actions.request-comment
   (:require [re-frame.core :as rf]
             [reagent.core :as r]
-            [rems.actions.action :refer [action-form-view action-comment button-wrapper]]
+            [rems.actions.action :refer [action-button action-form-view action-comment button-wrapper]]
             [rems.atoms :refer [textarea]]
             [rems.autocomplete :as autocomplete]
             [rems.status-modal :refer [status-modal]]
@@ -89,6 +89,9 @@
                            :on-error on-error})
    (on-pending)
    {}))
+
+(defn request-comment-action-button []
+  [action-button "request-comment" (text :t.actions/request-comment) #(rf/dispatch [::open-form])])
 
 (defn request-comment-view
   [{:keys [selected-commenters potential-commenters comment on-set-comment on-add-commenter on-remove-commenter on-send]}]

--- a/src/cljs/rems/actions/request_decision.cljs
+++ b/src/cljs/rems/actions/request_decision.cljs
@@ -102,7 +102,7 @@
     [action-comment {:id "request-decision"
                      :label (text :t.form/add-comments-not-shown-to-applicant)
                      :comment comment
-                     :on-comment #(on-set-comment (.. % -target -value))}]
+                     :on-comment on-set-comment}]
     [:div.form-group
      [:label (text :t.actions/request-selection)]
      [autocomplete/component

--- a/src/cljs/rems/actions/request_decision.cljs
+++ b/src/cljs/rems/actions/request_decision.cljs
@@ -91,19 +91,21 @@
    (on-pending)
    {}))
 
+(def ^:private action-form-id "request-decision")
+
 (defn request-decision-action-button []
-  [action-button "request-decision" (text :t.actions/request-decision) #(rf/dispatch [::open-form])])
+  [action-button action-form-id (text :t.actions/request-decision) #(rf/dispatch [::open-form])])
 
 (defn request-decision-view
   [{:keys [selected-deciders potential-deciders comment on-set-comment on-add-decider on-remove-decider on-send]}]
-  [action-form-view "request-decision"
+  [action-form-view action-form-id
    (text :t.actions/request-decision)
    [[button-wrapper {:id "request-decision"
                      :text (text :t.actions/request-decision)
                      :class "btn-primary"
                      :on-click on-send}]]
    [:div
-    [action-comment {:id "request-decision"
+    [action-comment {:id action-form-id
                      :label (text :t.form/add-comments-not-shown-to-applicant)
                      :comment comment
                      :on-comment on-set-comment}]

--- a/src/cljs/rems/actions/request_decision.cljs
+++ b/src/cljs/rems/actions/request_decision.cljs
@@ -97,6 +97,7 @@
    (text :t.actions/request-decision)
    [[button-wrapper {:id "request-decision"
                      :text (text :t.actions/request-decision)
+                     :class "btn-primary"
                      :on-click on-send}]]
    [:div
     [action-comment {:id "request-decision"

--- a/src/cljs/rems/actions/request_decision.cljs
+++ b/src/cljs/rems/actions/request_decision.cljs
@@ -100,9 +100,9 @@
                      :text (text :t.actions/request-decision)
                      :on-click on-send}]]
    [:div [:div.form-group
-          [:label {:for "comment"} (text :t.form/add-comments-not-shown-to-applicant)]
-          [textarea {:id "comment"
-                     :name "comment"
+          [:label {:for "comment-request-decision"} (text :t.form/add-comments-not-shown-to-applicant)]
+          [textarea {:id "comment-request-decision"
+                     :name "comment-request-decision"
                      :placeholder (text :t.form/comment)
                      :value comment
                      :on-change #(on-set-comment (.. % -target -value))}]]

--- a/src/cljs/rems/actions/request_decision.cljs
+++ b/src/cljs/rems/actions/request_decision.cljs
@@ -95,7 +95,6 @@
   [{:keys [selected-deciders potential-deciders comment on-set-comment on-add-decider on-remove-decider on-send]}]
   [action-form-view "request-decision"
    (text :t.actions/request-decision)
-   nil
    [[button-wrapper {:id "do-request-decision"
                      :text (text :t.actions/request-decision)
                      :on-click on-send}]]
@@ -115,9 +114,7 @@
        :item->value identity
        :search-fields [:name :email]
        :add-fn on-add-decider
-       :remove-fn on-remove-decider}]]]
-   nil
-   nil])
+       :remove-fn on-remove-decider}]]]])
 
 (defn request-decision-form [application-id on-finished]
   (let [selected-deciders (rf/subscribe [::selected-deciders])

--- a/src/cljs/rems/actions/request_decision.cljs
+++ b/src/cljs/rems/actions/request_decision.cljs
@@ -1,7 +1,7 @@
 (ns rems.actions.request-decision
   (:require [re-frame.core :as rf]
             [reagent.core :as r]
-            [rems.actions.action :refer [action-form-view action-comment button-wrapper]]
+            [rems.actions.action :refer [action-button action-form-view action-comment button-wrapper]]
             [rems.atoms :refer [textarea]]
             [rems.autocomplete :as autocomplete]
             [rems.status-modal :refer [status-modal]]
@@ -90,6 +90,9 @@
                             :on-error on-error})
    (on-pending)
    {}))
+
+(defn request-decision-action-button []
+  [action-button "request-decision" (text :t.actions/request-decision) #(rf/dispatch [::open-form])])
 
 (defn request-decision-view
   [{:keys [selected-deciders potential-deciders comment on-set-comment on-add-decider on-remove-decider on-send]}]

--- a/src/cljs/rems/actions/request_decision.cljs
+++ b/src/cljs/rems/actions/request_decision.cljs
@@ -94,7 +94,9 @@
 (def ^:private action-form-id "request-decision")
 
 (defn request-decision-action-button []
-  [action-button action-form-id (text :t.actions/request-decision) #(rf/dispatch [::open-form])])
+  [action-button {:id action-form-id
+                  :text (text :t.actions/request-decision)
+                  :on-click #(rf/dispatch [::open-form])}])
 
 (defn request-decision-view
   [{:keys [selected-deciders potential-deciders comment on-set-comment on-add-decider on-remove-decider on-send]}]

--- a/src/cljs/rems/actions/request_decision.cljs
+++ b/src/cljs/rems/actions/request_decision.cljs
@@ -95,7 +95,7 @@
   [{:keys [selected-deciders potential-deciders comment on-set-comment on-add-decider on-remove-decider on-send]}]
   [action-form-view "request-decision"
    (text :t.actions/request-decision)
-   [[button-wrapper {:id "do-request-decision"
+   [[button-wrapper {:id "request-decision"
                      :text (text :t.actions/request-decision)
                      :on-click on-send}]]
    [:div

--- a/src/cljs/rems/actions/request_decision.cljs
+++ b/src/cljs/rems/actions/request_decision.cljs
@@ -1,7 +1,7 @@
 (ns rems.actions.request-decision
   (:require [re-frame.core :as rf]
             [reagent.core :as r]
-            [rems.actions.action :refer [action-form-view button-wrapper]]
+            [rems.actions.action :refer [action-form-view action-comment button-wrapper]]
             [rems.atoms :refer [textarea]]
             [rems.autocomplete :as autocomplete]
             [rems.status-modal :refer [status-modal]]
@@ -99,13 +99,11 @@
    [[button-wrapper {:id "do-request-decision"
                      :text (text :t.actions/request-decision)
                      :on-click on-send}]]
-   [:div [:div.form-group
-          [:label {:for "comment-request-decision"} (text :t.form/add-comments-not-shown-to-applicant)]
-          [textarea {:id "comment-request-decision"
-                     :name "comment-request-decision"
-                     :placeholder (text :t.form/comment)
-                     :value comment
-                     :on-change #(on-set-comment (.. % -target -value))}]]
+   [:div
+    [action-comment {:id "request-decision"
+                     :label (text :t.form/add-comments-not-shown-to-applicant)
+                     :comment comment
+                     :on-comment #(on-set-comment (.. % -target -value))}]
     [:div.form-group
      [:label (text :t.actions/request-selection)]
      [autocomplete/component

--- a/src/cljs/rems/actions/request_decision.cljs
+++ b/src/cljs/rems/actions/request_decision.cljs
@@ -96,7 +96,7 @@
   [action-form-view "request-decision"
    (text :t.actions/request-decision)
    nil
-   [[button-wrapper {:id "request-decision"
+   [[button-wrapper {:id "do-request-decision"
                      :text (text :t.actions/request-decision)
                      :on-click on-send}]]
    [:div [:div.form-group
@@ -128,7 +128,7 @@
         description (text :t.actions/request-decision)
         state (r/atom nil)
         on-pending #(reset! state {:status :pending})
-        on-success #(reset! state {:status :saved })
+        on-success #(reset! state {:status :saved})
         on-error #(reset! state {:status :failed :error %})
         on-modal-close #(do (reset! state nil)
                             (on-finished))]

--- a/src/cljs/rems/actions/return_action.cljs
+++ b/src/cljs/rems/actions/return_action.cljs
@@ -42,16 +42,13 @@
   [{:keys [comment on-set-comment on-send]}]
   [action-form-view "return"
    (text :t.actions/return)
-   nil
    [[button-wrapper {:id "do-return"
                      :text (text :t.actions/return)
                      :on-click on-send}]]
    [action-comment {:id "return"
                     :label (text :t.form/add-comments-shown-to-applicant)
                     :comment comment
-                    :on-comment #(on-set-comment (.. % -target -value))}]
-   nil
-   nil])
+                    :on-comment #(on-set-comment (.. % -target -value))}]])
 
 (defn return-form [application-id on-finished]
   (let [comment (rf/subscribe [::comment])

--- a/src/cljs/rems/actions/return_action.cljs
+++ b/src/cljs/rems/actions/return_action.cljs
@@ -48,7 +48,7 @@
    [action-comment {:id "return"
                     :label (text :t.form/add-comments-shown-to-applicant)
                     :comment comment
-                    :on-comment #(on-set-comment (.. % -target -value))}]])
+                    :on-comment on-set-comment}]])
 
 (defn return-form [application-id on-finished]
   (let [comment (rf/subscribe [::comment])

--- a/src/cljs/rems/actions/return_action.cljs
+++ b/src/cljs/rems/actions/return_action.cljs
@@ -37,18 +37,20 @@
    (on-pending)
    {}))
 
+(def ^:private action-form-id "return")
+
 (defn return-action-button []
-  [action-button "return" (text :t.actions/return) #(rf/dispatch [::open-form])])
+  [action-button action-form-id (text :t.actions/return) #(rf/dispatch [::open-form])])
 
 (defn return-view
   [{:keys [comment on-set-comment on-send]}]
-  [action-form-view "return"
+  [action-form-view action-form-id
    (text :t.actions/return)
    [[button-wrapper {:id "return"
                      :text (text :t.actions/return)
                      :class "btn-primary"
                      :on-click on-send}]]
-   [action-comment {:id "return"
+   [action-comment {:id action-form-id
                     :label (text :t.form/add-comments-shown-to-applicant)
                     :comment comment
                     :on-comment on-set-comment}]])

--- a/src/cljs/rems/actions/return_action.cljs
+++ b/src/cljs/rems/actions/return_action.cljs
@@ -42,7 +42,7 @@
   [{:keys [comment on-set-comment on-send]}]
   [action-form-view "return"
    (text :t.actions/return)
-   [[button-wrapper {:id "do-return"
+   [[button-wrapper {:id "return"
                      :text (text :t.actions/return)
                      :on-click on-send}]]
    [action-comment {:id "return"

--- a/src/cljs/rems/actions/return_action.cljs
+++ b/src/cljs/rems/actions/return_action.cljs
@@ -1,7 +1,7 @@
 (ns rems.actions.return-action
   (:require [re-frame.core :as rf]
             [reagent.core :as r]
-            [rems.actions.action :refer [action-form-view button-wrapper]]
+            [rems.actions.action :refer [action-form-view action-comment button-wrapper]]
             [rems.atoms :refer [textarea]]
             [rems.autocomplete :as autocomplete]
             [rems.status-modal :refer [status-modal]]
@@ -46,13 +46,10 @@
    [[button-wrapper {:id "do-return"
                      :text (text :t.actions/return)
                      :on-click on-send}]]
-   [:div [:div.form-group
-          [:label {:for "comment-return"} (text :t.form/add-comments-shown-to-applicant)]
-          [textarea {:id "comment-return"
-                     :name "comment-return"
-                     :placeholder (text :t.form/comment)
-                     :value comment
-                     :on-change #(on-set-comment (.. % -target -value))}]]]
+   [action-comment {:id "return"
+                    :label (text :t.form/add-comments-shown-to-applicant)
+                    :comment comment
+                    :on-comment #(on-set-comment (.. % -target -value))}]
    nil
    nil])
 

--- a/src/cljs/rems/actions/return_action.cljs
+++ b/src/cljs/rems/actions/return_action.cljs
@@ -1,9 +1,8 @@
 (ns rems.actions.return-action
   (:require [re-frame.core :as rf]
             [reagent.core :as r]
-            [rems.actions.action :refer [action-form-view action-comment button-wrapper]]
+            [rems.actions.action :refer [action-button action-form-view action-comment button-wrapper]]
             [rems.atoms :refer [textarea]]
-            [rems.autocomplete :as autocomplete]
             [rems.status-modal :refer [status-modal]]
             [rems.text :refer [text]]
             [rems.util :refer [fetch post!]]))
@@ -37,6 +36,9 @@
                   :on-error on-error})
    (on-pending)
    {}))
+
+(defn return-action-button []
+  [action-button "return" (text :t.actions/return) #(rf/dispatch [::open-form])])
 
 (defn return-view
   [{:keys [comment on-set-comment on-send]}]

--- a/src/cljs/rems/actions/return_action.cljs
+++ b/src/cljs/rems/actions/return_action.cljs
@@ -43,7 +43,7 @@
   [action-form-view "return"
    (text :t.actions/return)
    nil
-   [[button-wrapper {:id "return"
+   [[button-wrapper {:id "do-return"
                      :text (text :t.actions/return)
                      :on-click on-send}]]
    [:div [:div.form-group
@@ -61,7 +61,7 @@
         description (text :t.actions/return)
         state (r/atom nil)
         on-pending #(reset! state {:status :pending})
-        on-success #(reset! state {:status :saved })
+        on-success #(reset! state {:status :saved})
         on-error #(reset! state {:status :failed :error %})
         on-modal-close #(do (reset! state nil)
                             (on-finished))]

--- a/src/cljs/rems/actions/return_action.cljs
+++ b/src/cljs/rems/actions/return_action.cljs
@@ -40,7 +40,9 @@
 (def ^:private action-form-id "return")
 
 (defn return-action-button []
-  [action-button action-form-id (text :t.actions/return) #(rf/dispatch [::open-form])])
+  [action-button {:id action-form-id
+                  :text (text :t.actions/return)
+                  :on-click #(rf/dispatch [::open-form])}])
 
 (defn return-view
   [{:keys [comment on-set-comment on-send]}]

--- a/src/cljs/rems/actions/return_action.cljs
+++ b/src/cljs/rems/actions/return_action.cljs
@@ -47,9 +47,9 @@
                      :text (text :t.actions/return)
                      :on-click on-send}]]
    [:div [:div.form-group
-          [:label {:for "comment"} (text :t.form/add-comments-shown-to-applicant)]
-          [textarea {:id "comment"
-                     :name "comment"
+          [:label {:for "comment-return"} (text :t.form/add-comments-shown-to-applicant)]
+          [textarea {:id "comment-return"
+                     :name "comment-return"
                      :placeholder (text :t.form/comment)
                      :value comment
                      :on-change #(on-set-comment (.. % -target -value))}]]]

--- a/src/cljs/rems/actions/return_action.cljs
+++ b/src/cljs/rems/actions/return_action.cljs
@@ -44,6 +44,7 @@
    (text :t.actions/return)
    [[button-wrapper {:id "return"
                      :text (text :t.actions/return)
+                     :class "btn-primary"
                      :on-click on-send}]]
    [action-comment {:id "return"
                     :label (text :t.form/add-comments-shown-to-applicant)

--- a/src/cljs/rems/application.cljs
+++ b/src/cljs/rems/application.cljs
@@ -751,11 +751,14 @@
                           :on-click #(rf/dispatch [::judge-application command text])}
                          (dissoc opts :command))])
 
+
+(def ^:private approve-form-id "approve")
+
 (defn- approve-action-button []
-  [action-button "approve" (text :t.actions/approve)])
+  [action-button approve-form-id (text :t.actions/approve)])
 
 (defn- approve-form []
-  [action-form "approve"
+  [action-form approve-form-id
    (text :t.actions/approve)
    (text :t.form/add-comments-shown-to-applicant)
    [judge-application-button {:id "static-approve"
@@ -763,11 +766,14 @@
                               :text (text :t.actions/approve)
                               :class "btn-success"}]])
 
+
+(def ^:private reject-form-id "reject")
+
 (defn- reject-action-button []
-  [action-button "reject" (text :t.actions/reject)])
+  [action-button reject-form-id (text :t.actions/reject)])
 
 (defn- reject-form []
-  [action-form "reject"
+  [action-form reject-form-id
    (text :t.actions/reject)
    (text :t.form/add-comments-shown-to-applicant)
    [judge-application-button {:id "static-reject"
@@ -775,11 +781,14 @@
                               :text (text :t.actions/reject)
                               :class "btn-danger"}]])
 
+
+(def ^:private static-return-form-id "static-return")
+
 (defn- static-return-action-button []
-  [action-button "static-return" (text :t.actions/return)])
+  [action-button static-return-form-id (text :t.actions/return)])
 
 (defn- static-return-form []
-  [action-form "static-return"
+  [action-form static-return-form-id
    (text :t.actions/return)
    (text :t.form/add-comments-shown-to-applicant)
    [judge-application-button {:id "static-return"
@@ -787,33 +796,42 @@
                               :text (text :t.actions/return)
                               :class "btn-primary"}]])
 
+
+(def ^:private review-form-id "review")
+
 (defn- review-action-button []
-  [action-button "review" (text :t.actions/review)])
+  [action-button review-form-id (text :t.actions/review)])
 
 (defn- review-form []
-  [action-form "review"
+  [action-form review-form-id
    (text :t.actions/review)
    (text :t.form/add-comments-not-shown-to-applicant)
    [judge-application-button {:command "review"
                               :text (text :t.actions/review)
                               :class "btn-primary"}]])
 
+
+(def ^:private third-party-review-form-id "third-party-review")
+
 (defn- third-party-review-action-button []
-  [action-button "third-party-review" (text :t.actions/review)])
+  [action-button third-party-review-form-id (text :t.actions/review)])
 
 (defn- third-party-review-form []
-  [action-form "third-party-review"
+  [action-form third-party-review-form-id
    (text :t.actions/review)
    (text :t.form/add-comments-not-shown-to-applicant)
    [judge-application-button {:command "third-party-review"
                               :text (text :t.actions/review)
                               :class "btn-primary"}]])
 
+
+(def ^:private applicant-close-form-id "applicant-close")
+
 (defn- applicant-close-action-button []
-  [action-button "applicant-close" (text :t.actions/close)])
+  [action-button applicant-close-form-id (text :t.actions/close)])
 
 (defn- applicant-close-form []
-  [action-form "applicant-close"
+  [action-form applicant-close-form-id
    (text :t.actions/close)
    (text :t.form/add-comments)
    [judge-application-button {:id "applicant-close"
@@ -821,11 +839,14 @@
                               :text (text :t.actions/close)
                               :class "btn-danger"}]])
 
+
+(def ^:private approver-close-form-id "approver-close")
+
 (defn- approver-close-action-button []
-  [action-button "approver-close" (text :t.actions/close)])
+  [action-button approver-close-form-id (text :t.actions/close)])
 
 (defn- approver-close-form []
-  [action-form "approver-close"
+  [action-form approver-close-form-id
    (text :t.actions/close)
    (text :t.form/add-comments-shown-to-applicant)
    [judge-application-button {:id "approver-close"
@@ -833,25 +854,31 @@
                               :text (text :t.actions/close)
                               :class "btn-danger"}]])
 
+
+(def ^:private withdraw-form-id "withdraw")
+
 (defn- withdraw-action-button []
-  [action-button "withdraw" (text :t.actions/withdraw)])
+  [action-button withdraw-form-id (text :t.actions/withdraw)])
 
 (defn- withdraw-form []
-  [action-form "withdraw"
+  [action-form withdraw-form-id
    (text :t.actions/withdraw)
    (text :t.form/add-comments)
    [judge-application-button {:command "withdraw"
                               :text (text :t.actions/withdraw)
                               :class "btn-primary"}]])
 
+
+(def ^:private review-request-form-id "review-request")
+
 (defn- review-request-action-button []
-  [action-button "review-request" (text :t.actions/review-request)])
+  [action-button review-request-form-id (text :t.actions/review-request)])
 
 (defn- review-request-form []
   (let [selected-third-party-reviewers @(rf/subscribe [::selected-third-party-reviewers])
         potential-third-party-reviewers @(rf/subscribe [::potential-third-party-reviewers])
         review-comment @(rf/subscribe [::review-comment])]
-    [action-form "review-request"
+    [action-form review-request-form-id
      (text :t.actions/review-request)
      nil
      [button-wrapper {:id "review-request"
@@ -876,6 +903,7 @@
          :search-fields [:name :email]
          :add-fn #(rf/dispatch [::add-selected-third-party-reviewer %])
          :remove-fn #(rf/dispatch [::remove-selected-third-party-reviewer %])}]]]]))
+
 
 (defn- dynamic-actions [app]
   (distinct

--- a/src/cljs/rems/application.cljs
+++ b/src/cljs/rems/application.cljs
@@ -733,55 +733,6 @@
                     (for [[k v] (dissoc user-attributes "commonName" "mail")]
                       [info-field k v]))}])
 
-
-(defn- judge-application-button [{:keys [command text] :as opts}]
-  [button-wrapper (merge {:id command
-                          :on-click #(rf/dispatch [::judge-application command text])}
-                         (dissoc opts :command))])
-
-(defn- approve-button []
-  [judge-application-button {:command "approve"
-                             :text (text :t.actions/approve)
-                             :class "btn-success"}])
-
-(defn- reject-button []
-  [judge-application-button {:command "reject"
-                             :text (text :t.actions/reject)
-                             :class "btn-danger"}])
-
-(defn- static-return-button []
-  [judge-application-button {:id "static-return"
-                             :command "return"
-                             :text (text :t.actions/return)
-                             :class "btn-primary"}])
-
-(defn- review-button []
-  [judge-application-button {:command "review"
-                             :text (text :t.actions/review)
-                             :class "btn-primary"}])
-
-(defn- third-party-review-button []
-  [judge-application-button {:command "third-party-review"
-                             :text (text :t.actions/review)
-                             :class "btn-primary"}])
-
-(defn- applicant-close-button []
-  [judge-application-button {:id "applicant-close"
-                             :command "close"
-                             :text (text :t.actions/close)
-                             :class "btn-danger"}])
-
-(defn- approver-close-button []
-  [judge-application-button {:id "approver-close"
-                             :command "close"
-                             :text (text :t.actions/close)
-                             :class "btn-danger"}])
-
-(defn- withdraw-button []
-  [judge-application-button {:command "withdraw"
-                             :text (text :t.actions/withdraw)
-                             :class "btn-primary"}])
-
 (defn- action-button [id content on-click]
   [:button.btn.mr-3
    {:id (str id "-action-button")
@@ -852,53 +803,77 @@
                        :comment @(rf/subscribe [::judge-comment])
                        :on-comment #(rf/dispatch [::set-judge-comment %])}])]])
 
+(defn- judge-application-button [{:keys [command text] :as opts}]
+  [button-wrapper (merge {:id command
+                          :on-click #(rf/dispatch [::judge-application command text])}
+                         (dissoc opts :command))])
+
 (defn- approve-form []
   [action-form "approve"
    (text :t.actions/approve)
    (text :t.form/add-comments-shown-to-applicant)
-   [approve-button]])
+   [judge-application-button {:command "approve"
+                              :text (text :t.actions/approve)
+                              :class "btn-success"}]])
 
 (defn- reject-form []
   [action-form "reject"
    (text :t.actions/reject)
    (text :t.form/add-comments-shown-to-applicant)
-   [reject-button]])
+   [judge-application-button {:command "reject"
+                              :text (text :t.actions/reject)
+                              :class "btn-danger"}]])
 
 (defn- static-return-form []
   [action-form "static-return"
    (text :t.actions/return)
    (text :t.form/add-comments-shown-to-applicant)
-   [static-return-button]])
+   [judge-application-button {:id "static-return"
+                              :command "return"
+                              :text (text :t.actions/return)
+                              :class "btn-primary"}]])
 
 (defn- review-form []
   [action-form "review"
    (text :t.actions/review)
    (text :t.form/add-comments-not-shown-to-applicant)
-   [review-button]])
+   [judge-application-button {:command "review"
+                              :text (text :t.actions/review)
+                              :class "btn-primary"}]])
 
 (defn- third-party-review-form []
   [action-form "third-party-review"
    (text :t.actions/review)
    (text :t.form/add-comments-not-shown-to-applicant)
-   [third-party-review-button]])
+   [judge-application-button {:command "third-party-review"
+                              :text (text :t.actions/review)
+                              :class "btn-primary"}]])
 
 (defn- applicant-close-form []
   [action-form "applicant-close"
    (text :t.actions/close)
    (text :t.form/add-comments)
-   [applicant-close-button]])
+   [judge-application-button {:id "applicant-close"
+                              :command "close"
+                              :text (text :t.actions/close)
+                              :class "btn-danger"}]])
 
 (defn- approver-close-form []
   [action-form "approver-close"
    (text :t.actions/close)
    (text :t.form/add-comments-shown-to-applicant)
-   [approver-close-button]])
+   [judge-application-button {:id "approver-close"
+                              :command "close"
+                              :text (text :t.actions/close)
+                              :class "btn-danger"}]])
 
 (defn- withdraw-form []
   [action-form "withdraw"
    (text :t.actions/withdraw)
    (text :t.form/add-comments)
-   [withdraw-button]])
+   [judge-application-button {:command "withdraw"
+                              :text (text :t.actions/withdraw)
+                              :class "btn-primary"}]])
 
 (defn- request-review-form []
   (let [selected-third-party-reviewers @(rf/subscribe [::selected-third-party-reviewers])

--- a/src/cljs/rems/application.cljs
+++ b/src/cljs/rems/application.cljs
@@ -847,7 +847,7 @@
       [action-judge-comment {:id id
                              :label comment-title
                              :comment @(rf/subscribe [::judge-comment])
-                             :on-comment #(rf/dispatch [::set-judge-comment (.. % -target -value)])}])]])
+                             :on-comment #(rf/dispatch [::set-judge-comment %])}])]])
 
 (defn- approve-form []
   [action-form "approve"

--- a/src/cljs/rems/application.cljs
+++ b/src/cljs/rems/application.cljs
@@ -742,7 +742,7 @@
 (defn- approve-button []
   [judge-application-button {:command "approve"
                              :text (text :t.actions/approve)
-                             :class "btn-primary"}])
+                             :class "btn-success"}])
 
 (defn- reject-button []
   [judge-application-button {:command "reject"
@@ -752,7 +752,8 @@
 (defn- static-return-button []
   [judge-application-button {:id "static-return"
                              :command "return"
-                             :text (text :t.actions/return)}])
+                             :text (text :t.actions/return)
+                             :class "btn-primary"}])
 
 (defn- review-button []
   [judge-application-button {:command "review"
@@ -767,16 +768,19 @@
 (defn- applicant-close-button []
   [judge-application-button {:id "applicant-close"
                              :command "close"
-                             :text (text :t.actions/close)}])
+                             :text (text :t.actions/close)
+                             :class "btn-danger"}])
 
 (defn- approver-close-button []
   [judge-application-button {:id "approver-close"
                              :command "close"
-                             :text (text :t.actions/close)}])
+                             :text (text :t.actions/close)
+                             :class "btn-danger"}])
 
 (defn- withdraw-button []
   [judge-application-button {:command "withdraw"
-                             :text (text :t.actions/withdraw)}])
+                             :text (text :t.actions/withdraw)
+                             :class "btn-primary"}])
 
 (defn- action-button [id content on-click]
   [:button.btn.mr-3
@@ -905,6 +909,7 @@
      nil
      [button-wrapper {:id "request-review"
                       :text (text :t.actions/review-request)
+                      :class "btn-primary"
                       :on-click #(rf/dispatch [::send-third-party-review-request selected-third-party-reviewers review-comment (text :t.actions/review-request)])}]
      [:div [:div.form-group
             [:label {:for "review-comment"} (text :t.form/add-comments-not-shown-to-applicant)]

--- a/src/cljs/rems/application.cljs
+++ b/src/cljs/rems/application.cljs
@@ -746,8 +746,8 @@
                    :text (text :t.actions/reject)
                    :on-click #(rf/dispatch [::judge-application "reject" (text :t.actions/reject)])}])
 
-(defn- return-button []
-  [button-wrapper {:id "return"
+(defn- static-return-button []
+  [button-wrapper {:id "static-return"
                    :text (text :t.actions/return)
                    :on-click #(rf/dispatch [::judge-application "return" (text :t.actions/return)])}])
 
@@ -865,7 +865,7 @@
   [action-form "static-return"
    (text :t.actions/return)
    (text :t.form/add-comments-shown-to-applicant)
-   [return-button]])
+   [static-return-button]])
 
 (defn- review-form []
   [action-form "review"

--- a/src/cljs/rems/application.cljs
+++ b/src/cljs/rems/application.cljs
@@ -755,7 +755,9 @@
 (def ^:private approve-form-id "approve")
 
 (defn- approve-action-button []
-  [action-button approve-form-id (text :t.actions/approve)])
+  [action-button {:id approve-form-id
+                  :text (text :t.actions/approve)
+                  :class "btn-primary"}])
 
 (defn- approve-form []
   [action-form approve-form-id
@@ -770,7 +772,8 @@
 (def ^:private reject-form-id "reject")
 
 (defn- reject-action-button []
-  [action-button reject-form-id (text :t.actions/reject)])
+  [action-button {:id reject-form-id
+                  :text (text :t.actions/reject)}])
 
 (defn- reject-form []
   [action-form reject-form-id
@@ -785,7 +788,8 @@
 (def ^:private static-return-form-id "static-return")
 
 (defn- static-return-action-button []
-  [action-button static-return-form-id (text :t.actions/return)])
+  [action-button {:id static-return-form-id
+                  :text (text :t.actions/return)}])
 
 (defn- static-return-form []
   [action-form static-return-form-id
@@ -800,7 +804,8 @@
 (def ^:private review-form-id "review")
 
 (defn- review-action-button []
-  [action-button review-form-id (text :t.actions/review)])
+  [action-button {:id review-form-id
+                  :text (text :t.actions/review)}])
 
 (defn- review-form []
   [action-form review-form-id
@@ -814,7 +819,8 @@
 (def ^:private third-party-review-form-id "third-party-review")
 
 (defn- third-party-review-action-button []
-  [action-button third-party-review-form-id (text :t.actions/review)])
+  [action-button {:id third-party-review-form-id
+                  :text (text :t.actions/review)}])
 
 (defn- third-party-review-form []
   [action-form third-party-review-form-id
@@ -828,7 +834,8 @@
 (def ^:private applicant-close-form-id "applicant-close")
 
 (defn- applicant-close-action-button []
-  [action-button applicant-close-form-id (text :t.actions/close)])
+  [action-button {:id applicant-close-form-id
+                  :text (text :t.actions/close)}])
 
 (defn- applicant-close-form []
   [action-form applicant-close-form-id
@@ -843,7 +850,8 @@
 (def ^:private approver-close-form-id "approver-close")
 
 (defn- approver-close-action-button []
-  [action-button approver-close-form-id (text :t.actions/close)])
+  [action-button {:id approver-close-form-id
+                  :text (text :t.actions/close)}])
 
 (defn- approver-close-form []
   [action-form approver-close-form-id
@@ -858,7 +866,8 @@
 (def ^:private withdraw-form-id "withdraw")
 
 (defn- withdraw-action-button []
-  [action-button withdraw-form-id (text :t.actions/withdraw)])
+  [action-button {:id withdraw-form-id
+                  :text (text :t.actions/withdraw)}])
 
 (defn- withdraw-form []
   [action-form withdraw-form-id
@@ -872,7 +881,8 @@
 (def ^:private review-request-form-id "review-request")
 
 (defn- review-request-action-button []
-  [action-button review-request-form-id (text :t.actions/review-request)])
+  [action-button {:id review-request-form-id
+                  :text (text :t.actions/review-request)}])
 
 (defn- review-request-form []
   (let [selected-third-party-reviewers @(rf/subscribe [::selected-third-party-reviewers])

--- a/src/cljs/rems/application.cljs
+++ b/src/cljs/rems/application.cljs
@@ -812,7 +812,8 @@
   [action-form "approve"
    (text :t.actions/approve)
    (text :t.form/add-comments-shown-to-applicant)
-   [judge-application-button {:command "approve"
+   [judge-application-button {:id "static-approve"
+                              :command "approve"
                               :text (text :t.actions/approve)
                               :class "btn-success"}]])
 
@@ -820,7 +821,8 @@
   [action-form "reject"
    (text :t.actions/reject)
    (text :t.form/add-comments-shown-to-applicant)
-   [judge-application-button {:command "reject"
+   [judge-application-button {:id "static-reject"
+                              :command "reject"
                               :text (text :t.actions/reject)
                               :class "btn-danger"}]])
 

--- a/src/cljs/rems/application.cljs
+++ b/src/cljs/rems/application.cljs
@@ -2,7 +2,7 @@
   (:require [clojure.string :as str]
             [medley.core :refer [map-vals]]
             [re-frame.core :as rf]
-            [rems.actions.action :refer [action-form-view action-judge-comment action-collapse-id button-wrapper]]
+            [rems.actions.action :refer [action-form-view action-comment action-collapse-id button-wrapper]]
             [rems.actions.approve-reject :refer [approve-reject-form]]
             [rems.actions.close :refer [close-form]]
             [rems.actions.comment :refer [comment-form]]
@@ -844,10 +844,10 @@
    [:div
     content
     (when comment-title
-      [action-judge-comment {:id id
-                             :label comment-title
-                             :comment @(rf/subscribe [::judge-comment])
-                             :on-comment #(rf/dispatch [::set-judge-comment %])}])]])
+      [action-comment {:id id
+                       :label comment-title
+                       :comment @(rf/subscribe [::judge-comment])
+                       :on-comment #(rf/dispatch [::set-judge-comment %])}])]])
 
 (defn- approve-form []
   [action-form "approve"

--- a/src/cljs/rems/application.cljs
+++ b/src/cljs/rems/application.cljs
@@ -758,15 +758,21 @@
                    :on-click #(rf/dispatch [::judge-application "review" (text :t.actions/review)])}])
 
 (defn- third-party-review-button []
-  [button-wrapper {:id "request-review"
+  [button-wrapper {:id "third-party-review"
                    :text (text :t.actions/review)
                    :class "btn-primary"
                    :on-click #(rf/dispatch [::judge-application "third-party-review" (text :t.actions/review)])}])
 
-(defn- close-button []
-  [button-wrapper {:id "close"
+(defn- close-button [id]
+  [button-wrapper {:id id
                    :text (text :t.actions/close)
                    :on-click #(rf/dispatch [::judge-application "close" (text :t.actions/close)])}])
+
+(defn- applicant-close-button []
+  [close-button "applicant-close"])
+
+(defn- approver-close-button []
+  [close-button "approver-close"])
 
 (defn- withdraw-button []
   [button-wrapper {:id "withdraw"
@@ -775,7 +781,7 @@
 
 (defn- action-button [id content on-click]
   [:button.btn.mr-3
-   {:id id
+   {:id (str id "-action-button")
     :class (if (contains? #{"approve" "approve-reject"} id) "btn-primary" "btn-secondary")
     :type "button"
     :data-toggle "collapse"
@@ -874,13 +880,13 @@
   [action-form "applicant-close"
    (text :t.actions/close)
    (text :t.form/add-comments)
-   [close-button]])
+   [applicant-close-button]])
 
 (defn- approver-close-form []
   [action-form "approver-close"
    (text :t.actions/close)
    (text :t.form/add-comments-shown-to-applicant)
-   [close-button]])
+   [approver-close-button]])
 
 (defn- withdraw-form []
   [action-form "withdraw"

--- a/src/cljs/rems/application.cljs
+++ b/src/cljs/rems/application.cljs
@@ -2,14 +2,14 @@
   (:require [clojure.string :as str]
             [medley.core :refer [map-vals]]
             [re-frame.core :as rf]
-            [rems.actions.action :refer [action-form-view action-comment action-collapse-id button-wrapper]]
-            [rems.actions.approve-reject :refer [approve-reject-form]]
-            [rems.actions.close :refer [close-form]]
-            [rems.actions.comment :refer [comment-form]]
-            [rems.actions.decide :refer [decide-form]]
-            [rems.actions.request-comment :refer [request-comment-form]]
-            [rems.actions.request-decision :refer [request-decision-form]]
-            [rems.actions.return-action :refer [return-form]]
+            [rems.actions.action :refer [action-button action-form-view action-comment action-collapse-id button-wrapper]]
+            [rems.actions.approve-reject :refer [approve-reject-action-button approve-reject-form]]
+            [rems.actions.close :refer [close-action-button close-form]]
+            [rems.actions.comment :refer [comment-action-button comment-form]]
+            [rems.actions.decide :refer [decide-action-button decide-form]]
+            [rems.actions.request-comment :refer [request-comment-action-button request-comment-form]]
+            [rems.actions.request-decision :refer [request-decision-action-button request-decision-form]]
+            [rems.actions.return-action :refer [return-action-button return-form]]
             [rems.atoms :refer [external-link flash-message textarea]]
             [rems.autocomplete :as autocomplete]
             [rems.collapsible :as collapsible]
@@ -733,63 +733,6 @@
                     (for [[k v] (dissoc user-attributes "commonName" "mail")]
                       [info-field k v]))}])
 
-(defn- action-button [id content on-click]
-  [:button.btn.mr-3
-   {:id (str id "-action-button")
-    :class (if (contains? #{"approve" "approve-reject"} id) "btn-primary" "btn-secondary")
-    :type "button"
-    :data-toggle "collapse"
-    :data-target (str "#" (action-collapse-id id))
-    :on-click on-click}
-   (str content " ...")])
-
-(defn- approve-action-button []
-  [action-button "approve" (text :t.actions/approve)])
-
-(defn- reject-action-button []
-  [action-button "reject" (text :t.actions/reject)])
-
-(defn- static-return-action-button []
-  [action-button "static-return" (text :t.actions/return)])
-
-(defn- review-action-button []
-  [action-button "review" (text :t.actions/review)])
-
-(defn- third-party-review-action-button []
-  [action-button "third-party-review" (text :t.actions/review)])
-
-(defn- request-comment-action-button []
-  [action-button "request-comment" (text :t.actions/request-comment) #(rf/dispatch [:rems.actions.request-comment/open-form])])
-
-(defn- request-decision-action-button []
-  [action-button "request-decision" (text :t.actions/request-decision) #(rf/dispatch [:rems.actions.request-decision/open-form])])
-
-(defn- comment-action-button []
-  [action-button "comment" (text :t.actions/comment) #(rf/dispatch [:rems.actions.comment/open-form])])
-
-(defn- close-action-button []
-  [action-button "close" (text :t.actions/close) #(rf/dispatch [:rems.actions.close/open-form])])
-
-(defn- decide-action-button []
-  [action-button "decide" (text :t.actions/decide) #(rf/dispatch [:rems.actions.decide/open-form])])
-
-(defn- return-action-button []
-  [action-button "return" (text :t.actions/return) #(rf/dispatch [:rems.actions.return/open-form])])
-
-(defn- approve-reject-action-button []
-  [action-button "approve-reject" (text :t.actions/approve-reject)])
-
-(defn- applicant-close-action-button []
-  [action-button "applicant-close" (text :t.actions/close)])
-
-(defn- approver-close-action-button []
-  [action-button "approver-close" (text :t.actions/close)])
-
-(defn- withdraw-action-button []
-  [action-button "withdraw" (text :t.actions/withdraw)])
-
-(defn- review-request-action-button []
-  [action-button "review-request" (text :t.actions/review-request)])
 
 (defn action-form [id title comment-title button content]
   [action-form-view id
@@ -808,6 +751,9 @@
                           :on-click #(rf/dispatch [::judge-application command text])}
                          (dissoc opts :command))])
 
+(defn- approve-action-button []
+  [action-button "approve" (text :t.actions/approve)])
+
 (defn- approve-form []
   [action-form "approve"
    (text :t.actions/approve)
@@ -816,6 +762,9 @@
                               :command "approve"
                               :text (text :t.actions/approve)
                               :class "btn-success"}]])
+
+(defn- reject-action-button []
+  [action-button "reject" (text :t.actions/reject)])
 
 (defn- reject-form []
   [action-form "reject"
@@ -826,6 +775,9 @@
                               :text (text :t.actions/reject)
                               :class "btn-danger"}]])
 
+(defn- static-return-action-button []
+  [action-button "static-return" (text :t.actions/return)])
+
 (defn- static-return-form []
   [action-form "static-return"
    (text :t.actions/return)
@@ -835,6 +787,9 @@
                               :text (text :t.actions/return)
                               :class "btn-primary"}]])
 
+(defn- review-action-button []
+  [action-button "review" (text :t.actions/review)])
+
 (defn- review-form []
   [action-form "review"
    (text :t.actions/review)
@@ -843,6 +798,9 @@
                               :text (text :t.actions/review)
                               :class "btn-primary"}]])
 
+(defn- third-party-review-action-button []
+  [action-button "third-party-review" (text :t.actions/review)])
+
 (defn- third-party-review-form []
   [action-form "third-party-review"
    (text :t.actions/review)
@@ -850,6 +808,9 @@
    [judge-application-button {:command "third-party-review"
                               :text (text :t.actions/review)
                               :class "btn-primary"}]])
+
+(defn- applicant-close-action-button []
+  [action-button "applicant-close" (text :t.actions/close)])
 
 (defn- applicant-close-form []
   [action-form "applicant-close"
@@ -860,6 +821,9 @@
                               :text (text :t.actions/close)
                               :class "btn-danger"}]])
 
+(defn- approver-close-action-button []
+  [action-button "approver-close" (text :t.actions/close)])
+
 (defn- approver-close-form []
   [action-form "approver-close"
    (text :t.actions/close)
@@ -869,6 +833,9 @@
                               :text (text :t.actions/close)
                               :class "btn-danger"}]])
 
+(defn- withdraw-action-button []
+  [action-button "withdraw" (text :t.actions/withdraw)])
+
 (defn- withdraw-form []
   [action-form "withdraw"
    (text :t.actions/withdraw)
@@ -877,21 +844,25 @@
                               :text (text :t.actions/withdraw)
                               :class "btn-primary"}]])
 
-(defn- request-review-form []
+(defn- review-request-action-button []
+  [action-button "review-request" (text :t.actions/review-request)])
+
+(defn- review-request-form []
   (let [selected-third-party-reviewers @(rf/subscribe [::selected-third-party-reviewers])
         potential-third-party-reviewers @(rf/subscribe [::potential-third-party-reviewers])
         review-comment @(rf/subscribe [::review-comment])]
     [action-form "review-request"
      (text :t.actions/review-request)
      nil
-     [button-wrapper {:id "request-review"
+     [button-wrapper {:id "review-request"
                       :text (text :t.actions/review-request)
                       :class "btn-primary"
                       :on-click #(rf/dispatch [::send-third-party-review-request selected-third-party-reviewers review-comment (text :t.actions/review-request)])}]
      [:div [:div.form-group
             [:label {:for "review-comment"} (text :t.form/add-comments-not-shown-to-applicant)]
             [textarea {:id "review-comment"
-                       :name "comment" :placeholder (text :t.form/comment)
+                       :name "review-comment"
+                       :placeholder (text :t.form/comment)
                        :on-change #(rf/dispatch [::set-review-comment (.. % -target -value)])}]]
       [:div.form-group
        [:label (text :t.actions/review-request-selection)]
@@ -954,7 +925,7 @@
                 [reject-form]
                 [static-return-form]
                 [review-form]
-                [request-review-form]
+                [review-request-form]
                 [request-comment-form (:id app) reload]
                 [request-decision-form (:id app) reload]
                 [comment-form (:id app) reload]

--- a/src/cljs/rems/application.cljs
+++ b/src/cljs/rems/application.cljs
@@ -734,50 +734,49 @@
                       [info-field k v]))}])
 
 
+(defn- judge-application-button [{:keys [command text] :as opts}]
+  [button-wrapper (merge {:id command
+                          :on-click #(rf/dispatch [::judge-application command text])}
+                         (dissoc opts :command))])
+
 (defn- approve-button []
-  [button-wrapper {:id "approve"
-                   :class "btn-primary"
-                   :text (text :t.actions/approve)
-                   :on-click #(rf/dispatch [::judge-application "approve" (text :t.actions/approve)])}])
+  [judge-application-button {:command "approve"
+                             :text (text :t.actions/approve)
+                             :class "btn-primary"}])
 
 (defn- reject-button []
-  [button-wrapper {:id "reject"
-                   :class "btn-danger"
-                   :text (text :t.actions/reject)
-                   :on-click #(rf/dispatch [::judge-application "reject" (text :t.actions/reject)])}])
+  [judge-application-button {:command "reject"
+                             :text (text :t.actions/reject)
+                             :class "btn-danger"}])
 
 (defn- static-return-button []
-  [button-wrapper {:id "static-return"
-                   :text (text :t.actions/return)
-                   :on-click #(rf/dispatch [::judge-application "return" (text :t.actions/return)])}])
+  [judge-application-button {:id "static-return"
+                             :command "return"
+                             :text (text :t.actions/return)}])
 
 (defn- review-button []
-  [button-wrapper {:id "review"
-                   :text (text :t.actions/review)
-                   :class "btn-primary"
-                   :on-click #(rf/dispatch [::judge-application "review" (text :t.actions/review)])}])
+  [judge-application-button {:command "review"
+                             :text (text :t.actions/review)
+                             :class "btn-primary"}])
 
 (defn- third-party-review-button []
-  [button-wrapper {:id "third-party-review"
-                   :text (text :t.actions/review)
-                   :class "btn-primary"
-                   :on-click #(rf/dispatch [::judge-application "third-party-review" (text :t.actions/review)])}])
-
-(defn- close-button [id]
-  [button-wrapper {:id id
-                   :text (text :t.actions/close)
-                   :on-click #(rf/dispatch [::judge-application "close" (text :t.actions/close)])}])
+  [judge-application-button {:command "third-party-review"
+                             :text (text :t.actions/review)
+                             :class "btn-primary"}])
 
 (defn- applicant-close-button []
-  [close-button "applicant-close"])
+  [judge-application-button {:id "applicant-close"
+                             :command "close"
+                             :text (text :t.actions/close)}])
 
 (defn- approver-close-button []
-  [close-button "approver-close"])
+  [judge-application-button {:id "approver-close"
+                             :command "close"
+                             :text (text :t.actions/close)}])
 
 (defn- withdraw-button []
-  [button-wrapper {:id "withdraw"
-                   :text (text :t.actions/withdraw)
-                   :on-click #(rf/dispatch [::judge-application "withdraw" (text :t.actions/withdraw)])}])
+  [judge-application-button {:command "withdraw"
+                             :text (text :t.actions/withdraw)}])
 
 (defn- action-button [id content on-click]
   [:button.btn.mr-3

--- a/src/cljs/rems/application.cljs
+++ b/src/cljs/rems/application.cljs
@@ -2,7 +2,7 @@
   (:require [clojure.string :as str]
             [medley.core :refer [map-vals]]
             [re-frame.core :as rf]
-            [rems.actions.action :refer [action-form-view action-collapse-id button-wrapper]]
+            [rems.actions.action :refer [action-form-view action-judge-comment action-collapse-id button-wrapper]]
             [rems.actions.approve-reject :refer [approve-reject-form]]
             [rems.actions.close :refer [close-form]]
             [rems.actions.comment :refer [comment-form]]
@@ -840,11 +840,14 @@
 (defn action-form [id title comment-title button content]
   [action-form-view id
    title
-   comment-title
    [button]
-   content
-   @(rf/subscribe [::judge-comment])
-   #(rf/dispatch [::set-judge-comment (.. % -target -value)])])
+   [:div
+    content
+    (when comment-title
+      [action-judge-comment {:id id
+                             :label comment-title
+                             :comment @(rf/subscribe [::judge-comment])
+                             :on-comment #(rf/dispatch [::set-judge-comment (.. % -target -value)])}])]])
 
 (defn- approve-form []
   [action-form "approve"
@@ -925,17 +928,17 @@
 (defn- dynamic-actions [app]
   (distinct
    (mapcat #:rems.workflow.dynamic
-           {:submit [[save-button]
-                     [submit-button]]
-            :add-member nil ; TODO implement
-            :return [[return-action-button]]
-            :request-decision [[request-decision-action-button]]
-            :decide [[decide-action-button]]
-            :request-comment [[request-comment-action-button]]
-            :comment [[comment-action-button]]
-            :approve [[approve-reject-action-button]]
-            :reject [[approve-reject-action-button]]
-            :close [[close-action-button]]}
+               {:submit [[save-button]
+                         [submit-button]]
+                :add-member nil ; TODO implement
+                :return [[return-action-button]]
+                :request-decision [[request-decision-action-button]]
+                :decide [[decide-action-button]]
+                :request-comment [[request-comment-action-button]]
+                :comment [[comment-action-button]]
+                :approve [[approve-reject-action-button]]
+                :reject [[approve-reject-action-button]]
+                :close [[close-action-button]]}
            (:possible-commands app))))
 
 (defn- static-actions [app]


### PR DESCRIPTION
P.S. Handy plugin for finding duplicate IDs: https://chrome.google.com/webstore/detail/dup-id-scans-html-for-dup/nggpgolddgjmkjioagggmnmddbgedice