### PR TITLE
fix: collapsible margin

### DIFF
--- a/src/clj/rems/css/styles.clj
+++ b/src/clj/rems/css/styles.clj
@@ -450,8 +450,7 @@
                     :font-size (u/rem 1.5)
                     :line-height 1.1
                     :font-family "'Lato'"}]]
-   [:.collapse-content {:padding (u/rem 1.25)
-                        :padding-bottom 0}]
+   [:.collapse-content {:margin (u/rem 1.25)}]
    [:.collapse-wrapper.slow
     [:.collapsing {:-webkit-transition "height 0.25s linear"
                    :-o-transition "height 0.25s linear"

--- a/src/cljs/rems/collapsible.cljs
+++ b/src/cljs/rems/collapsible.cljs
@@ -28,7 +28,7 @@
 
 (defn- block [id expanded callback content-always content-hideable top-less-button? bottom-less-button?]
   [:div.collapse-content
-   [:div content-always]
+   content-always
    (when-not (empty? content-hideable)
      [:div
       (when top-less-button? [show-less-button id expanded])


### PR DESCRIPTION
Collapsible margin was absent and caused some visual bugs with buttons. Do it with margin instead of padding so we can take advantage of margin collapsing.