### PR TITLE
refactor: map as error with :key like in field validations

### DIFF
--- a/src/clj/rems/api/resources.clj
+++ b/src/clj/rems/api/resources.clj
@@ -30,7 +30,7 @@
 (s/defschema CreateResourceResponse
   {:success s/Bool
    (s/optional-key :id) s/Num
-   (s/optional-key :errors) [{:key s/Keyword :resid s/Str}]})
+   (s/optional-key :errors) [s/Any]})
 
 (defn- format-resource
   [{:keys [id owneruserid modifieruserid organization resid start endt active?]}]

--- a/src/clj/rems/api/schema.clj
+++ b/src/clj/rems/api/schema.clj
@@ -109,4 +109,4 @@
 
 (s/defschema SuccessResponse
   {:success s/Bool
-   (s/optional-key :errors) s/Any})
+   (s/optional-key :errors) [s/Any]})

--- a/src/clj/rems/db/resource.clj
+++ b/src/clj/rems/db/resource.clj
@@ -35,5 +35,5 @@
     (catch Exception e
       (if (duplicate-resid? e)
         {:success false
-         :errors [{:key :t.administration.errors/duplicate-resid :resid resid}]}
+         :errors [{:type :t.administration.errors/duplicate-resid :resid resid}]}
         (throw e)))))

--- a/src/clj/rems/workflow/dynamic.clj
+++ b/src/clj/rems/workflow/dynamic.clj
@@ -272,7 +272,7 @@
 (defn- applicant-error
   [application cmd]
   (when-not (= (:actor cmd) (:applicantuserid application))
-    {:errors [:forbidden]}))
+    {:errors [{:key :forbidden}]}))
 
 (defn- handler?
   [application user]
@@ -281,18 +281,18 @@
 (defn- actor-is-not-handler-error
   [application cmd]
   (when-not (handler? application (:actor cmd))
-    {:errors [:forbidden]}))
+    {:errors [{:key :forbidden}]}))
 
 (defn- state-error
   [application & expected-states]
   (when-not (contains? (set expected-states) (:state application))
-    {:errors [[:invalid-state (:state application)]]}))
+    {:errors [{:key :invalid-state :state (:state application)}]}))
 
 (defn- valid-user-error
   [injections user]
   (cond
-    (not (:valid-user? injections)) {:errors [[:missing-injection :valid-user?]]}
-    (not ((:valid-user? injections) user)) {:errors [[:t.form.validation/invalid-user user]]}))
+    (not (:valid-user? injections)) {:errors [{:key :missing-injection :injection :valid-user?}]}
+    (not ((:valid-user? injections) user)) {:errors [{:key :t.form.validation/invalid-user :userid user}]}))
 
 (defn- validation-error
   [injections application-id]
@@ -385,10 +385,10 @@
 (defmethod handle-command ::decide
   [cmd application _injections]
   (or (when-not (= (:actor cmd) (:decider application))
-        {:errors [:forbidden]})
+        {:errors [{:key :forbidden}]})
       (state-error application ::submitted)
       (when-not (contains? #{:approved :rejected} (:decision cmd))
-        {:errors [[:invalid-decision (:decision cmd)]]})
+        {:errors [{:key :invalid-decision :decision (:decision cmd)}]})
       {:success true
        :result {:event/type :application.event/decided
                 :event/time (:time cmd)
@@ -404,7 +404,7 @@
 
 (defn- must-not-be-empty [cmd key]
   (when-not (seq (get cmd key))
-    {:errors [[:must-not-be-empty key]]}))
+    {:errors [{:key :must-not-be-empty :cmd-key key}]}))
 
 (defmethod handle-command ::request-comment
   [cmd application injections]
@@ -422,7 +422,7 @@
 
 (defn- actor-is-not-commenter-error [application cmd]
   (when-not (contains? (:commenters application) (:actor cmd))
-    {:errors [:forbidden]}))
+    {:errors [{:key :forbidden}]}))
 
 (defmethod handle-command ::comment
   [cmd application _injections]
@@ -561,7 +561,7 @@
                              application
                              injections))))
     (testing "only the applicant can save a draft"
-      (is (= {:errors [:forbidden]}
+      (is (= {:errors [{:key :forbidden}]}
              (handle-command {:type ::save-draft
                               :time 456
                               :actor "non-applicant"
@@ -592,7 +592,7 @@
                                         [{:actor "applicant" :type ::save-draft :items {1 "original"} :licenses {2 "original"}}
                                          {:actor "applicant" :type ::submit}]
                                         injections)]
-        (is (= {:errors [[:invalid-state ::submitted]]}
+        (is (= {:errors [{:key :invalid-state :state ::submitted}]}
                (handle-command {:type ::save-draft
                                 :actor "applicant"
                                 :items {1 "updated"} :licenses {2 "updated"}}
@@ -638,14 +638,14 @@
                      :workflow {:type :workflow/dynamic
                                 :handlers ["assistant"]}}]
     (testing "only applicant can submit"
-      (is (= {:errors [:forbidden]}
+      (is (= {:errors [{:key :forbidden}]}
              (handle-command {:actor "not-applicant" :type ::submit} application injections))))
     (testing "can only submit valid form"
       (is (= {:errors expected-errors}
              (handle-command {:actor "applicant" :type ::submit} application fail-injections))))
     (let [submitted (apply-command application {:actor "applicant" :type ::submit} injections)]
       (testing "cannot submit twice"
-        (is (= {:errors [[:invalid-state ::submitted]]}
+        (is (= {:errors [{:key :invalid-state :state ::submitted}]}
                (handle-command {:actor "applicant" :type ::submit} submitted injections))))
       (testing "submitter is member"
         (is (= [{:userid "applicant"}] (:members submitted))))
@@ -684,17 +684,17 @@
                                 :handlers ["assistant"]}}
         injections {:valid-user? #{"deity"}}]
     (testing "required :valid-user? injection"
-      (is (= {:errors [[:missing-injection :valid-user?]]}
+      (is (= {:errors [{:key :missing-injection :injection :valid-user?}]}
              (handle-command {:actor "assistant" :decider "deity" :type ::request-decision}
                              application
                              {}))))
     (testing "decider must be a valid user"
-      (is (= {:errors [[:t.form.validation/invalid-user "deity2"]]}
+      (is (= {:errors [{:key :t.form.validation/invalid-user :userid "deity2"}]}
              (handle-command {:actor "assistant" :decider "deity2" :type ::request-decision}
                              application
                              injections))))
     (testing "deciding before ::request-decision should fail"
-      (is (= {:errors [:forbidden]}
+      (is (= {:errors [{:key :forbidden}]}
              (handle-command {:actor "deity" :decision :approved :type ::decide}
                              application
                              injections))))
@@ -702,7 +702,7 @@
       (testing "request decision succesfully"
         (is (= {:decider "deity"} (select-keys requested [:decider :decision]))))
       (testing "only the requested user can decide"
-        (is (= {:errors [:forbidden]}
+        (is (= {:errors [{:key :forbidden}]}
                (handle-command {:actor "deity2" :decision :approved :type ::decide}
                                requested
                                injections))))
@@ -710,7 +710,7 @@
         (testing "succesfully approved"
           (is (= {:decision :approved} (select-keys approved [:decider :decision]))))
         (testing "cannot approve twice"
-          (is (= {:errors [:forbidden]}
+          (is (= {:errors [{:key :forbidden}]}
                  (handle-command {:actor "deity" :decision :approved :type ::decide}
                                  approved
                                  injections)))))
@@ -718,12 +718,12 @@
         (testing "successfully rejected"
           (is (= {:decision :rejected} (select-keys rejected [:decider :decision]))))
         (testing "can not reject twice"
-          (is (= {:errors [:forbidden]}
+          (is (= {:errors [{:key :forbidden}]}
                  (handle-command {:actor "deity" :decision :rejected :type ::decide}
                                  rejected
                                  injections)))))
       (testing "other decisions are not possible"
-        (is (= {:errors [[:invalid-decision :foobar]]}
+        (is (= {:errors [{:key :invalid-decision :decision :foobar}]}
                (handle-command {:actor "deity" :decision :foobar :type ::decide}
                                requested
                                injections)))))))
@@ -742,7 +742,7 @@
                               [{:type ::add-member :actor "assistant" :member {:userid "member1"}}]
                               injections)))))
     (testing "only handler can add members"
-      (is (= {:errors [:forbidden]}
+      (is (= {:errors [{:key :forbidden}]}
              (handle-command {:type ::add-member :actor "member1" :member "member1"}
                              application
                              injections)
@@ -750,7 +750,7 @@
                              application
                              injections))))
     (testing "only valid users can be added"
-      (is (= {:errors [[:t.form.validation/invalid-user "member3"]]}
+      (is (= {:errors [{:key :t.form.validation/invalid-user :userid "member3"}]}
              (handle-command {:type ::add-member :actor "assistant" :member {:userid "member3"}}
                              application
                              injections))))))
@@ -776,12 +776,12 @@
                                {:type ::invite-member :actor "assistant" :member {:name "Member Applicant 2" :email "member2@applicants.com"}}]
                               injections)))))
     (testing "only applicant or handler can invite members"
-      (is (= {:errors [:forbidden]}
+      (is (= {:errors [{:key :forbidden}]}
              (handle-command {:type ::invite-member :actor "member1" :member {:name "Member Applicant 1" :email "member1@applicants.com"}}
                              application
                              injections))))
     (testing "applicant can't invite members to approved application"
-      (is (= {:errors [[:invalid-state ::approved]]}
+      (is (= {:errors [{:key :invalid-state :state ::approved}]}
              (handle-command {:type ::invite-member :actor "applicant" :member {:name "Member Applicant 1" :email "member1@applicants.com"}}
                              (assoc application :state ::approved)
                              injections))))
@@ -800,22 +800,22 @@
                                 :handlers ["assistant"]}}
         injections {:valid-user? #{"commenter" "commenter2" "commenter3"}}]
     (testing "required :valid-user? injection"
-      (is (= {:errors [[:missing-injection :valid-user?]]}
+      (is (= {:errors [{:key :missing-injection :injection :valid-user?}]}
              (handle-command {:actor "assistant" :commenters ["commenter"] :type ::request-comment}
                              application
                              {}))))
     (testing "commenters must not be empty"
-      (is (= {:errors [[:must-not-be-empty :commenters]]}
+      (is (= {:errors [{:key :must-not-be-empty :cmd-key :commenters}]}
              (handle-command {:actor "assistant" :commenters [] :type ::request-comment}
                              application
                              {}))))
     (testing "commenters must be a valid users"
-      (is (= {:errors [[:t.form.validation/invalid-user "invaliduser"] [:t.form.validation/invalid-user "invaliduser2"]]}
+      (is (= {:errors [{:key :t.form.validation/invalid-user :userid "invaliduser"} {:key :t.form.validation/invalid-user :userid "invaliduser2"}]}
              (handle-command {:actor "assistant" :commenters ["invaliduser" "commenter" "invaliduser2"] :type ::request-comment}
                              application
                              injections))))
     (testing "commenting before ::request-comment should fail"
-      (is (= {:errors [:forbidden]}
+      (is (= {:errors [{:key :forbidden}]}
              (handle-command {:actor "commenter" :decision :approved :type ::comment}
                              application
                              injections))))
@@ -826,7 +826,7 @@
       (testing "request comment succesfully"
         (is (= #{"commenter2" "commenter"} (:commenters requested))))
       (testing "only the requested commenter can comment"
-        (is (= {:errors [:forbidden]}
+        (is (= {:errors [{:key :forbidden}]}
                (handle-command {:actor "commenter3" :comment "..." :type ::comment}
                                requested
                                injections))))
@@ -834,7 +834,7 @@
         (testing "succesfully commented"
           (is (= #{"commenter2"} (:commenters commented))))
         (testing "cannot comment twice"
-          (is (= {:errors [:forbidden]}
+          (is (= {:errors [{:key :forbidden}]}
                  (handle-command {:actor "commenter" :comment "..." :type ::comment}
                                  commented
                                  injections))))

--- a/test/clj/rems/test/api/applications.clj
+++ b/test/clj/rems/test/api/applications.clj
@@ -796,14 +796,14 @@
 
     (testing "send command without user"
       (is (= {:success false
-              :errors ["forbidden"]}
+              :errors [{:type "forbidden"}]}
              (send-dynamic-command "" {:type :rems.workflow.dynamic/approve
                                        :application-id application-id}))
           "user should be forbidden to send command"))
 
     (testing "send command with a user that is not a handler"
       (is (= {:success false
-              :errors ["forbidden"]}
+              :errors [{:type "forbidden"}]}
              (send-dynamic-command user-id {:type :rems.workflow.dynamic/approve
                                             :application-id application-id
                                             :comment ""}))

--- a/test/clj/rems/test/api/resources.clj
+++ b/test/clj/rems/test/api/resources.clj
@@ -49,7 +49,7 @@
                 body (read-body response)]
             (is (= 200 (:status response)))
             (is (= false (:success body)))
-            (is (= [{:key "t.administration.errors/duplicate-resid" :resid resid}] (:errors body)))))
+            (is (= [{:type "t.administration.errors/duplicate-resid" :resid resid}] (:errors body)))))
         (testing "duplicate resource ID is allowed between organizations"
           (-> (request :post "/api/resources/create")
               (authenticate api-key user-id)


### PR DESCRIPTION
Some dynamic workflow errors had the new `:key` field and some did not. This modifies the format to always have the `:key` but does not try to localize them all yet.