### PR TITLE
Refactor members and implement viewing

### DIFF
--- a/resources/translations/en.edn
+++ b/resources/translations/en.edn
@@ -125,9 +125,13 @@
                    :view "View"
                    :workflow "Workflow"
                    :workflows "Workflows"}
-  :applicant-info {:applicants "Applicants"
+  :applicant-info {:applicant "Applicant"
+                   :applicants "Applicants"
                    :email "Email"
-                   :username "Name"}
+                   :invited-member "Invited member"
+                   :member "Member"
+                   :name "Name"
+                   :username "Username"}
   :applications {:application "Application"
                  :applications "Applications"
                  :created "Created"

--- a/resources/translations/en.edn
+++ b/resources/translations/en.edn
@@ -125,7 +125,7 @@
                    :view "View"
                    :workflow "Workflow"
                    :workflows "Workflows"}
-  :applicant-info {:applicant "Applicant"
+  :applicant-info {:applicants "Applicants"
                    :email "Email"
                    :username "Name"}
   :applications {:application "Application"

--- a/resources/translations/en.edn
+++ b/resources/translations/en.edn
@@ -143,6 +143,7 @@
                                   :decision-requested "Decision requested"
                                   :draft-saved "Modified"
                                   :member-added "Member added"
+                                  :member-invited "Invited member"
                                   :rejected "Rejected"
                                   :returned "Changes requested"
                                   :submitted "Applied"}
@@ -153,8 +154,7 @@
                                   :returned "Returned"
                                   :submitted "Submitted"}
                  :empty "You don't have any applications."
-                 :events {:add-member "Added member"
-                          :apply "Applied"
+                 :events {:apply "Applied"
                           :approve "Approved"
                           :autoapprove "Automatically approved"
                           :close "Deleted"

--- a/resources/translations/en.edn
+++ b/resources/translations/en.edn
@@ -143,7 +143,7 @@
                                   :decision-requested "Decision requested"
                                   :draft-saved "Modified"
                                   :member-added "Member added"
-                                  :member-invited "Invited member"
+                                  :member-invited "Member invited"
                                   :rejected "Rejected"
                                   :returned "Changes requested"
                                   :submitted "Applied"}

--- a/resources/translations/fi.edn
+++ b/resources/translations/fi.edn
@@ -125,7 +125,7 @@
                    :view "Avaa"
                    :workflow "Työvuo"
                    :workflows "Työvuot"}
-  :applicant-info {:applicant "Hakija"
+  :applicant-info {:applicants "Hakijat"
                    :email "Sähköposti"
                    :username "Nimi"}
   :applications {:application "Hakemus"

--- a/resources/translations/fi.edn
+++ b/resources/translations/fi.edn
@@ -143,6 +143,7 @@
                                   :decision-requested "Pyydetty päätöstä"
                                   :draft-saved "Muokattu"
                                   :member-added "Lisätty jäsen"
+                                  :member-invited "Kutsuttu jäsen"
                                   :rejected "Hylätty"
                                   :returned "Palautettu muokattavaksi"
                                   :submitted "Lähtetetty hyväksyttäväksi"}
@@ -153,8 +154,7 @@
                                   :returned "Palautettu"
                                   :submitted "Haettu"}
                  :empty "Sinulla ei ole hakemuksia."
-                 :events {:add-member "Lisätty jäsen"
-                          :apply "Lähetetty hyväksyttäväksi"
+                 :events {:apply "Lähetetty hyväksyttäväksi"
                           :approve "Hyväksytty"
                           :autoapprove "Automaattisesti hyväksytty"
                           :close "Poistettu"

--- a/resources/translations/fi.edn
+++ b/resources/translations/fi.edn
@@ -125,9 +125,13 @@
                    :view "Avaa"
                    :workflow "Työvuo"
                    :workflows "Työvuot"}
-  :applicant-info {:applicants "Hakijat"
+  :applicant-info {:applicant "Hakija"
+                   :applicants "Hakijat"
                    :email "Sähköposti"
-                   :username "Nimi"}
+                   :invited-member "Kutsuttu jäsen"
+                   :member "Jäsen"
+                   :name "Nimi"
+                   :username "Käyttäjätunnus"}
   :applications {:application "Hakemus"
                  :applications "Hakemukset"
                  :created "Luotu"

--- a/src/clj/rems/api/applications.clj
+++ b/src/clj/rems/api/applications.clj
@@ -95,10 +95,6 @@
 (s/defschema Deciders
   [Decider])
 
-(s/defschema AddMemberCommand
-  {:application-id s/Num
-   :member s/Str})
-
 (s/defschema DynamicCommand
   {:type s/Keyword
    :application-id s/Num
@@ -305,17 +301,6 @@
                                         (:round request)
                                         (:comment request)
                                         (:recipients request))
-      (ok {:success true}))
-
-    (POST "/add_member" []
-      :summary "Add a member to an application"
-      :roles #{:applicant}
-      :body [request AddMemberCommand]
-      :return SuccessResponse
-      ;; TODO: provide a nicer error message when user doesn't exist?
-      (applications/add-member (getx-user-id)
-                               (:application-id request)
-                               (:member request))
       (ok {:success true}))
 
     ;; TODO: think about size limit

--- a/src/clj/rems/api/schema.clj
+++ b/src/clj/rems/api/schema.clj
@@ -56,14 +56,15 @@
    :time DateTime
    :eventdata s/Any})
 
+(s/defschema InvitedMember
+  {:name s/Str
+   :email s/Str})
+
+(s/defschema AddedMember
+  {:userid s/Str})
+
 (s/defschema DynamicEvent
-  (let [common-keys (set (keys dynamic/EventBase))]
-    (into (assoc dynamic/EventBase
-                 :event/type (apply s/enum (keys dynamic/event-schemas)))
-          (for [schema (vals dynamic/event-schemas)
-                [key val] schema
-                :when (not (contains? common-keys key))]
-            [(s/optional-key key) val]))))
+  {s/Keyword s/Any})
 
 (s/defschema Application
   {:id (s/maybe s/Num) ;; does not exist for unsaved draft
@@ -85,7 +86,8 @@
    :catalogue-items [CatalogueItem]
    (s/optional-key :review-type) (s/maybe (s/enum :normal :third-party))
    (s/optional-key :last-modified) DateTime
-   (s/optional-key :members) [s/Str]
+   (s/optional-key :invited-members) [InvitedMember]
+   (s/optional-key :members) [AddedMember]
    (s/optional-key :description) (s/maybe s/Str)
    (s/optional-key :workflow) s/Any
    (s/optional-key :possible-commands) #{s/Keyword}

--- a/src/clj/rems/css/styles.clj
+++ b/src/clj/rems/css/styles.clj
@@ -341,6 +341,12 @@
    [:.example-content {:border "1px dashed black"}]
    [:.example-content-end {:clear "both"}]
    [:textarea.form-control {:overflow "hidden"}]
+   [:.group {:position "relative"
+             :border "1px solid #ccc"
+             :border-radius (u/rem 0.4)
+             :padding (u/px 10)
+             :margin-top 0
+             :margin-bottom (u/px 16)}]
    [:div.form-control {:height :auto
                        :white-space "pre-wrap"
                        :border-color "rgba(206, 212, 218, 0.2)" ; "#ced4da"

--- a/src/clj/rems/db/applications.clj
+++ b/src/clj/rems/db/applications.clj
@@ -768,12 +768,6 @@
   [application event]
   (assoc application :state "closed"))
 
-(defmethod apply-event "add-member"
-  [application event]
-  (let [data (cheshire/parse-string (:eventdata event))
-        uid (getx data "uid")]
-    (update application :members #((fnil conj []) % uid))))
-
 (defn- apply-events [application events]
   (reduce apply-event application events))
 
@@ -945,17 +939,6 @@
     (when-not (can-close? user-id application)
       (throw-forbidden))
     (unjudge-application user-id application "close" round msg)))
-
-(defn add-member [user-id application-id member]
-  (let [application (get-application-state application-id)]
-    (when-not (= user-id (:applicantuserid application))
-      (throw-forbidden))
-    (when-not (#{"draft" "returned" "withdrawn"} (:state application))
-      (throw-forbidden))
-    (assert (users/get-user-attributes member) (str "User '" member "' must exist"))
-    (db/add-application-event! {:application application-id :user user-id :round 0
-                                :comment nil
-                                :event "add-member" :eventdata (cheshire/generate-string {"uid" member})})))
 
 ;;; Dynamic workflows
 ;; TODO these should be in their own namespace probably

--- a/src/clj/rems/db/test_data.clj
+++ b/src/clj/rems/db/test_data.clj
@@ -17,6 +17,7 @@
 
 (def +fake-users+
   {:applicant1 "alice"
+   :applicant2 "malice"
    :approver1 "developer"
    :approver2 "bob"
    :owner "owner"
@@ -25,6 +26,7 @@
 (def +fake-user-data+
   {"developer" {"eppn" "developer" "mail" "deve@lo.per" "commonName" "Deve Loper"}
    "alice" {"eppn" "alice" "mail" "a@li.ce" "commonName" "Alice Applicant"}
+   "malice" {"eppn" "malice" "mail" "ma@li.ce" "commonName" "Malice Applicant"}
    "bob" {"eppn" "bob" "mail" "b@o.b" "commonName" "Bob Approver"}
    "carl" {"eppn" "carl" "mail" "c@a.rl" "commonName" "Carl Reviewer"}
    "owner" {"eppn" "owner" "mail" "ow@n.er" "commonName" "Own Er"}})
@@ -51,6 +53,7 @@
   (roles/add-role! (+fake-users+ :approver1) :applicant)
   (roles/add-role! (+fake-users+ :approver1) :approver)
   (users/add-user! (+fake-users+ :applicant1) (+fake-user-data+ (+fake-users+ :applicant1)))
+  (users/add-user! (+fake-users+ :applicant2) (+fake-user-data+ (+fake-users+ :applicant2)))
   (roles/add-role! (+fake-users+ :applicant1) :applicant)
   (users/add-user! (+fake-users+ :approver2) (+fake-user-data+ (+fake-users+ :approver2)))
   (roles/add-role! (+fake-users+ :approver2) :approver)
@@ -505,6 +508,11 @@
       (applications/return-application approver app-id 0 "comment for return")
       (applications/submit-application applicant app-id))))
 
+(defn- create-member-application! [catid wfid applicant approver members]
+  (let [appid (create-draft! applicant catid wfid "draft application")]
+    (doseq [member members]
+      (applications/add-member applicant appid member))))
+
 (defn- run-and-check-dynamic-command! [& args]
   (let [result (apply applications/dynamic-command! args)]
     (assert (nil? result) {:actual result})
@@ -609,7 +617,8 @@
                                             {"en" "Dynamic workflow" "fi" "Dynaaminen työvuo"})]
         (create-dynamic-applications! dynamic (:dynamic workflows) +fake-users+))
       (let [thlform (create-thl-demo-form! +fake-users+)]
-        (create-catalogue-item! res1 (:dynamic workflows) thlform {"en" "THL catalogue item" "fi" "THL katalogi-itemi"})))
+        (create-catalogue-item! res1 (:dynamic workflows) thlform {"en" "THL catalogue item" "fi" "THL katalogi-itemi"}))
+      (create-member-application! simple (:simple workflows) (+fake-users+ :applicant1) (+fake-users+ :approver1) [(+fake-users+ :applicant2)]))
     (finally
       (DateTimeUtils/setCurrentMillisSystem))))
 
@@ -650,4 +659,5 @@
                                           {"en" "Dynamic workflow" "fi" "Dynaaminen työvuo"})]
       (create-dynamic-applications! dynamic (:dynamic workflows) +demo-users+))
     (let [thlform (create-thl-demo-form! +demo-users+)]
-      (create-catalogue-item! res1 (:dynamic workflows) thlform {"en" "THL catalogue item" "fi" "THL katalogi-itemi"}))))
+      (create-catalogue-item! res1 (:dynamic workflows) thlform {"en" "THL catalogue item" "fi" "THL katalogi-itemi"}))
+    (create-member-application! simple (:simple workflows) (+demo-users+ :applicant1) (+demo-users+ :approver1) [(+demo-users+ :applicant2)])))

--- a/src/cljc/rems/text.cljc
+++ b/src/cljc/rems/text.cljc
@@ -61,7 +61,6 @@
 (defn localize-event [event]
   (text (case event
           ;; static
-          "add-member" :t.application.events/add-member
           "apply" :t.applications.events/apply
           "approve" :t.applications.events/approve
           "autoapprove" :t.applications.events/autoapprove
@@ -83,6 +82,7 @@
           "decision-requested" :t.applications.dynamic-events/decision-requested
           "draft-saved" :t.applications.dynamic-events/draft-saved
           "member-added" :t.applications.dynamic-events/member-added
+          "member-invited" :t.application.dynamic-events/invite-member
           "rejected" :t.applications.dynamic-events/rejected
           "returned" :t.applications.dynamic-events/returned
           "submitted" :t.applications.dynamic-events/submitted

--- a/src/cljs/rems/application.cljs
+++ b/src/cljs/rems/application.cljs
@@ -787,27 +787,23 @@
     (into [:div
            [collapsible/minimal
             {:id (str id "-applicant")
-             :class (when (> (count members) 0) "form-item")
+             :class (when (> (count members) 0) "group")
              :always
-             [:div.row
-              [:div.col-md-6
-               [info-field (text :t.applicant-info/username) (or (get applicant-attributes "commonName")
-                                                                 (get applicant-attributes "eppn"))]]
-              [:div.col-md-6
-               [info-field (text :t.applicant-info/email) (get applicant-attributes "mail")]]]
+             [:div
+              [info-field (text :t.applicant-info/username) (or (get applicant-attributes "commonName")
+                                                                (get applicant-attributes "eppn")) {:inline? true}]
+              [info-field (text :t.applicant-info/email) (get applicant-attributes "mail") {:inline? true}]]
              :collapse (into [:div]
                              (for [[k v] (dissoc applicant-attributes "commonName" "mail")]
-                               [info-field k v]))}]]
+                               [info-field k v {:inline? true}]))}]]
           (for [member members]
             [collapsible/minimal
              {:id (str "member-" member)
-              :class "form-item"
+              :class "group"
               :always
-              [:div.row
-               [:div.col-md-6
-                [info-field (text :t.applicant-info/username) member]]
-               [:div.col-md-6
-                [info-field (text :t.applicant-info/email) (get member "mail")]]]}]))}])
+              [:div
+               [info-field (text :t.applicant-info/username) member {:inline? true}]
+               [info-field (text :t.applicant-info/email) (get member "mail") {:inline? true}]]}]))}])
 
 
 (defn action-form [id title comment-title button content]

--- a/src/cljs/rems/application.cljs
+++ b/src/cljs/rems/application.cljs
@@ -784,19 +784,30 @@
    {:id id
     :title (text :t.applicant-info/applicants)
     :always
-    [collapsible/minimal
-     {:id (str id "-applicant")
-      :class (when (> (count members) 0) "form-item")
-      :always
-      [:div.row
-       [:div.col-md-6
-        [info-field (text :t.applicant-info/username) (or (get applicant-attributes "commonName")
-                                                          (get applicant-attributes "eppn"))]]
-       [:div.col-md-6
-        [info-field (text :t.applicant-info/email) (get applicant-attributes "mail")]]]
-      :collapse (into [:div]
-                      (for [[k v] (dissoc applicant-attributes "commonName" "mail")]
-                        [info-field k v]))}]}])
+    (into [:div
+           [collapsible/minimal
+            {:id (str id "-applicant")
+             :class (when (> (count members) 0) "form-item")
+             :always
+             [:div.row
+              [:div.col-md-6
+               [info-field (text :t.applicant-info/username) (or (get applicant-attributes "commonName")
+                                                                 (get applicant-attributes "eppn"))]]
+              [:div.col-md-6
+               [info-field (text :t.applicant-info/email) (get applicant-attributes "mail")]]]
+             :collapse (into [:div]
+                             (for [[k v] (dissoc applicant-attributes "commonName" "mail")]
+                               [info-field k v]))}]]
+          (for [member members]
+            [collapsible/minimal
+             {:id (str "member-" member)
+              :class "form-item"
+              :always
+              [:div.row
+               [:div.col-md-6
+                [info-field (text :t.applicant-info/username) member]]
+               [:div.col-md-6
+                [info-field (text :t.applicant-info/email) (get member "mail")]]]}]))}])
 
 
 (defn action-form [id title comment-title button content]
@@ -1081,7 +1092,8 @@
         phases (:phases application)
         events (concat (:events app)
                        (map dynamic-event->event (:dynamic-events app)))
-        user-attributes (:applicant-attributes application)
+        applicant-attributes (:applicant-attributes application)
+        members (:members app)
         messages (remove nil?
                          [(disabled-items-warning (:catalogue-items application)) ; NB: eval this here so we get nil or a warning
                           (when @(rf/subscribe [::send-third-party-review-request-message])
@@ -1098,8 +1110,8 @@
      [:h2 (text :t.applications/application)]
      (into [:div] messages)
      [application-header state phases events]
-     (when user-attributes
-       [:div.mt-3 [applicant-info "applicant-info" user-attributes]])
+     (when applicant-attributes
+       [:div.mt-3 [applicant-info "applicant-info" applicant-attributes members]])
      [:div.mt-3 [applied-resources (:catalogue-items application)]]
      [:div.my-3 [fields application edit-application language]]
      [:div.mb-3 [actions-form app]]

--- a/src/cljs/rems/application.cljs
+++ b/src/cljs/rems/application.cljs
@@ -779,19 +779,24 @@
                   [events-view events])}]))
 
 
-(defn applicant-info [id user-attributes]
+(defn applicant-info [id applicant-attributes members]
   [collapsible/component
    {:id id
-    :title (str (text :t.applicant-info/applicants))
-    :always [:div.row
-             [:div.col-md-6
-              [info-field (text :t.applicant-info/username) (or (get user-attributes "commonName")
-                                                                (get user-attributes "eppn"))]]
-             [:div.col-md-6
-              [info-field (text :t.applicant-info/email) (get user-attributes "mail")]]]
-    :collapse (into [:form]
-                    (for [[k v] (dissoc user-attributes "commonName" "mail")]
-                      [info-field k v]))}])
+    :title (text :t.applicant-info/applicants)
+    :always
+    [collapsible/minimal
+     {:id (str id "-applicant")
+      :class (when (> (count members) 0) "form-item")
+      :always
+      [:div.row
+       [:div.col-md-6
+        [info-field (text :t.applicant-info/username) (or (get applicant-attributes "commonName")
+                                                          (get applicant-attributes "eppn"))]]
+       [:div.col-md-6
+        [info-field (text :t.applicant-info/email) (get applicant-attributes "mail")]]]
+      :collapse (into [:div]
+                      (for [[k v] (dissoc applicant-attributes "commonName" "mail")]
+                        [info-field k v]))}]}])
 
 
 (defn action-form [id title comment-title button content]

--- a/src/cljs/rems/application.cljs
+++ b/src/cljs/rems/application.cljs
@@ -782,7 +782,7 @@
 (defn applicant-info [id user-attributes]
   [collapsible/component
    {:id id
-    :title (str (text :t.applicant-info/applicant))
+    :title (str (text :t.applicant-info/applicants))
     :always [:div.row
              [:div.col-md-6
               [info-field (text :t.applicant-info/username) (or (get user-attributes "commonName")

--- a/src/cljs/rems/collapsible.cljs
+++ b/src/cljs/rems/collapsible.cljs
@@ -36,6 +36,27 @@
       [show-more-button id expanded callback]
       (when-not (false? bottom-less-button?) [show-less-button id expanded])])])
 
+(defn minimal
+  "Displays a minimal collapsible block of content.
+
+  The difference to `component` is that there are no borders around the content.
+
+  Pass a map of options with the following keys:
+  `:id` unique id required
+  `:class` optional class for wrapper div
+  `:open?` should the collapsible be open? Default false
+  `:top-less-button?` should top show less button be shown? Default false
+  `:bottom-less-button?` should bottom show less button be shown? Default true
+  `:on-open` triggers the function callback given as an argument when load-more is clicked
+  `:title` component displayed in title area
+  `:always` component displayed always before collapsible area
+  `:collapse` component that is toggled displayed or not"
+  [{:keys [id class open? on-open title always collapse top-less-button? bottom-less-button?]}]
+  [:div {:id id :class class}
+   (when title [header title])
+   (when (or always collapse)
+     [block id open? on-open always collapse top-less-button? bottom-less-button?])])
+
 (defn component
   "Displays a collapsible block of content.
 
@@ -92,4 +113,20 @@
                         :title "Collapse expanded"
                         :always [:p "I am content that is always visible"]
                         :top-less-button? true
-                        :collapse (into [:div] (repeat 15 [:p "I am long content that you can hide"]))}])])
+                        :collapse (into [:div] (repeat 15 [:p "I am long content that you can hide"]))}])
+   (component-info minimal)
+   (example "minimal collapsible without title"
+            [component {:id "minimal1"
+                        :always [:p "I am content that is always visible"]
+                        :collapse (into [:div] (repeat 5 [:p "I am long content that you can hide"]))}])
+   (example "minimal collapsible with custom border"
+            [component {:id "minimal2"
+                        :class "form-item"
+                        :always [:p "I am content that is always visible"]
+                        :collapse (into [:div] (repeat 5 [:p "I am long content that you can hide"]))}])
+   (example "minimal collapsible"
+            [component {:id "minimal3"
+                        :class "slow"
+                        :title "Minimal expanded"
+                        :always [:p "I am content that is always visible"]
+                        :collapse (into [:div] (repeat 5 [:p "I am long content that you can hide"]))}])])

--- a/test/clj/rems/test/api.clj
+++ b/test/clj/rems/test/api.clj
@@ -30,8 +30,10 @@
   (assert response)
   (assert (= 200 (:status response))
           (pr-str {:status (:status response)
-                   :body (when (:body response)
-                           (slurp (:body response)))}))
+                   :body (when-let [body (:body response)]
+                           (if (string? body)
+                             body
+                             (slurp body)))}))
   response)
 
 (defn response-is-unauthorized? [response]

--- a/test/clj/rems/test/api/actions.clj
+++ b/test/clj/rems/test/api/actions.clj
@@ -21,8 +21,8 @@
           handled-body (get-response-body "developer" "actions/handled")]
       (is (:approver? actions-body))
       (is (:approver? handled-body))
-      (is (= [2 8 11 12 13 15 16] (map :id (:approvals actions-body))))
-      (is (= [2 2 3 7 8 9 9 9] (sort (map :id (mapcat :catalogue-items (:approvals actions-body))))))
+      (is (= [2 8 11 12 13 15 16 18] (map :id (:approvals actions-body))))
+      (is (= [2 2 2 3 7 8 9 9 9] (sort (map :id (mapcat :catalogue-items (:approvals actions-body))))))
       (is (= [3 4 5 7 9 14] (map :id (:handled-approvals handled-body))))
       (is (empty? (:reviews body)))
       (is (empty? (:handled-reviews handled-body)))))

--- a/test/clj/rems/test/api/applications.clj
+++ b/test/clj/rems/test/api/applications.clj
@@ -451,51 +451,6 @@
 
 ;; TODO test for event filtering when it gets implemented
 
-(deftest application-api-add-member-test
-  (let [api-key "42"
-        user-id "alice"
-        another-user "bob"
-        catid 2
-        app-id (-> (request :post (str "/api/applications/save"))
-                   (authenticate api-key user-id)
-                   (json-body {:command "save"
-                               :catalogue-items [catid]
-                               :items {1 "REST-Test"}})
-                   app
-                   assert-response-is-ok
-                   read-body
-                   :id)]
-    (testing "happy path"
-      (-> (request :post "/api/applications/add_member")
-          (authenticate api-key user-id)
-          (json-body {:application-id app-id
-                      :member another-user})
-          app
-          assert-response-is-ok)
-      (let [members (-> (request :get (str "/api/applications/" app-id))
-                        (authenticate api-key user-id)
-                        app
-                        assert-response-is-ok
-                        read-body
-                        :application
-                        :members)]
-        (is (= ["bob"] members))))
-    (testing "adding nonexistant user"
-      (let [response (-> (request :post "/api/applications/add_member")
-                         (authenticate api-key user-id)
-                         (json-body {:application-id app-id
-                                     :member "nonexistant"})
-                         app)]
-        ;; TODO: should be a bad request?
-        (is (= 500 (:status response)))))
-    (testing "adding as non-applicant"
-      (let [response (-> (request :post "/api/applications/add_member")
-                         (authenticate api-key "developer")
-                         (json-body {:application-id app-id
-                                     :member "developer"})
-                         app)]
-        (is (response-is-forbidden? response))))))
-
 (defn- strip-cookie-attributes [cookie]
   (re-find #"[^;]*" cookie))
 

--- a/test/clj/rems/test/api/applications.clj
+++ b/test/clj/rems/test/api/applications.clj
@@ -364,7 +364,7 @@
                           (authenticate api-key approver)
                           app
                           read-body)]
-        (is (= ["alice" "bob" "carl" "developer" "owner"] (sort (map :userid reviewers))))
+        (is (= ["alice" "bob" "carl" "developer" "malice" "owner"] (sort (map :userid reviewers))))
         (is (not (contains? (set (map :userid reviewers)) "invalid")))))
     (testing "reviews is not open without authentication"
       (let [response (-> (request :get (str "/api/applications/reviewers"))

--- a/test/clj/rems/test/api/applications.clj
+++ b/test/clj/rems/test/api/applications.clj
@@ -779,7 +779,7 @@
                  :event/actor user-id
                  :application/id application-id}]
                (get-in data [:application :dynamic-events])))
-        (is (= ["rems.workflow.dynamic/add-member"] (get-in data [:application :possible-commands])))))
+        (is (= [] (get-in data [:application :possible-commands])))))
 
     (testing "getting dynamic application as handler"
       (let [data (get-application handler-id application-id)]
@@ -788,7 +788,9 @@
                  "rems.workflow.dynamic/request-decision"
                  "rems.workflow.dynamic/reject"
                  "rems.workflow.dynamic/approve"
-                 "rems.workflow.dynamic/return"}
+                 "rems.workflow.dynamic/return"
+                 "rems.workflow.dynamic/add-member"
+                 "rems.workflow.dynamic/invite-member"}
                (set (get-in data [:application :possible-commands]))))))
 
     (testing "send command without user"

--- a/test/clj/rems/test/db.clj
+++ b/test/clj/rems/test/db.clj
@@ -934,6 +934,11 @@
             :state :rems.workflow.dynamic/draft
             :workflow workflow}
            (select-keys (applications/get-dynamic-application-state app-id) [:applicantuserid :state :workflow])))
+    (is (nil? (applications/dynamic-command! {:type :rems.workflow.dynamic/invite-member
+                                              :actor "alice"
+                                              :member {:name "Jane Doe" :email "jane.doe@members.com"}
+                                              :application-id app-id
+                                              :time (time/now)})))
     (is (nil? (applications/dynamic-command! {:type :rems.workflow.dynamic/submit
                                               :actor "alice"
                                               :application-id app-id
@@ -943,6 +948,11 @@
     (is (nil? (applications/dynamic-command! {:type :rems.workflow.dynamic/add-member
                                               :actor "handler"
                                               :member {:userid "bob"}
+                                              :application-id app-id
+                                              :time (time/now)})))
+    (is (nil? (applications/dynamic-command! {:type :rems.workflow.dynamic/invite-member
+                                              :actor "handler"
+                                              :member {:name "John Doe" :email "john.doe@members.com"}
                                               :application-id app-id
                                               :time (time/now)})))
     (is (= [{:userid "alice"} {:userid "bob"}]

--- a/test/clj/rems/test/db.clj
+++ b/test/clj/rems/test/db.clj
@@ -941,11 +941,11 @@
     (is (= :rems.workflow.dynamic/submitted
            (:state (applications/get-dynamic-application-state app-id))))
     (is (nil? (applications/dynamic-command! {:type :rems.workflow.dynamic/add-member
-                                              :actor "alice"
-                                              :member "bob"
+                                              :actor "handler"
+                                              :member {:userid "bob"}
                                               :application-id app-id
                                               :time (time/now)})))
-    (is (= ["alice" "bob"]
+    (is (= [{:userid "alice"} {:userid "bob"}]
            (:members (applications/get-dynamic-application-state app-id))))
     (is (nil? (applications/dynamic-command! {:type :rems.workflow.dynamic/approve
                                               :actor "handler"

--- a/test/clj/rems/test/db.clj
+++ b/test/clj/rems/test/db.clj
@@ -837,35 +837,6 @@
                   {:round 0 :event "review-request" :comment "can you please review this?"}
                   {:round 0 :event "return" :comment "returning"}])))))))
 
-(deftest test-add-member
-  (db/add-user! {:user "alice" :userattrs "{\"eppn\": \"alice\"}"})
-  (db/add-user! {:user "bob" :userattrs "{\"eppn\": \"bob\"}"})
-  (db/add-user! {:user "carl" :userattrs "{\"eppn\": \"carl\"}"})
-  (db/add-user! {:user "david" :userattrs "{\"eppn\": \"david\"}"})
-  (let [uid "alice"
-        wf (:id (db/create-workflow! {:organization "abc" :modifieruserid "owner" :owneruserid "owner" :title "Test workflow" :fnlround 1}))
-        item (:id (db/create-catalogue-item! {:title "A" :form nil :resid nil :wfid wf}))
-        app (applications/create-new-draft uid wf)]
-    (db/add-application-item! {:application app :item item})
-    (testing "Adding two members"
-      (applications/add-member uid app "bob")
-      (applications/add-member uid app "carl")
-      (is (= ["bob" "carl"] (:members (applications/get-application-state app)))))
-    (testing "Can't add non-existing members"
-      (is (thrown? AssertionError
-                   (applications/add-member uid app "non-existent"))))
-    (testing "Non-applicant can't add members"
-      (is (thrown? ForbiddenException
-                   (applications/add-member "other-user" app "david"))))
-    (applications/submit-application uid app)
-    (testing "Can't add members to submitted application"
-      (is (thrown? ForbiddenException
-                   (applications/add-member uid app "david"))))
-    (testing "Members persist after autoapprove"
-      (let [state (applications/get-application-state app)]
-        (is (= "approved" (:state state)))
-        (is (= ["bob" "carl"] (:members state)))))))
-
 (deftest test-get-entitlements-for-export
   (db/add-user! {:user "jack" :userattrs nil})
   (db/add-user! {:user "jill" :userattrs nil})

--- a/test/clj/rems/test/db_localization.clj
+++ b/test/clj/rems/test/db_localization.clj
@@ -6,7 +6,8 @@
             [rems.db.applications :as applications]
             [rems.db.core :as db]
             [rems.test.locales :refer [loc-en]]
-            [rems.test.tempura :refer [with-fake-tempura]]))
+            [rems.test.tempura :refer [with-fake-tempura]]
+            [rems.workflow.dynamic :as dynamic]))
 
 (use-fixtures
   :once
@@ -40,6 +41,16 @@
          (->> (applications/get-event-types)
               (map keyword)
               (sort))))
-  (with-fake-tempura
-    (is (not (contains? (set (map rems.text/localize-event (applications/get-event-types)))
-                        :t.applications.events/unknown)))))
+  (is (= (-> (:dynamic-events (:applications (:t loc-en)))
+             (dissoc :unknown)
+             (keys)
+             (sort))
+         (->> (dynamic/get-event-types)
+              (map name)
+              (map keyword)
+              (sort))))
+  (let [event-types (concat (applications/get-event-types)
+                            (map name (dynamic/get-event-types)))]
+    (with-fake-tempura
+      (is (not (contains? (set (map rems.text/localize-event event-types))
+                          :t.applications.events/unknown))))))


### PR DESCRIPTION
See #609 and #870.

- Removes add member support for old applications
- Splits add member events to add member (REMS user, handler action only) and invite member (not rems user, handler and applicant depending on state)
- Implements a view of the additional members of an application as well as invited members. 