### PR TITLE
Editor fixes

### DIFF
--- a/resources/translations/en.edn
+++ b/resources/translations/en.edn
@@ -170,6 +170,7 @@
                 :input-prompt "Placeholder text"
                 :item-n "Field %1"
                 :item-title "Field title"
+                :maxlength "Maximum length (optional)"
                 :option-key "ID code"
                 :option-label "Label"
                 :option-n "Option %1"

--- a/resources/translations/fi.edn
+++ b/resources/translations/fi.edn
@@ -170,6 +170,7 @@
                 :input-prompt "Esimerkkiteksti"
                 :item-n "Kenttä %1"
                 :item-title "Kentän otsikko"
+                :maxlength "Maksimipituus (ei pakollinen)"
                 :option-key "Tunnuskoodi"
                 :option-label "Otsikko"
                 :option-n "Vaihtoehto %1"

--- a/src/clj/rems/css/styles.clj
+++ b/src/clj/rems/css/styles.clj
@@ -173,10 +173,8 @@
 
 (def ^:private dashed-form-group {:position "relative"
                                   :border "2px dashed #ccc"
-                                  :border-radius (u/px 15)
+                                  :border-radius (u/rem 0.4)
                                   :padding (u/px 10)
-                                  :margin-left (u/px -10)
-                                  :margin-right (u/px -10)
                                   :margin-top 0
                                   :margin-bottom (u/px 16)})
 


### PR DESCRIPTION
- styling of editor components was inconsistent with the application in the dashed border radius and margins
- maxlength fields were missing translation in the editor