### PR TITLE
Form labels are always optional

### DIFF
--- a/src/clj/rems/form_validation.clj
+++ b/src/clj/rems/form_validation.clj
@@ -4,7 +4,7 @@
 (defn- validate-item
   [item]
   (if (empty? (:value item))
-    (when-not (:optional item)
+    (when-not (or (:optional item) (= "label" (:type item)))
       {:field-id (:id item)
        :type :t.form.validation/required})
     (when (and (:maxlength item)

--- a/src/cljs/rems/administration/components.cljs
+++ b/src/cljs/rems/administration/components.cljs
@@ -94,13 +94,12 @@
 
 (defn checkbox
   "A single checkbox, on its own line."
-  [context {:keys [keys label disabled?]}]
+  [context {:keys [keys label]}]
   (let [form @(rf/subscribe [(:get-form context)])
         id (keys-to-id keys)]
     [:div.form-group.field
      [:div.form-check
       [:input.form-check-input {:id id
-                                :disabled disabled?
                                 :type "checkbox"
                                 :checked (boolean (get-in form keys))
                                 :on-change #(rf/dispatch [(:update-form context)

--- a/src/cljs/rems/administration/components.cljs
+++ b/src/cljs/rems/administration/components.cljs
@@ -94,12 +94,13 @@
 
 (defn checkbox
   "A single checkbox, on its own line."
-  [context {:keys [keys label]}]
+  [context {:keys [keys label disabled?]}]
   (let [form @(rf/subscribe [(:get-form context)])
         id (keys-to-id keys)]
     [:div.form-group.field
      [:div.form-check
       [:input.form-check-input {:id id
+                                :disabled disabled?
                                 :type "checkbox"
                                 :checked (boolean (get-in form keys))
                                 :on-change #(rf/dispatch [(:update-form context)

--- a/src/cljs/rems/administration/components.cljs
+++ b/src/cljs/rems/administration/components.cljs
@@ -109,7 +109,7 @@
       [:label.form-check-label {:for id}
        label]]]))
 
-(defn- radio-button [context {:keys [keys value label orientation on-change]}]
+(defn- radio-button [context {:keys [keys value label orientation]}]
   (let [form @(rf/subscribe [(:get-form context)])
         name (keys-to-id keys)
         id (keys-to-id (conj keys value))]
@@ -122,7 +122,6 @@
                                :value value
                                :checked (= value (get-in form keys))
                                :on-change #(when (.. % -target -checked)
-                                             (when on-change (on-change))
                                              (rf/dispatch [(:update-form context) keys value]))}]
      [:label.form-check-label {:for id}
       label]]))
@@ -138,9 +137,8 @@
   [:div.form-group.field {:id id}
    (when label [:label {:for id} label])
    (into [:div.form-control]
-         (map (fn [{:keys [value label on-change]}]
+         (map (fn [{:keys [value label]}]
                 [radio-button context {:keys keys
-                                       :on-change on-change
                                        :value value
                                        :label label
                                        :orientation orientation}])

--- a/src/cljs/rems/administration/components.cljs
+++ b/src/cljs/rems/administration/components.cljs
@@ -109,7 +109,7 @@
       [:label.form-check-label {:for id}
        label]]]))
 
-(defn- radio-button [context {:keys [keys value label orientation]}]
+(defn- radio-button [context {:keys [keys value label orientation on-change]}]
   (let [form @(rf/subscribe [(:get-form context)])
         name (keys-to-id keys)
         id (keys-to-id (conj keys value))]
@@ -122,6 +122,7 @@
                                :value value
                                :checked (= value (get-in form keys))
                                :on-change #(when (.. % -target -checked)
+                                             (when on-change (on-change))
                                              (rf/dispatch [(:update-form context) keys value]))}]
      [:label.form-check-label {:for id}
       label]]))
@@ -137,8 +138,9 @@
   [:div.form-group.field {:id id}
    (when label [:label {:for id} label])
    (into [:div.form-control]
-         (map (fn [{:keys [value label]}]
+         (map (fn [{:keys [value label on-change]}]
                 [radio-button context {:keys keys
+                                       :on-change on-change
                                        :value value
                                        :label label
                                        :orientation orientation}])

--- a/src/cljs/rems/administration/create_form.cljs
+++ b/src/cljs/rems/administration/create_form.cljs
@@ -238,7 +238,7 @@
                                          {:value "multiselect", :label (text :t.create-form/type-multiselect)}
                                          {:value "date", :label (text :t.create-form/type-date)}
                                          {:value "attachment", :label (text :t.create-form/type-attachment)}
-                                         {:value "label" :label (text :t.create-form/type-label)}]}])
+                                         {:value "label", :label (text :t.create-form/type-label)}]}])
 
 (defn- form-item-optional-checkbox [item-index]
   [checkbox context {:keys [:items item-index :optional]

--- a/src/cljs/rems/administration/create_form.cljs
+++ b/src/cljs/rems/administration/create_form.cljs
@@ -27,6 +27,11 @@
  (fn [db _]
    (::form db)))
 
+(rf/reg-sub
+ ::form-item
+ (fn [db [_ item-index]]
+   (get-in db [::form :items item-index])))
+
 (rf/reg-event-db
  ::set-form-field
  (fn [db [_ keys value]]
@@ -235,11 +240,17 @@
                                          {:value "multiselect", :label (text :t.create-form/type-multiselect)}
                                          {:value "date", :label (text :t.create-form/type-date)}
                                          {:value "attachment", :label (text :t.create-form/type-attachment)}
-                                         {:value "label", :label (text :t.create-form/type-label)}]}])
+                                         {:value "label" :label (text :t.create-form/type-label)
+                                          :on-change #(rf/dispatch [::set-form-field [:items item-index :optional] true])}]}])
 
 (defn- form-item-optional-checkbox [item-index]
-  [checkbox context {:keys [:items item-index :optional]
-                     :label (text :t.create-form/optional)}])
+  (let [item @(rf/subscribe [::form-item item-index])]
+    (if (= "label" (:type item))
+      [checkbox context {:label (text :t.create-form/optional)
+                         :disabled? true}]
+
+      [checkbox context {:keys [:items item-index :optional]
+                        :label (text :t.create-form/optional)}])))
 
 (defn- add-form-item-button []
   [:a


### PR DESCRIPTION
Fixes #966

Previously it was possible to create a form with mandatory labels, but labels are not input elements.

Now `:optional` is set to `true`, and the checkbox is disabled, when the element is of type label.