### PR TITLE
Allow members to see application

### DIFF
--- a/src/clj/rems/api/applications.clj
+++ b/src/clj/rems/api/applications.clj
@@ -1,5 +1,6 @@
 (ns rems.api.applications
   (:require [clj-time.core :as time]
+            [clojure.set :as set]
             [clojure.string :as str]
             [clojure.test :refer [deftest is]]
             [compojure.api.sweet :refer :all]
@@ -10,9 +11,11 @@
             [rems.context :as context]
             [rems.db.applications :as applications]
             [rems.db.core :as db]
+            [rems.db.dynamic-roles :as dynamic-roles]
             [rems.db.users :as users]
             [rems.form :as form]
             [rems.pdf :as pdf]
+            [rems.permissions :as permissions]
             [rems.util :refer [getx-user-id update-present]]
             [rems.workflow.dynamic :as dynamic]
             [ring.swagger.upload :as upload]
@@ -206,7 +209,20 @@
       :summary "Get current user's all applications"
       :roles #{:logged-in}
       :return GetApplicationsResponse
-      (ok (applications/get-user-applications (getx-user-id))))
+      ;; XXX: the old API doesn't know about members, so it doesn't return applications where the user is a member
+      ;; XXX: this code cannot be moved to rems.db.applications because it would create a cyclic dependency
+      (let [user-id (getx-user-id)
+            old-applications (applications/get-user-applications user-id)
+            member-application-ids (->> (applications/get-dynamic-application-events-since 0)
+                                        (reduce dynamic-roles/permissions-of-all-applications nil)
+                                        (filter (fn [[_id app]]
+                                                  (contains? (permissions/user-roles app user-id)
+                                                             :member)))
+                                        (map first))
+            missing-ids (set/difference (set member-application-ids)
+                                        (set (map :id old-applications)))
+            missing-applications (map #(:application (api-get-application user-id %)) missing-ids)]
+        (ok (concat old-applications missing-applications))))
 
     (GET "/draft" []
       :summary "Get application (draft) for `catalogue-items`"

--- a/src/clj/rems/db/dynamic_roles.clj
+++ b/src/clj/rems/db/dynamic_roles.clj
@@ -5,7 +5,8 @@
             [rems.permissions :as permissions]
             [rems.workflow.dynamic :as dynamic]))
 
-(defn- permissions-of-all-applications [applications event]
+;; TODO: make private after removing the hack which uses this
+(defn permissions-of-all-applications [applications event]
   (if-let [app-id (:application/id event)] ; old style events don't have :application/id
     (update applications app-id dynamic/calculate-permissions event)
     applications))

--- a/src/clj/rems/permissions.clj
+++ b/src/clj/rems/permissions.clj
@@ -22,6 +22,10 @@
     m))
 
 (defn remove-role-from-user [application role user]
+  (assert (keyword? role)
+          (str "role must be a keyword: " (pr-str role)))
+  (assert (string? user)
+          (str "user must be a string: " (pr-str user)))
   (-> application
       (update-in [::user-roles user] disj role)
       (update ::user-roles dissoc-if-empty user)))

--- a/src/clj/rems/permissions.clj
+++ b/src/clj/rems/permissions.clj
@@ -4,10 +4,8 @@
 (def ^:private conj-set (fnil conj #{}))
 
 (defn- give-role-to-user [application role user]
-  (assert (keyword? role)
-          (str "role must be a keyword: " (pr-str role)))
-  (assert (string? user)
-          (str "user must be a string: " (pr-str user)))
+  (assert (keyword? role) {:role role})
+  (assert (string? user) {:user user})
   (update-in application [::user-roles user] conj-set role))
 
 (defn give-role-to-users [application role users]
@@ -22,10 +20,8 @@
     m))
 
 (defn remove-role-from-user [application role user]
-  (assert (keyword? role)
-          (str "role must be a keyword: " (pr-str role)))
-  (assert (string? user)
-          (str "user must be a string: " (pr-str user)))
+  (assert (keyword? role) {:role role})
+  (assert (string? user) {:user user})
   (-> application
       (update-in [::user-roles user] disj role)
       (update ::user-roles dissoc-if-empty user)))
@@ -89,7 +85,7 @@
    comments from the reviewers (e.g. `:see-everything`)."
   [application permission-map]
   (reduce (fn [application [role permissions]]
-            (assert (keyword? role))
+            (assert (keyword? role) {:role role})
             (assoc-in application [::role-permissions role] (set permissions)))
           application
           permission-map))

--- a/src/clj/rems/permissions.clj
+++ b/src/clj/rems/permissions.clj
@@ -1,4 +1,4 @@
-(ns rems.permissions
+(ns ^:focused rems.permissions
   (:require [clojure.test :refer [deftest is testing]]))
 
 (def ^:private conj-set (fnil conj #{}))

--- a/src/clj/rems/permissions.clj
+++ b/src/clj/rems/permissions.clj
@@ -1,4 +1,4 @@
-(ns ^:focused rems.permissions
+(ns rems.permissions
   (:require [clojure.test :refer [deftest is testing]]))
 
 (def ^:private conj-set (fnil conj #{}))

--- a/src/clj/rems/workflow/dynamic.clj
+++ b/src/clj/rems/workflow/dynamic.clj
@@ -894,11 +894,10 @@
                              application
                              injections))))
     (testing "added members can see the application"
-      (is (= #{:member}
-             (-> (apply-commands application
-                                 [{:type ::add-member :actor "assistant" :member {:userid "member1"}}]
-                                 injections)
-                 (permissions/user-roles "member1")))))))
+      (is (true? (-> (apply-commands application
+                                     [{:type ::add-member :actor "assistant" :member {:userid "member1"}}]
+                                     injections)
+                     (permissions/has-any-role? "member1")))))))
 
 (deftest test-invite-member
   (let [application (apply-events nil
@@ -978,14 +977,12 @@
                              application
                              injections))))
     (testing "removed members cannot see the application"
-      (is (not= #{}
-                (-> application
-                    (permissions/user-roles "somebody"))))
-      (is (= #{}
-             (-> application
-                 (apply-commands [{:type ::remove-member :actor "applicant" :member {:userid "somebody"}}]
-                                 injections)
-                 (permissions/user-roles "somebody")))))))
+      (is (true? (-> application
+                     (permissions/has-any-role? "somebody"))))
+      (is (false? (-> application
+                      (apply-commands [{:type ::remove-member :actor "applicant" :member {:userid "somebody"}}]
+                                      injections)
+                      (permissions/has-any-role? "somebody")))))))
 
 
 (deftest test-uninvite-member

--- a/src/cljs/rems/navbar.cljs
+++ b/src/cljs/rems/navbar.cljs
@@ -30,7 +30,7 @@
     [e [:div.navbar-nav.mr-auto
         (when (roles/is-logged-in? roles)
           [nav-link "#/catalogue" (text :t.navigation/catalogue) (= page-id :catalogue)])
-        (when (roles/is-applicant? roles)
+        (when (roles/is-applicant-or-member? roles)
           [nav-link "#/applications" (text :t.navigation/applications) (contains? #{:application
                                                                                     :applications}
                                                                                   page-id)])

--- a/src/cljs/rems/roles.cljs
+++ b/src/cljs/rems/roles.cljs
@@ -7,8 +7,10 @@
 (defn is-logged-in? [roles]
   (has-some? #{:logged-in} roles))
 
-(defn is-applicant? [roles]
-  (has-some? #{:applicant} roles))
+(defn is-applicant-or-member? [roles]
+  (has-some? #{:applicant
+               :member}
+             roles))
 
 ;; TODO: Think of a common name for handlers, commenters and deciders. After removing the legacy workflow, "reviewer" would be a free word.
 (defn is-handler-or-commenter-or-decider? [roles]


### PR DESCRIPTION
Fixes #950 

The old `rems.db.applications/get-user-applications` is unaware of members and needed a hack. Updating it to be aware of members is probably not worth it because #852 will anyways replace it with `rems.api.applications-v2/get-user-applications-v2`