### PR TITLE
Refactor: decouple the tests of command handlers from apply-event 

### DIFF
--- a/src/clj/rems/application/events.clj
+++ b/src/clj/rems/application/events.clj
@@ -123,6 +123,14 @@
 (s/defschema Event
   (apply r/dispatch-on :event/type (flatten (seq event-schemas))))
 
+(defn validate-event [event]
+  (s/validate Event event))
+
+(defn validate-events [events]
+  (doseq [event events]
+    (validate-event event))
+  events)
+
 (deftest test-event-schema
   (testing "check specific event schema"
     (is (nil? (s/check SubmittedEvent {:event/type :application.event/submitted

--- a/src/clj/rems/db/applications.clj
+++ b/src/clj/rems/db/applications.clj
@@ -25,7 +25,6 @@
             [rems.workflow.dynamic :as dynamic]
             [schema-tools.core :as st]
             [schema.coerce :as coerce]
-            [schema.core :as s]
             [schema.utils])
   (:import [java.io ByteArrayOutputStream FileInputStream]
            [org.joda.time DateTime]))
@@ -687,11 +686,8 @@
                         {:schema events/Event :value json :error result})))
       result)))
 
-(defn validate-dynamic-event [event]
-  (s/validate events/Event event))
-
 (defn event->json [event]
-  (validate-dynamic-event event)
+  (events/validate-event event)
   (json/generate-string event))
 
 (defn- fix-event-from-db [event]

--- a/test/clj/rems/application/test_model.clj
+++ b/test/clj/rems/application/test_model.clj
@@ -1,16 +1,11 @@
 (ns rems.application.test-model
   (:require [clojure.test :refer :all]
+            [rems.application.events :as events]
             [rems.application.model :as model]
             [rems.common-util :refer [deep-merge]]
-            [rems.db.applications :as applications]
             [rems.permissions :as permissions])
   (:import [java.util UUID]
            [org.joda.time DateTime]))
-
-(defn- validate-events [events]
-  (doseq [event events]
-    (applications/validate-dynamic-event event))
-  events)
 
 (deftest test-application-view
   (let [injections {:get-form {40 {:id 40
@@ -117,7 +112,7 @@
                                             :commonName "Applicant"}}}
         apply-events (fn [events]
                        (let [application (-> events
-                                             validate-events
+                                             events/validate-events
                                              (model/build-application-view injections)
                                              permissions/cleanup)]
                          (is (contains? model/states (:application/state application)))

--- a/test/clj/rems/workflow/test_dynamic.clj
+++ b/test/clj/rems/workflow/test_dynamic.clj
@@ -136,7 +136,7 @@
                             :field-values {1 "updated"}
                             :accepted-licenses #{3}})))))))
 
-(deftest test-submit-form-validation
+(deftest test-submit
   (let [injections {:validate-form-answers fake-validate-form-answers}
         created-event {:event/type :application.event/created
                        :event/time test-time
@@ -395,7 +395,7 @@
                                     :application/id 123
                                     :application/member {:userid "somebody"}}])
         injections {:valid-user? #{"member1" "member2" "somebody" "applicant"}}]
-    (testing "add two members"
+    (testing "handler can add members"
       (is (= [{:event/type :application.event/member-added
                :event/time test-time
                :event/actor "assistant"
@@ -601,7 +601,7 @@
                                     :application/id 123
                                     :application/member {:userid "somebody"}}])
         injections {:valid-user? #{"somebody" "applicant" "assistant"}}]
-    (testing "remove member by applicant"
+    (testing "applicant can remove members"
       (is (= [{:event/type :application.event/member-removed
                :event/time test-time
                :event/actor "applicant"
@@ -614,15 +614,7 @@
                           :member {:userid "somebody"}
                           :comment "some comment"}
                          injections))))
-    (testing "remove applicant by applicant"
-      (is (= {:errors [{:type :cannot-remove-applicant}]}
-             (fail-command application
-                           {:type :application.command/remove-member
-                            :actor "applicant"
-                            :member {:userid "applicant"}
-                            :comment ""}
-                           injections))))
-    (testing "remove member by handler"
+    (testing "handler can remove members"
       (is (= [{:event/type :application.event/member-removed
                :event/time test-time
                :event/actor "assistant"
@@ -635,7 +627,21 @@
                           :member {:userid "somebody"}
                           :comment ""}
                          injections))))
-    (testing "only members can be removed"
+    (testing "applicant cannot be removed"
+      (is (= {:errors [{:type :cannot-remove-applicant}]}
+             (fail-command application
+                           {:type :application.command/remove-member
+                            :actor "applicant"
+                            :member {:userid "applicant"}
+                            :comment ""}
+                           injections)
+             (fail-command application
+                           {:type :application.command/remove-member
+                            :actor "assistant"
+                            :member {:userid "applicant"}
+                            :comment ""}
+                           injections))))
+    (testing "non-members cannot be removed"
       (is (= {:errors [{:type :user-not-member :user {:userid "notamember"}}]}
              (fail-command application
                            {:type :application.command/remove-member

--- a/test/clj/rems/workflow/test_dynamic.clj
+++ b/test/clj/rems/workflow/test_dynamic.clj
@@ -112,22 +112,6 @@
                               :accepted-licenses #{1 2}}
                              application
                              injections))))
-    (testing "draft can be updated multiple times"
-      (is (= {:state :application.state/draft
-              :form-contents {:items {1 "updated"}
-                              :licenses {3 "approved"}
-                              :accepted-licenses {"applicant" #{3}}}}
-             (-> (apply-commands application
-                                 [{:type :application.command/save-draft
-                                   :actor "applicant"
-                                   :field-values {1 "original"}
-                                   :accepted-licenses #{2}}
-                                  {:type :application.command/save-draft
-                                   :actor "applicant"
-                                   :field-values {1 "updated"}
-                                   :accepted-licenses #{3}}]
-                                 injections)
-                 (select-keys relevant-application-keys)))))
     (testing "draft cannot be updated after submitting"
       (let [application (apply-commands application
                                         [{:type :application.command/save-draft
@@ -165,25 +149,6 @@
                                    :actor "assistant"}
                                   {:type :application.command/save-draft
                                    :actor "applicant" :field-values {1 "updated"} :accepted-licenses #{3}}]
-                                 injections)
-                 (select-keys relevant-application-keys)))))
-    (testing "resubmitting remembers the previous and current application"
-      (is (= {:state :application.state/submitted
-              :form-contents {:items {1 "updated"}
-                              :licenses {3 "approved"}
-                              :accepted-licenses {"applicant" #{3}}}
-              :submitted-form-contents {:items {1 "updated"}
-                                        :licenses {3 "approved"}
-                                        :accepted-licenses {"applicant" #{3}}}
-              :previous-submitted-form-contents {:items {1 "original"}
-                                                 :licenses {2 "approved"}
-                                                 :accepted-licenses {"applicant" #{2}}}}
-             (-> (apply-commands application
-                                 [{:actor "applicant" :type :application.command/save-draft :field-values {1 "original"} :accepted-licenses #{2}}
-                                  {:actor "applicant" :type :application.command/submit}
-                                  {:actor "assistant" :type :application.command/return :comment ""}
-                                  {:actor "applicant" :type :application.command/save-draft :field-values {1 "updated"} :accepted-licenses #{3}}
-                                  {:actor "applicant" :type :application.command/submit}]
                                  injections)
                  (select-keys relevant-application-keys)))))))
 

--- a/test/clj/rems/workflow/test_dynamic.clj
+++ b/test/clj/rems/workflow/test_dynamic.clj
@@ -666,19 +666,31 @@
                                     :application/id 123}])
         injections {}]
     (testing "uninvite member by applicant"
-      (is (= []
-             (:invited-members
-              (apply-commands application
-                              [{:type :application.command/uninvite-member :actor "applicant" :member {:name "Some Body" :email "some@body.com"}
-                                :comment ""}]
-                              injections)))))
+      (is (= [{:event/type :application.event/member-uninvited
+               :event/time test-time
+               :event/actor "applicant"
+               :application/id 123
+               :application/member {:name "Some Body" :email "some@body.com"}
+               :application/comment ""}]
+             (ok-command application
+                         {:type :application.command/uninvite-member
+                          :actor "applicant"
+                          :member {:name "Some Body" :email "some@body.com"}
+                          :comment ""}
+                         injections))))
     (testing "uninvite member by handler"
-      (is (= []
-             (:invited-members
-              (apply-commands application
-                              [{:type :application.command/uninvite-member :actor "assistant" :member {:name "Some Body" :email "some@body.com"}
-                                :comment ""}]
-                              injections)))))
+      (is (= [{:event/type :application.event/member-uninvited
+               :event/time test-time
+               :event/actor "assistant"
+               :application/id 123
+               :application/member {:name "Some Body" :email "some@body.com"}
+               :application/comment ""}]
+             (ok-command application
+                         {:type :application.command/uninvite-member
+                          :actor "assistant"
+                          :member {:name "Some Body" :email "some@body.com"}
+                          :comment ""}
+                         injections))))
     (testing "only invited members can be uninvited"
       (is (= {:errors [{:type :user-not-member :user {:name "Not Member" :email "not@member.com"}}]}
              (handle-command {:application-id 123 :time test-time

--- a/test/clj/rems/workflow/test_dynamic.clj
+++ b/test/clj/rems/workflow/test_dynamic.clj
@@ -11,6 +11,17 @@
 (def ^:private test-time (DateTime. 1000))
 (def ^:private command-defaults {:application-id 123
                                  :time test-time})
+(def ^:private dummy-created-event {:event/type :application.event/created
+                                    :event/time test-time
+                                    :event/actor "applicant"
+                                    :application/id 123
+                                    :application/resources []
+                                    :application/licenses []
+                                    :form/id 1
+                                    :workflow/id 1
+                                    :workflow/type :workflow/dynamic
+                                    :application/external-id nil
+                                    :workflow.dynamic/handlers #{"assistant"}})
 
 (defn apply-events [application events]
   (events/validate-events events)
@@ -65,18 +76,7 @@
 ;;; Tests
 
 (deftest test-save-draft
-  (let [application (apply-events nil
-                                  [{:event/type :application.event/created
-                                    :event/time test-time
-                                    :event/actor "applicant"
-                                    :application/id 123
-                                    :application/resources []
-                                    :application/licenses []
-                                    :form/id 1
-                                    :workflow/id 1
-                                    :workflow/type :workflow/dynamic
-                                    :application/external-id nil
-                                    :workflow.dynamic/handlers #{"assistant"}}])]
+  (let [application (apply-events nil [dummy-created-event])]
     (testing "saves a draft"
       (is (= [{:event/type :application.event/draft-saved
                :event/time test-time
@@ -202,17 +202,7 @@
 
 (deftest test-approve-or-reject
   (let [application (apply-events nil
-                                  [{:event/type :application.event/created
-                                    :event/time test-time
-                                    :event/actor "applicant"
-                                    :application/id 123
-                                    :application/resources []
-                                    :application/licenses []
-                                    :form/id 1
-                                    :workflow/id 1
-                                    :workflow/type :workflow/dynamic
-                                    :application/external-id nil
-                                    :workflow.dynamic/handlers #{"assistant"}}
+                                  [dummy-created-event
                                    {:event/type :application.event/submitted
                                     :event/time test-time
                                     :event/actor "applicant"
@@ -240,17 +230,7 @@
 
 (deftest test-return
   (let [application (apply-events nil
-                                  [{:event/type :application.event/created
-                                    :event/time test-time
-                                    :event/actor "applicant"
-                                    :application/id 123
-                                    :application/resources []
-                                    :application/licenses []
-                                    :form/id 1
-                                    :workflow/id 1
-                                    :workflow/type :workflow/dynamic
-                                    :application/external-id nil
-                                    :workflow.dynamic/handlers #{"assistant"}}
+                                  [dummy-created-event
                                    {:event/type :application.event/submitted
                                     :event/time test-time
                                     :event/actor "applicant"
@@ -267,17 +247,7 @@
 
 (deftest test-close
   (let [application (apply-events nil
-                                  [{:event/type :application.event/created
-                                    :event/time test-time
-                                    :event/actor "applicant"
-                                    :application/id 123
-                                    :application/resources []
-                                    :application/licenses []
-                                    :form/id 1
-                                    :workflow/id 1
-                                    :workflow/type :workflow/dynamic
-                                    :application/external-id nil
-                                    :workflow.dynamic/handlers #{"assistant"}}
+                                  [dummy-created-event
                                    {:event/type :application.event/submitted
                                     :event/time test-time
                                     :event/actor "applicant"
@@ -299,17 +269,7 @@
 
 (deftest test-decision
   (let [application (apply-events nil
-                                  [{:event/type :application.event/created
-                                    :event/time test-time
-                                    :event/actor "applicant"
-                                    :application/id 123
-                                    :application/resources []
-                                    :application/licenses []
-                                    :form/id 1
-                                    :workflow/id 1
-                                    :workflow/type :workflow/dynamic
-                                    :application/external-id nil
-                                    :workflow.dynamic/handlers #{"assistant"}}
+                                  [dummy-created-event
                                    {:event/type :application.event/submitted
                                     :event/time test-time
                                     :event/actor "applicant"
@@ -420,17 +380,7 @@
 
 (deftest test-add-member
   (let [application (apply-events nil
-                                  [{:event/type :application.event/created
-                                    :event/time test-time
-                                    :event/actor "applicant"
-                                    :application/id 123
-                                    :application/resources []
-                                    :application/licenses []
-                                    :form/id 1
-                                    :workflow/id 1
-                                    :workflow/type :workflow/dynamic
-                                    :application/external-id nil
-                                    :workflow.dynamic/handlers #{"assistant"}}
+                                  [dummy-created-event
                                    {:event/type :application.event/submitted
                                     :event/time test-time
                                     :event/actor "applicant"
@@ -480,18 +430,7 @@
               (model/see-application? "member1"))))))
 
 (deftest test-invite-member
-  (let [application (apply-events nil
-                                  [{:event/type :application.event/created
-                                    :event/time test-time
-                                    :event/actor "applicant"
-                                    :application/id 123
-                                    :application/resources []
-                                    :application/licenses []
-                                    :form/id 1
-                                    :workflow/id 1
-                                    :workflow/type :workflow/dynamic
-                                    :application/external-id nil
-                                    :workflow.dynamic/handlers #{"assistant"}}])
+  (let [application (apply-events nil [dummy-created-event])
         injections {:valid-user? #{"somebody" "applicant"}
                     :secure-token (constantly "very-secure")}]
     (testing "applicant can invite members"
@@ -557,17 +496,7 @@
 
 (deftest test-accept-invitation
   (let [application (apply-events nil
-                                  [{:event/type :application.event/created
-                                    :event/time test-time
-                                    :event/actor "applicant"
-                                    :application/id 123
-                                    :application/resources []
-                                    :application/licenses []
-                                    :form/id 1
-                                    :workflow/id 1
-                                    :workflow/type :workflow/dynamic
-                                    :application/external-id nil
-                                    :workflow.dynamic/handlers #{"assistant"}}
+                                  [dummy-created-event
                                    {:event/type :application.event/member-invited
                                     :event/time test-time
                                     :event/actor "applicant"
@@ -657,17 +586,7 @@
 
 (deftest test-remove-member
   (let [application (apply-events nil
-                                  [{:event/type :application.event/created
-                                    :event/time test-time
-                                    :event/actor "applicant"
-                                    :application/id 123
-                                    :application/resources []
-                                    :application/licenses []
-                                    :form/id 1
-                                    :workflow/id 1
-                                    :workflow/type :workflow/dynamic
-                                    :application/external-id nil
-                                    :workflow.dynamic/handlers #{"assistant"}}
+                                  [dummy-created-event
                                    {:event/type :application.event/submitted
                                     :event/time test-time
                                     :event/actor "applicant"
@@ -734,17 +653,7 @@
 
 (deftest test-uninvite-member
   (let [application (apply-events nil
-                                  [{:event/type :application.event/created
-                                    :event/time test-time
-                                    :event/actor "applicant"
-                                    :application/id 123
-                                    :application/resources []
-                                    :application/licenses []
-                                    :form/id 1
-                                    :workflow/id 1
-                                    :workflow/type :workflow/dynamic
-                                    :application/external-id nil
-                                    :workflow.dynamic/handlers #{"assistant"}}
+                                  [dummy-created-event
                                    {:event/type :application.event/member-invited
                                     :event/time test-time
                                     :event/actor "applicant"
@@ -780,17 +689,7 @@
 
 (deftest test-comment
   (let [application (apply-events nil
-                                  [{:event/type :application.event/created
-                                    :event/time test-time
-                                    :event/actor "applicant"
-                                    :application/id 123
-                                    :application/resources []
-                                    :application/licenses []
-                                    :form/id 1
-                                    :workflow/id 1
-                                    :workflow/type :workflow/dynamic
-                                    :application/external-id nil
-                                    :workflow.dynamic/handlers #{"assistant"}}
+                                  [dummy-created-event
                                    {:event/type :application.event/submitted
                                     :event/time test-time
                                     :event/actor "applicant"


### PR DESCRIPTION
#852 

Many of the tests for command handlers were asserting things about the old application model. In preparation for removing the `rems.workflow.dynamic/apply-event` method, this PR decouples the tests from `apply-event` method by asserting the events produced by the command handlers. 

Some tests which are already covered in `rems.application.test-model` were removed. There is still some overlap with the rather declarative `rems.application.model/calculate-permissions`, but maybe that's ok.