### PR TITLE
Add missing SMTP settings to config defaults

### DIFF
--- a/resources/config-defaults.edn
+++ b/resources/config-defaults.edn
@@ -18,6 +18,11 @@
         :search-root "dc=Suivohtor,dc=local"}
  :alternative-login-url nil
 
+ ;; Sending email.
+ :smtp-host nil
+ :smtp-port 25
+ :mail-from nil
+
  ;; URLs to notify about granted and revoked entitlements.
  :entitlements-target {:add nil
                        :remove nil}


### PR DESCRIPTION
There were some keys in env which were being used but not in the config defaults.