### PR TITLE
fix: img-path default

### DIFF
--- a/src/clj/rems/css/styles.clj
+++ b/src/clj/rems/css/styles.clj
@@ -24,7 +24,7 @@
   (when path
     (let [url (if (str/starts-with? path "http")
                 path
-                (str (util/get-theme-attribute :img-path "../img/") path))]
+                (str (util/get-theme-attribute :img-path "../../img/") path))]
       (str "url(\"" url "\")"))))
 
 (defn get-logo-image [lang]


### PR DESCRIPTION
Fix the `:img-path` default. We now have the language subdirectory in the path that must be bypassed.