### PR TITLE
Improve logging

### DIFF
--- a/env/test/resources/logback-test.xml
+++ b/env/test/resources/logback-test.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<configuration>
+<configuration scan="true" scanPeriod="15 seconds">
     <statusListener class="ch.qos.logback.core.status.NopStatusListener"/>
 
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
             <charset>UTF-8</charset>
-            <pattern>%date{ISO8601} [%thread] %-5level %logger{36} - %msg %n</pattern>
+            <pattern>%date{ISO8601} [%thread %mdc{user:--} %mdc{request-method:--} %mdc{request-uri:--}] %-5level %logger{36} - %msg%n</pattern>
         </encoder>
     </appender>
 

--- a/resources/logback.xml
+++ b/resources/logback.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<configuration>
+<configuration scan="true" scanPeriod="15 seconds">
     <statusListener class="ch.qos.logback.core.status.NopStatusListener"/>
 
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
             <charset>UTF-8</charset>
-            <pattern>%date{ISO8601} [%thread] %-5level %logger{36} - %msg %n</pattern>
+            <pattern>%date{ISO8601} [%thread %mdc{user:--} %mdc{request-method:--} %mdc{request-uri:--}] %-5level %logger{36} - %msg%n</pattern>
         </encoder>
     </appender>
 

--- a/src/clj/rems/db/applications.clj
+++ b/src/clj/rems/db/applications.clj
@@ -1,13 +1,10 @@
 (ns rems.db.applications
   "Query functions for forms and applications."
-  (:require [clj-time.coerce :as time-coerce]
-            [clj-time.core :as time]
+  (:require [clj-time.core :as time]
             [clj-time.format :as time-format]
             [clojure.set :refer [difference union]]
             [clojure.test :refer [deftest is]]
             [cprop.tools :refer [merge-maps]]
-            [cuerdas.core :refer [numeric? parse-number]]
-            [medley.core :refer [map-keys]]
             [rems.application-util :refer [editable?]]
             [rems.auth.util :refer [throw-forbidden]]
             [rems.context :as context]
@@ -23,7 +20,7 @@
             [rems.form-validation :as form-validation]
             [rems.json :as json]
             [rems.permissions :as permissions]
-            [rems.util :refer [getx get-username update-present]]
+            [rems.util :refer [get-username]]
             [rems.workflow.dynamic :as dynamic]
             [schema-tools.core :as st]
             [schema.coerce :as coerce]

--- a/src/clj/rems/logging.clj
+++ b/src/clj/rems/logging.clj
@@ -11,13 +11,13 @@
                        (str v)]))
                (into {}))]
     (try
-      (doseq [[key val] m]
-        (when-not (empty? val)
-          (MDC/put key val)))
+      (doseq [[k v] m]
+        (when (seq v)
+          (MDC/put k v)))
       (f)
       (finally
-        (doseq [key (keys m)]
-          (MDC/remove key))))))
+        (doseq [k (keys m)]
+          (MDC/remove k))))))
 
 (defmacro with-mdc
   "Adds a map of values to SLF4J's MDC for logging context."

--- a/src/clj/rems/logging.clj
+++ b/src/clj/rems/logging.clj
@@ -13,7 +13,7 @@
     (try
       (doseq [[key val] m]
         (when-not (empty? val)
-          (MDC/put key (str val))))
+          (MDC/put key val)))
       (f)
       (finally
         (doseq [key (keys m)]

--- a/src/clj/rems/logging.clj
+++ b/src/clj/rems/logging.clj
@@ -4,11 +4,11 @@
 
 (defn with-mdc* [m f]
   (let [m (->> m
-               (map (fn [[key val]]
-                      [(if (keyword? key)
-                         (name key)
-                         key)
-                       (str val)]))
+               (map (fn [[k v]]
+                      [(if (keyword? k)
+                         (name k)
+                         k)
+                       (str v)]))
                (into {}))]
     (try
       (doseq [[key val] m]

--- a/src/clj/rems/logging.clj
+++ b/src/clj/rems/logging.clj
@@ -1,0 +1,58 @@
+(ns rems.logging
+  (:require [clojure.test :refer [deftest is testing]])
+  (:import (org.slf4j MDC)))
+
+(defn with-mdc* [m f]
+  (let [m (->> m
+               (map (fn [[key val]]
+                      [(if (keyword? key)
+                         (name key)
+                         key)
+                       (str val)]))
+               (into {}))]
+    (try
+      (doseq [[key val] m]
+        (when-not (empty? val)
+          (MDC/put key (str val))))
+      (f)
+      (finally
+        (doseq [key (keys m)]
+          (MDC/remove key))))))
+
+(defmacro with-mdc
+  "Adds a map of values to SLF4J's MDC for logging context."
+  [m & body]
+  `(with-mdc* ~m (fn [] ~@body)))
+
+(deftest test-with-mdc
+  (testing "adds keys to context"
+    (with-mdc {"foo" "bar"}
+      (is (= "bar" (MDC/get "foo")))))
+  (testing "removes keys from context afterwards"
+    (with-mdc {"foo" "bar"})
+    (is (nil? (MDC/get "foo"))))
+  (testing "can add multiple keys at once"
+    (with-mdc {"foo" "one"
+               "bar" "two"}
+      (is (= "one" (MDC/get "foo")))
+      (is (= "two" (MDC/get "bar"))))
+    (is (empty? (MDC/getCopyOfContextMap))))
+  (testing "converts keyword keys to string"
+    (with-mdc {:foo "bar"}
+      (is (= "bar" (MDC/get "foo")))))
+  (testing "converts non-string values to string"
+    (with-mdc {"foo" :bar}
+      (is (= ":bar" (MDC/get "foo"))))
+    (with-mdc {"foo" 123}
+      (is (= "123" (MDC/get "foo"))))
+    (with-mdc {"foo" true}
+      (is (= "true" (MDC/get "foo")))))
+  (testing "ignores nil values"
+    (with-mdc {"foo" nil}
+      (is (empty? (MDC/getCopyOfContextMap)))))
+  (testing "ignores empty string values"
+    (with-mdc {"foo" ""}
+      (is (empty? (MDC/getCopyOfContextMap)))))
+  (testing "does not ignore false values"
+    (with-mdc {"foo" false}
+      (is (= "false" (MDC/get "foo"))))))

--- a/src/clj/rems/logging.clj
+++ b/src/clj/rems/logging.clj
@@ -1,4 +1,8 @@
 (ns rems.logging
+  "Logback's Mapped Diagnostic Context (MDC) is a thread-local place
+   for storing information about the current request. The information
+   can then be included in the logs via Logback's appender patterns.
+   See https://logback.qos.ch/manual/mdc.html for more information."
   (:require [clojure.test :refer [deftest is testing]])
   (:import (org.slf4j MDC)))
 
@@ -20,7 +24,7 @@
           (MDC/remove k))))))
 
 (defmacro with-mdc
-  "Adds a map of values to SLF4J's MDC for logging context."
+  "Adds a map of values to Logback's MDC for use within `body`."
   [m & body]
   `(with-mdc* ~m (fn [] ~@body)))
 


### PR DESCRIPTION
Adds information about the current user and request to [Mapped Diagnostic Context](https://logback.qos.ch/manual/mdc.html). The log will then look like this:

```
2019-02-22 16:28:34,760 [main - - -] INFO  rems.xyz - not in a request
2019-02-22 16:29:03,204 [qtp374065596-26 - GET /Shibboleth.sso/Login] INFO  rems.xyz - non-authenticated user
2019-02-22 16:29:19,343 [qtp374065596-23 developer GET /api/applications/7] INFO  rems.xyz - authenticated user
```