### PR TITLE
refactor: move joda-time-writer to db ns

### DIFF
--- a/env/dev/clj/rems/repl_utils.clj
+++ b/env/dev/clj/rems/repl_utils.clj
@@ -1,7 +1,7 @@
 (ns rems.repl-utils
   (:require [clojure.pprint :refer [pprint]]
             [muuntaja.core :as muuntaja]
-            [rems.api :as api])
+            [rems.json :as json])
   (:import (java.awt Toolkit)
            (java.awt.datatransfer DataFlavor)))
 
@@ -11,7 +11,7 @@
       (.getData DataFlavor/stringFlavor)))
 
 (defn decode-transit [data]
-  (muuntaja/decode api/muuntaja "application/transit+json" data))
+  (muuntaja/decode json/muuntaja "application/transit+json" data))
 
 (defn pptransit
   ([]

--- a/src/clj/rems/api.clj
+++ b/src/clj/rems/api.clj
@@ -1,8 +1,6 @@
 (ns rems.api
-  (:require [cheshire.generate :as cheshire]
-            [clojure.stacktrace :refer [print-cause-trace]]
+  (:require [clojure.stacktrace :refer [print-cause-trace]]
             [clojure.tools.logging :as log]
-            [cognitect.transit :as transit]
             [compojure.api.exception :as ex]
             [compojure.api.sweet :refer :all]
             [conman.core :as conman]
@@ -25,8 +23,7 @@
             [ring.middleware.cors :refer [wrap-cors]]
             [ring.util.http-response :refer :all]
             [schema.core :as s])
-  (:import [org.joda.time DateTime ReadableInstant]
-           [rems.auth ForbiddenException NotAuthorizedException]
+  (:import [rems.auth ForbiddenException NotAuthorizedException]
            rems.InvalidRequestException))
 
 (defn unauthorized-handler
@@ -63,17 +60,6 @@
       (conman/with-transaction [rems.db.core/*db* {:isolation :serializable}]
         (handler request))
       (handler request))))
-
-(def joda-time-writer
-  (transit/write-handler
-   "m"
-   (fn [v] (-> ^ReadableInstant v .getMillis))
-   (fn [v] (-> ^ReadableInstant v .getMillis .toString))))
-
-(cheshire/add-encoder
- DateTime
- (fn [c jsonGenerator]
-   (.writeString jsonGenerator (-> ^ReadableInstant c .getMillis .toString))))
 
 (def muuntaja
   (muuntaja/create

--- a/src/clj/rems/api.clj
+++ b/src/clj/rems/api.clj
@@ -4,9 +4,6 @@
             [compojure.api.exception :as ex]
             [compojure.api.sweet :refer :all]
             [conman.core :as conman]
-            [muuntaja.core :as muuntaja]
-            [muuntaja.format.json :refer [json-format]]
-            [muuntaja.format.transit :as transit-format]
             [rems.api.actions :refer [actions-api]]
             [rems.api.applications :refer [applications-api]]
             [rems.api.catalogue :refer [catalogue-api]]
@@ -20,6 +17,7 @@
             [rems.api.workflows :refer [workflows-api]]
             [rems.auth.ForbiddenException]
             [rems.auth.NotAuthorizedException]
+            [rems.json :refer [muuntaja]]
             [ring.middleware.cors :refer [wrap-cors]]
             [ring.util.http-response :refer :all]
             [schema.core :as s])
@@ -60,23 +58,6 @@
       (conman/with-transaction [rems.db.core/*db* {:isolation :serializable}]
         (handler request))
       (handler request))))
-
-(def muuntaja
-  (muuntaja/create
-   (update
-    muuntaja/default-options
-    :formats
-    merge
-    {"application/json"
-     json-format
-
-     "application/transit+json"
-     {:decoder [(partial transit-format/make-transit-decoder :json)]
-      :encoder [#(transit-format/make-transit-encoder
-                  :json
-                  (merge
-                   %
-                   {:handlers {DateTime joda-time-writer}}))]}})))
 
 (defn slow-middleware [request]
   (Thread/sleep 2000)

--- a/src/clj/rems/db/applications.clj
+++ b/src/clj/rems/db/applications.clj
@@ -1,7 +1,6 @@
 (ns rems.db.applications
   "Query functions for forms and applications."
-  (:require [cheshire.core :as cheshire]
-            [clj-time.coerce :as time-coerce]
+  (:require [clj-time.coerce :as time-coerce]
             [clj-time.core :as time]
             [clojure.set :refer [difference union]]
             [clojure.test :refer [deftest is]]
@@ -21,6 +20,7 @@
             [rems.db.workflow-actors :as actors]
             [rems.email :as email]
             [rems.form-validation :as form-validation]
+            [rems.json :as json]
             [rems.permissions :as permissions]
             [rems.util :refer [getx get-username update-present]]
             [rems.workflow.dynamic :as dynamic]
@@ -951,7 +951,7 @@
 
 (defn- fix-workflow-from-db [wf]
   ;; TODO could use a schema for this coercion
-  (update (cheshire/parse-string wf keyword)
+  (update (json/parse-string wf keyword)
           :type keyword))
 
 (defn- string->datetime [s]
@@ -986,7 +986,7 @@
 (defn json->event [json]
   (when json
     ;; most keys are keywords, but some events use numeric keys in maps
-    (let [result (coerce-dynamic-event (cheshire/parse-string json str->keyword-or-number))]
+    (let [result (coerce-dynamic-event (json/parse-string json str->keyword-or-number))]
       (when (schema.utils/error? result)
         ;; similar exception as what schema.core/validate throws
         (throw (ex-info (str "Value does not match schema: " (pr-str result))
@@ -998,7 +998,7 @@
 
 (defn event->json [event]
   (validate-dynamic-event event)
-  (cheshire/generate-string event))
+  (json/generate-string event))
 
 (defn- fix-event-from-db [event]
   (assoc (-> event :eventdata json->event)

--- a/src/clj/rems/db/core.clj
+++ b/src/clj/rems/db/core.clj
@@ -1,25 +1,11 @@
 (ns rems.db.core
   {:ns-tracker/resource-deps ["sql/queries.sql"]}
-  (:require [cheshire.generate :as cheshire]
-            [clj-time.core :as time]
+  (:require [clj-time.core :as time]
             [clj-time.jdbc] ;; convert db timestamps to joda-time objects
             [clojure.set :refer [superset?]]
-            [cognitect.transit :as transit]
             [conman.core :as conman]
             [mount.core :refer [defstate]]
-            [rems.config :refer [env]])
-  (:import [org.joda.time DateTime ReadableInstant]))
-
-(def joda-time-writer
-  (transit/write-handler
-   "m"
-   (fn [v] (-> ^ReadableInstant v .getMillis))
-   (fn [v] (-> ^ReadableInstant v .getMillis .toString))))
-
-(cheshire/add-encoder
- DateTime
- (fn [c jsonGenerator]
-   (.writeString jsonGenerator (-> ^ReadableInstant c .getMillis .toString))))
+            [rems.config :refer [env]]))
 
 (defstate ^:dynamic *db*
           :start (cond

--- a/src/clj/rems/db/core.clj
+++ b/src/clj/rems/db/core.clj
@@ -1,11 +1,25 @@
 (ns rems.db.core
   {:ns-tracker/resource-deps ["sql/queries.sql"]}
-  (:require [clj-time.core :as time]
+  (:require [cheshire.generate :as cheshire]
+            [clj-time.core :as time]
             [clj-time.jdbc] ;; convert db timestamps to joda-time objects
             [clojure.set :refer [superset?]]
+            [cognitect.transit :as transit]
             [conman.core :as conman]
             [mount.core :refer [defstate]]
-            [rems.config :refer [env]]))
+            [rems.config :refer [env]])
+  (:import [org.joda.time DateTime ReadableInstant]))
+
+(def joda-time-writer
+  (transit/write-handler
+   "m"
+   (fn [v] (-> ^ReadableInstant v .getMillis))
+   (fn [v] (-> ^ReadableInstant v .getMillis .toString))))
+
+(cheshire/add-encoder
+ DateTime
+ (fn [c jsonGenerator]
+   (.writeString jsonGenerator (-> ^ReadableInstant c .getMillis .toString))))
 
 (defstate ^:dynamic *db*
           :start (cond

--- a/src/clj/rems/db/entitlements.clj
+++ b/src/clj/rems/db/entitlements.clj
@@ -1,12 +1,12 @@
 (ns rems.db.entitlements
   "Creating and fetching entitlements."
-  (:require [cheshire.core :as cheshire]
-            [clj-http.client :as http]
+  (:require [clj-http.client :as http]
             [clojure.string :refer [join]]
             [clojure.tools.logging :as log]
             [rems.auth.util :refer [throw-forbidden]]
             [rems.config :refer [env]]
             [rems.db.core :as db]
+            [rems.json :as json]
             [rems.roles :refer [has-roles?]]
             [rems.text :as text]
             [rems.util :refer [getx-user-id]]))
@@ -45,7 +45,7 @@
                      :resource (:resid e)
                      :user (:userid e)
                      :mail (:mail e)})
-          json-payload (cheshire/generate-string payload)]
+          json-payload (json/generate-string payload)]
       (log/infof "Posting entitlements to %s:" target payload)
       (let [response (try
                        (http/post target

--- a/src/clj/rems/db/form.clj
+++ b/src/clj/rems/db/form.clj
@@ -1,6 +1,6 @@
 (ns rems.db.form
   (:require [rems.db.core :as db]
-            [cheshire.core :as cheshire]))
+            [rems.json :as json]))
 
 (defn get-forms [filters]
   (->> (db/get-forms)
@@ -9,7 +9,7 @@
 
 (defn get-form [id]
   (-> (db/get-form {:id id})
-      (update :fields cheshire/parse-string true)))
+      (update :fields json/parse-string true)))
 
 (defn- create-form-item! [user-id form-id item-index {:keys [title optional type input-prompt maxlength options]}]
   (let [item-id (:id (db/create-form-item! {:type type

--- a/src/clj/rems/db/users.clj
+++ b/src/clj/rems/db/users.clj
@@ -1,10 +1,10 @@
 (ns rems.db.users
-  (:require [cheshire.core :refer [generate-string parse-string]]
-            [rems.db.core :as db]))
+  (:require [rems.db.core :as db]
+            [rems.json :as json]))
 
 (defn add-user! [user userattrs]
   (assert (and userattrs user) "User or user attributes missing!")
-  (db/add-user! {:user user :userattrs (generate-string userattrs)}))
+  (db/add-user! {:user user :userattrs (json/generate-string userattrs)}))
 
 (defn add-user-if-logged-in! [user userattrs]
   (when user
@@ -19,7 +19,7 @@
     :surname \"loper\"
     ...etc}"
   [userid]
-  (parse-string (:userattrs (db/get-user-attributes {:user userid})) true))
+  (json/parse-string (:userattrs (db/get-user-attributes {:user userid})) true))
 
 (defn get-all-users
   []

--- a/src/clj/rems/db/workflow.clj
+++ b/src/clj/rems/db/workflow.clj
@@ -1,13 +1,13 @@
 (ns rems.db.workflow
   (:require [rems.db.core :as db]
             [rems.db.workflow-actors :as actors]
-            [cheshire.core :as cheshire]))
+            [rems.json :as json]))
 
 (defn- parse-workflow-body [json]
-  (cheshire/parse-string json true))
+  (json/parse-string json true))
 
 (defn- parse-licenses [json]
-  (cheshire/parse-string json true))
+  (json/parse-string json true))
 
 (defn get-workflow [id]
   (-> {:wfid id}
@@ -38,8 +38,8 @@
                                         :modifieruserid user-id,
                                         :title title,
                                         :fnlround 0
-                                        :workflow (cheshire/generate-string {:type :workflow/dynamic
-                                                                             :handlers handlers})}))]
+                                        :workflow (json/generate-string {:type :workflow/dynamic
+                                                                         :handlers handlers})}))]
     {:id wfid}))
 
 (defn- create-rounds-workflow! [{:keys [user-id organization title rounds]}]

--- a/src/clj/rems/json.clj
+++ b/src/clj/rems/json.clj
@@ -1,0 +1,40 @@
+(ns rems.json
+  (:require [cheshire.core :as cheshire-core]
+            [cheshire.generate :as cheshire-generate]
+            [cognitect.transit :as transit]
+            [muuntaja.core :as muuntaja]
+            [muuntaja.format.json :refer [json-format]]
+            [muuntaja.format.transit :as transit-format])
+  (:import [org.joda.time DateTime ReadableInstant]))
+
+(def joda-time-writer
+  (transit/write-handler
+   "m"
+   (fn [v] (-> ^ReadableInstant v .getMillis))
+   (fn [v] (-> ^ReadableInstant v .getMillis .toString))))
+
+(cheshire-generate/add-encoder
+ DateTime
+ (fn [c jsonGenerator]
+   (.writeString jsonGenerator (-> ^ReadableInstant c .getMillis .toString))))
+
+(def muuntaja
+  (muuntaja/create
+   (update
+    muuntaja/default-options
+    :formats
+    merge
+    {"application/json"
+     json-format
+
+     "application/transit+json"
+     {:decoder [(partial transit-format/make-transit-decoder :json)]
+      :encoder [#(transit-format/make-transit-encoder
+                  :json
+                  (merge
+                   %
+                   {:handlers {DateTime joda-time-writer}}))]}})))
+
+
+(def generate-string cheshire-core/generate-string)
+(def parse-string cheshire-core/parse-string)

--- a/src/clj/rems/layout.clj
+++ b/src/clj/rems/layout.clj
@@ -1,9 +1,9 @@
 (ns rems.layout
-  (:require [cheshire.core :as cheshire]
-            [hiccup.page :refer [html5 include-css include-js]]
+  (:require [hiccup.page :refer [html5 include-css include-js]]
             [rems.config :refer [env]]
             [rems.context :as context]
             [rems.db.users :as users]
+            [rems.json :as json]
             [rems.text :refer [text]]
             [rems.util :refer [get-user-id]]
             [ring.middleware.anti-forgery :refer [*anti-forgery-token*]]
@@ -76,7 +76,7 @@ window.rems = {
      (format "var csrfToken = '%s';" *anti-forgery-token*)]
     (include-js "/js/app.js")
     [:script {:type "text/javascript"}
-     (format "rems.app.setIdentity(%s);" (cheshire/generate-string {:user context/*user* :roles context/*roles*}))])))
+     (format "rems.app.setIdentity(%s);" (json/generate-string {:user context/*user* :roles context/*roles*}))])))
 
 (defn- error-content
   [error-details]


### PR DESCRIPTION
This helps running single db tests that don't require the api