### PR TITLE
Define config file location with `rems.config` system property

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -2,7 +2,7 @@
 
 REMS contains a number of configuration options that can be used to alter authentication options, theming or to add integration points, just to name a few.
 
-Configuration uses the [cprop](https://github.com/tolitius/cprop) library. You can specify the location of the configuration file by setting the `conf` system property: `java -Dconf="../somepath/config.edn" -jar rems.jar` You can also configure the application using environment variables as described in the cprop documentation.
+Configuration uses the [cprop](https://github.com/tolitius/cprop) library. You can specify the location of the configuration file by setting the `rems.config` system property: `java -Drems.config="../somepath/config.edn" -jar rems.jar` You can also configure the application using environment variables as described in the cprop documentation.
 
 The full list of available configuration options can be seen in [config-defaults.edn](https://github.com/CSCfi/rems/blob/master/resources/config-defaults.edn).  
 

--- a/project.clj
+++ b/project.clj
@@ -153,7 +153,7 @@
                            [lein-figwheel "0.5.18"]]
                  :aot [rems.InvalidRequestException rems.auth.NotAuthorizedException rems.auth.ForbiddenException]
 
-                 :jvm-opts ["-Dconf=dev-config.edn"]
+                 :jvm-opts ["-Drems.config=dev-config.edn"]
                  :source-paths ["env/dev/clj"]
                  :resource-paths ["env/dev/resources"]
                  :repl-options {:init-ns rems.standalone
@@ -176,7 +176,7 @@
                                                         :output-dir "target/cljsbuild/test/out"
                                                         :main rems.cljs-tests
                                                         :optimizations :none}}}}}
-   :project/test {:jvm-opts ["-Dconf=test-config.edn"]
+   :project/test {:jvm-opts ["-Drems.config=test-config.edn"]
                   :resource-paths ["env/test/resources"]}
    :profiles/dev {}
    :profiles/test {}})

--- a/src/clj/rems/config.clj
+++ b/src/clj/rems/config.clj
@@ -24,9 +24,8 @@
     config))
 
 (defstate env :start (-> (load-config :resource "config-defaults.edn"
-                                      ;; Precedence:
-                                      ;; 1. Use `rems.config` system property if defined
-                                      ;; 2. Use `conf` system property if defined (hard-coded in cprop)
-                                      ;; 3. Ignore `:file`
+                                      ;; If the "rems.config" system property is not defined, the :file parameter will
+                                      ;; fall back to using the "conf" system property (hard-coded in cprop).
+                                      ;; If neither system property is defined, the :file parameter is silently ignored.
                                       :file (System/getProperty "rems.config"))
                          (load-external-theme)))

--- a/src/clj/rems/config.clj
+++ b/src/clj/rems/config.clj
@@ -23,5 +23,10 @@
                  :theme-static-resources (file-sibling file "public")})
     config))
 
-(defstate env :start (-> (load-config :resource "config-defaults.edn")
+(defstate env :start (-> (load-config :resource "config-defaults.edn"
+                                      ;; Precedence:
+                                      ;; 1. Use `rems.config` system property if defined
+                                      ;; 2. Use `conf` system property if defined (hard-coded in cprop)
+                                      ;; 3. Ignore `:file`
+                                      :file (System/getProperty "rems.config"))
                          (load-external-theme)))


### PR DESCRIPTION
The old `conf` system property will still work (it's hard-coded in cprop), but an application specific system property will work better (less chance of a naming conflict) when deploying on an application server.