### PR TITLE
administration: hide disabled things by default

### DIFF
--- a/resources/translations/en.edn
+++ b/resources/translations/en.edn
@@ -97,7 +97,7 @@
                    :create-workflow "Create workflow"
                    :created "Created"
                    :disable "Disable"
-                   :display-archived "Display archived"
+                   :display-old "Display old"
                    :enable "Enable"
                    :end "End"
                    :errors {:duplicate-resid "Duplicate resource for organization."

--- a/resources/translations/fi.edn
+++ b/resources/translations/fi.edn
@@ -97,7 +97,7 @@
                    :create-workflow "Uusi työvuo"
                    :created "Luotu"
                    :disable "Poista käytöstä"
-                   :display-archived "Näytä arkistoidut"
+                   :display-old "Näytä vanhat"
                    :enable "Ota käyttöön"
                    :end "Loppu"
                    :errors {:duplicate-resid "Resurssi on jo olemassa organisaatiossa."

--- a/src/clj/rems/api/catalogue_items.clj
+++ b/src/clj/rems/api/catalogue_items.clj
@@ -40,11 +40,17 @@
       :roles #{:logged-in}
       :query-params [{resource :- (describe s/Str "resource id (optional)") nil}
                      {expand :- (describe s/Str "expanded additional attributes (optional), can be \"names\"") nil}
-                     {archived :- (describe s/Bool "'true' to include archived items, defaults to 'false'") false}]
+                     {archived :- (describe s/Bool "whether to include archived items") false}
+                     {disabled :- (describe s/Bool "whether to include disabled resources") false}
+                     {inactive :- (describe s/Bool "whether to include active resources") false}]
       :return GetCatalogueItemsResponse
-      (ok (catalogue/get-localized-catalogue-items {:resource resource
-                                                    :expand-names? (str/includes? (or expand "") "names")
-                                                    :archived archived})))
+      (ok (db/apply-filters
+           (merge (when-not inactive {:active true})
+                  (when-not disabled {:enabled true})
+                  (when-not archived {:archived false}))
+           (catalogue/get-localized-catalogue-items {:resource resource
+                                                     :expand-names? (str/includes? (or expand "") "names")
+                                                     :archived archived}))))
 
     (GET "/:item-id" []
       :summary "Get a single catalogue item"

--- a/src/clj/rems/api/catalogue_items.clj
+++ b/src/clj/rems/api/catalogue_items.clj
@@ -41,11 +41,11 @@
       :query-params [{resource :- (describe s/Str "resource id (optional)") nil}
                      {expand :- (describe s/Str "expanded additional attributes (optional), can be \"names\"") nil}
                      {archived :- (describe s/Bool "whether to include archived items") false}
-                     {disabled :- (describe s/Bool "whether to include disabled resources") false}
-                     {inactive :- (describe s/Bool "whether to include active resources") false}]
+                     {disabled :- (describe s/Bool "whether to include disabled items") false}
+                     {expired :- (describe s/Bool "whether to include expired items") false}]
       :return GetCatalogueItemsResponse
       (ok (db/apply-filters
-           (merge (when-not inactive {:active true})
+           (merge (when-not expired {:active true})
                   (when-not disabled {:enabled true})
                   (when-not archived {:archived false}))
            (catalogue/get-localized-catalogue-items {:resource resource

--- a/src/clj/rems/api/forms.clj
+++ b/src/clj/rems/api/forms.clj
@@ -69,11 +69,11 @@
     (GET "/" []
       :summary "Get forms"
       :roles #{:owner}
-      :query-params [{disabled :- (describe s/Bool "whether to include disabled resources") false}
-                     {inactive :- (describe s/Bool "whether to include active resources") false}
-                     {archived :- (describe s/Bool "whether to include archived resources") false}]
+      :query-params [{disabled :- (describe s/Bool "whether to include disabled forms") false}
+                     {expired :- (describe s/Bool "whether to include expired forms") false}
+                     {archived :- (describe s/Bool "whether to include archived forms") false}]
       :return Forms
-      (ok (get-forms (merge (when-not inactive {:active true})
+      (ok (get-forms (merge (when-not expired {:active true})
                                 (when-not disabled {:enabled true})
                                 (when-not archived {:archived false})))))
 

--- a/src/clj/rems/api/forms.clj
+++ b/src/clj/rems/api/forms.clj
@@ -74,8 +74,8 @@
                      {archived :- (describe s/Bool "whether to include archived forms") false}]
       :return Forms
       (ok (get-forms (merge (when-not expired {:active true})
-                                (when-not disabled {:enabled true})
-                                (when-not archived {:archived false})))))
+                            (when-not disabled {:enabled true})
+                            (when-not archived {:archived false})))))
 
     (GET "/:form-id" []
       :summary "Get form by id"

--- a/src/clj/rems/api/forms.clj
+++ b/src/clj/rems/api/forms.clj
@@ -69,11 +69,13 @@
     (GET "/" []
       :summary "Get forms"
       :roles #{:owner}
-      :query-params [{active :- (describe s/Bool "filter active or inactive forms") nil}
+      :query-params [{disabled :- (describe s/Bool "whether to include disabled resources") false}
+                     {inactive :- (describe s/Bool "whether to include active resources") false}
                      {archived :- (describe s/Bool "whether to include archived resources") false}]
       :return Forms
-      (ok (get-forms (merge (when active {:active active})
-                            (when-not archived {:archived false})))))
+      (ok (get-forms (merge (when-not inactive {:active true})
+                                (when-not disabled {:enabled true})
+                                (when-not archived {:archived false})))))
 
     (GET "/:form-id" []
       :summary "Get form by id"

--- a/src/clj/rems/api/licenses.clj
+++ b/src/clj/rems/api/licenses.clj
@@ -47,10 +47,12 @@
     (GET "/" []
       :summary "Get licenses"
       :roles #{:owner}
-      :query-params [{active :- (describe s/Bool "filter active or inactive licenses") nil}
+      :query-params [{disabled :- (describe s/Bool "whether to include disabled resources") false}
+                     {inactive :- (describe s/Bool "whether to include active resources") false}
                      {archived :- (describe s/Bool "whether to include archived resources") false}]
       :return Licenses
-      (ok (licenses/get-all-licenses (merge (when active {:active active})
+      (ok (licenses/get-all-licenses (merge (when-not disabled {:enabled true})
+                                            (when-not inactive {:active true})
                                             (when-not archived {:archived false})))))
 
     (GET "/:license-id" []

--- a/src/clj/rems/api/licenses.clj
+++ b/src/clj/rems/api/licenses.clj
@@ -47,12 +47,12 @@
     (GET "/" []
       :summary "Get licenses"
       :roles #{:owner}
-      :query-params [{disabled :- (describe s/Bool "whether to include disabled resources") false}
-                     {inactive :- (describe s/Bool "whether to include active resources") false}
-                     {archived :- (describe s/Bool "whether to include archived resources") false}]
+      :query-params [{disabled :- (describe s/Bool "whether to include disabled licenses") false}
+                     {expired :- (describe s/Bool "whether to include expired licenses") false}
+                     {archived :- (describe s/Bool "whether to include archived licenses") false}]
       :return Licenses
       (ok (licenses/get-all-licenses (merge (when-not disabled {:enabled true})
-                                            (when-not inactive {:active true})
+                                            (when-not expired {:active true})
                                             (when-not archived {:archived false})))))
 
     (GET "/:license-id" []

--- a/src/clj/rems/api/resources.clj
+++ b/src/clj/rems/api/resources.clj
@@ -68,11 +68,11 @@
     (GET "/" []
       :summary "Get resources"
       :roles #{:owner}
-      :query-params [{active :- (describe s/Bool "filter active or inactive resources") nil}
-                     {disabled :- (describe s/Bool "whether to include disabled resources") false}
+      :query-params [{disabled :- (describe s/Bool "whether to include disabled resources") false}
+                     {inactive :- (describe s/Bool "whether to include active resources") false}
                      {archived :- (describe s/Bool "whether to include archived resources") false}]
       :return Resources
-      (ok (get-resources (merge (when active {:active active})
+      (ok (get-resources (merge (when-not inactive {:active true})
                                 (when-not disabled {:enabled true})
                                 (when-not archived {:archived false})))))
 

--- a/src/clj/rems/api/resources.clj
+++ b/src/clj/rems/api/resources.clj
@@ -69,10 +69,10 @@
       :summary "Get resources"
       :roles #{:owner}
       :query-params [{disabled :- (describe s/Bool "whether to include disabled resources") false}
-                     {inactive :- (describe s/Bool "whether to include active resources") false}
+                     {expired :- (describe s/Bool "whether to include expired resources") false}
                      {archived :- (describe s/Bool "whether to include archived resources") false}]
       :return Resources
-      (ok (get-resources (merge (when-not inactive {:active true})
+      (ok (get-resources (merge (when-not expired {:active true})
                                 (when-not disabled {:enabled true})
                                 (when-not archived {:archived false})))))
 

--- a/src/clj/rems/api/workflows.clj
+++ b/src/clj/rems/api/workflows.clj
@@ -113,11 +113,11 @@
     (GET "/" []
       :summary "Get workflows"
       :roles #{:owner}
-      :query-params [{disabled :- (describe s/Bool "whether to include disabled resources") false}
-                     {inactive :- (describe s/Bool "whether to include active resources") false}
-                     {archived :- (describe s/Bool "whether to include archived resources") false}]
+      :query-params [{disabled :- (describe s/Bool "whether to include disabled workflows") false}
+                     {expired :- (describe s/Bool "whether to include expired workflows") false}
+                     {archived :- (describe s/Bool "whether to include archived workflows") false}]
       :return Workflows
-      (ok (get-workflows (merge (when-not inactive {:active true})
+      (ok (get-workflows (merge (when-not expired {:active true})
                                 (when-not disabled {:enabled true})
                                 (when-not archived {:archived false})))))
 

--- a/src/clj/rems/api/workflows.clj
+++ b/src/clj/rems/api/workflows.clj
@@ -113,10 +113,12 @@
     (GET "/" []
       :summary "Get workflows"
       :roles #{:owner}
-      :query-params [{active :- (describe s/Bool "filter active or inactive workflows") nil}
+      :query-params [{disabled :- (describe s/Bool "whether to include disabled resources") false}
+                     {inactive :- (describe s/Bool "whether to include active resources") false}
                      {archived :- (describe s/Bool "whether to include archived resources") false}]
       :return Workflows
-      (ok (get-workflows (merge (when active {:active active})
+      (ok (get-workflows (merge (when-not inactive {:active true})
+                                (when-not disabled {:enabled true})
                                 (when-not archived {:archived false})))))
 
     (POST "/create" []

--- a/src/cljs/rems/administration/catalogue_items.cljs
+++ b/src/cljs/rems/administration/catalogue_items.cljs
@@ -13,7 +13,7 @@
 (rf/reg-event-fx
  ::enter-page
  (fn [{:keys [db]}]
-   {:db (assoc db ::display-archived? false)
+   {:db (assoc db ::display-old? false)
     :dispatch [::fetch-catalogue]}))
 
 (rf/reg-event-fx
@@ -21,8 +21,8 @@
  (fn [{:keys [db]}]
    (fetch "/api/catalogue-items/" {:url-params {:expand :names
                                                 :disabled true
-                                                :expired (::display-archived? db)
-                                                :archived (::display-archived? db)}
+                                                :expired (::display-old? db)
+                                                :archived (::display-old? db)}
                                    :handler #(rf/dispatch [::fetch-catalogue-result %])
                                    :error-handler status-modal/common-error-handler!})
    {:db (assoc db ::loading? true)}))
@@ -58,11 +58,11 @@
 (rf/reg-sub ::filtering (fn [db _] (::filtering db)))
 
 (rf/reg-event-fx
- ::set-display-archived?
- (fn [{:keys [db]} [_ display-archived?]]
-   {:db (assoc db ::display-archived? display-archived?)
+ ::set-display-old?
+ (fn [{:keys [db]} [_ display-old?]]
+   {:db (assoc db ::display-old? display-old?)
     :dispatch [::fetch-catalogue]}))
-(rf/reg-sub ::display-archived? (fn [db _] (::display-archived? db)))
+(rf/reg-sub ::display-old? (fn [db _] (::display-old? db)))
 
 (defn- to-create-catalogue-item []
   [:a.btn.btn-primary
@@ -126,9 +126,9 @@
         (if @(rf/subscribe [::loading?])
           [[spinner/big]]
           [[to-create-catalogue-item]
-           [status-flags/display-archived-toggle
-            @(rf/subscribe [::display-archived?])
-            #(rf/dispatch [::set-display-archived? %])]
+           [status-flags/display-old-toggle
+            @(rf/subscribe [::display-old?])
+            #(rf/dispatch [::set-display-old? %])]
            [catalogue-list
             @(rf/subscribe [::catalogue])
             @(rf/subscribe [:language])

--- a/src/cljs/rems/administration/catalogue_items.cljs
+++ b/src/cljs/rems/administration/catalogue_items.cljs
@@ -20,6 +20,8 @@
  ::fetch-catalogue
  (fn [{:keys [db]}]
    (fetch "/api/catalogue-items/" {:url-params {:expand :names
+                                                :disabled true
+                                                :inactive (::display-archived? db)
                                                 :archived (::display-archived? db)}
                                    :handler #(rf/dispatch [::fetch-catalogue-result %])
                                    :error-handler status-modal/common-error-handler!})

--- a/src/cljs/rems/administration/catalogue_items.cljs
+++ b/src/cljs/rems/administration/catalogue_items.cljs
@@ -21,7 +21,7 @@
  (fn [{:keys [db]}]
    (fetch "/api/catalogue-items/" {:url-params {:expand :names
                                                 :disabled true
-                                                :inactive (::display-archived? db)
+                                                :expired (::display-archived? db)
                                                 :archived (::display-archived? db)}
                                    :handler #(rf/dispatch [::fetch-catalogue-result %])
                                    :error-handler status-modal/common-error-handler!})

--- a/src/cljs/rems/administration/forms.cljs
+++ b/src/cljs/rems/administration/forms.cljs
@@ -19,7 +19,7 @@
  ::fetch-forms
  (fn [db]
    (fetch "/api/forms/" {:url-params {:disabled true
-                                      :inactive (::display-archived? db)
+                                      :expired (::display-archived? db)
                                       :archived (::display-archived? db)}
                          :handler #(rf/dispatch [::fetch-forms-result %])})
    (assoc db ::loading? true)))

--- a/src/cljs/rems/administration/forms.cljs
+++ b/src/cljs/rems/administration/forms.cljs
@@ -18,7 +18,9 @@
 (rf/reg-event-db
  ::fetch-forms
  (fn [db]
-   (fetch "/api/forms/" {:url-params {:archived (::display-archived? db)}
+   (fetch "/api/forms/" {:url-params {:disabled true
+                                      :inactive (::display-archived? db)
+                                      :archived (::display-archived? db)}
                          :handler #(rf/dispatch [::fetch-forms-result %])})
    (assoc db ::loading? true)))
 

--- a/src/cljs/rems/administration/forms.cljs
+++ b/src/cljs/rems/administration/forms.cljs
@@ -12,15 +12,15 @@
 (rf/reg-event-fx
  ::enter-page
  (fn [{:keys [db]}]
-   {:db (assoc db ::display-archived? false)
+   {:db (assoc db ::display-old? false)
     :dispatch [::fetch-forms]}))
 
 (rf/reg-event-db
  ::fetch-forms
  (fn [db]
    (fetch "/api/forms/" {:url-params {:disabled true
-                                      :expired (::display-archived? db)
-                                      :archived (::display-archived? db)}
+                                      :expired (::display-old? db)
+                                      :archived (::display-old? db)}
                          :handler #(rf/dispatch [::fetch-forms-result %])})
    (assoc db ::loading? true)))
 
@@ -56,12 +56,12 @@
 (rf/reg-sub ::filtering (fn [db _] (::filtering db)))
 
 (rf/reg-event-fx
- ::set-display-archived?
- (fn [{:keys [db]} [_ display-archived?]]
-   {:db (assoc db ::display-archived? display-archived?)
+ ::set-display-old?
+ (fn [{:keys [db]} [_ display-old?]]
+   {:db (assoc db ::display-old? display-old?)
     :dispatch [::fetch-forms]}))
 
-(rf/reg-sub ::display-archived? (fn [db _] (::display-archived? db)))
+(rf/reg-sub ::display-old? (fn [db _] (::display-old? db)))
 
 (defn- to-create-form []
   [:a.btn.btn-primary
@@ -109,9 +109,9 @@
         (if @(rf/subscribe [::loading?])
           [[spinner/big]]
           [[to-create-form]
-           [status-flags/display-archived-toggle
-            @(rf/subscribe [::display-archived?])
-            #(rf/dispatch [::set-display-archived? %])]
+           [status-flags/display-old-toggle
+            @(rf/subscribe [::display-old?])
+            #(rf/dispatch [::set-display-old? %])]
            [forms-list
             @(rf/subscribe [::forms])
             (assoc @(rf/subscribe [::sorting]) :set-sorting #(rf/dispatch [::set-sorting %]))

--- a/src/cljs/rems/administration/licenses.cljs
+++ b/src/cljs/rems/administration/licenses.cljs
@@ -19,7 +19,7 @@
  ::fetch-licenses
  (fn [db]
    (fetch "/api/licenses/" {:url-params {:disabled true
-                                         :inactive (::display-archived? db)
+                                         :expired (::display-archived? db)
                                          :archived (::display-archived? db)}
                             :handler #(rf/dispatch [::fetch-licenses-result %])})
    (assoc db ::loading? true)))

--- a/src/cljs/rems/administration/licenses.cljs
+++ b/src/cljs/rems/administration/licenses.cljs
@@ -18,7 +18,9 @@
 (rf/reg-event-db
  ::fetch-licenses
  (fn [db]
-   (fetch "/api/licenses/" {:url-params {:archived (::display-archived? db)}
+   (fetch "/api/licenses/" {:url-params {:disabled true
+                                         :inactive (::display-archived? db)
+                                         :archived (::display-archived? db)}
                             :handler #(rf/dispatch [::fetch-licenses-result %])})
    (assoc db ::loading? true)))
 

--- a/src/cljs/rems/administration/licenses.cljs
+++ b/src/cljs/rems/administration/licenses.cljs
@@ -12,15 +12,15 @@
 (rf/reg-event-fx
  ::enter-page
  (fn [{:keys [db]}]
-   {:db (assoc db ::display-archived? false)
+   {:db (assoc db ::display-old? false)
     :dispatch [::fetch-licenses]}))
 
 (rf/reg-event-db
  ::fetch-licenses
  (fn [db]
    (fetch "/api/licenses/" {:url-params {:disabled true
-                                         :expired (::display-archived? db)
-                                         :archived (::display-archived? db)}
+                                         :expired (::display-old? db)
+                                         :archived (::display-old? db)}
                             :handler #(rf/dispatch [::fetch-licenses-result %])})
    (assoc db ::loading? true)))
 
@@ -56,12 +56,12 @@
 (rf/reg-sub ::filtering (fn [db _] (::filtering db)))
 
 (rf/reg-event-fx
- ::set-display-archived?
- (fn [{:keys [db]} [_ display-archived?]]
-   {:db (assoc db ::display-archived? display-archived?)
+ ::set-display-old?
+ (fn [{:keys [db]} [_ display-old?]]
+   {:db (assoc db ::display-old? display-old?)
     :dispatch [::fetch-licenses]}))
 
-(rf/reg-sub ::display-archived? (fn [db _] (::display-archived? db)))
+(rf/reg-sub ::display-old? (fn [db _] (::display-old? db)))
 
 (defn- to-create-licenses []
   [:a.btn.btn-primary
@@ -109,9 +109,9 @@
         (if @(rf/subscribe [::loading?])
           [[spinner/big]]
           [[to-create-licenses]
-           [status-flags/display-archived-toggle
-            @(rf/subscribe [::display-archived?])
-            #(rf/dispatch [::set-display-archived? %])]
+           [status-flags/display-old-toggle
+            @(rf/subscribe [::display-old?])
+            #(rf/dispatch [::set-display-old? %])]
            [licenses-list
             @(rf/subscribe [::licenses])
             (assoc @(rf/subscribe [::sorting]) :set-sorting #(rf/dispatch [::set-sorting %]))

--- a/src/cljs/rems/administration/resources.cljs
+++ b/src/cljs/rems/administration/resources.cljs
@@ -13,15 +13,15 @@
 (rf/reg-event-fx
  ::enter-page
  (fn [{:keys [db]}]
-   {:db (assoc db ::display-archived? false)
+   {:db (assoc db ::display-old? false)
     :dispatch [::fetch-resources]}))
 
 (rf/reg-event-fx
  ::fetch-resources
  (fn [{:keys [db]}]
    (fetch "/api/resources" {:url-params {:disabled true
-                                         :expired (::display-archived? db)
-                                         :archived (::display-archived? db)}
+                                         :expired (::display-old? db)
+                                         :archived (::display-old? db)}
                             :handler #(rf/dispatch [::fetch-resources-result %])
                             :error-handler status-modal/common-error-handler!})
    {:db (assoc db ::loading? true)}))
@@ -53,11 +53,11 @@
 (rf/reg-sub ::filtering (fn [db _] (or (::filtering db))))
 
 (rf/reg-event-fx
- ::set-display-archived?
- (fn [{:keys [db]} [_ display-archived?]]
-   {:db (assoc db ::display-archived? display-archived?)
+ ::set-display-old?
+ (fn [{:keys [db]} [_ display-old?]]
+   {:db (assoc db ::display-old? display-old?)
     :dispatch [::fetch-resources]}))
-(rf/reg-sub ::display-archived? (fn [db _] (::display-archived? db)))
+(rf/reg-sub ::display-old? (fn [db _] (::display-old? db)))
 
 (defn- to-create-resource []
   [:a.btn.btn-primary
@@ -105,9 +105,9 @@
         (if @(rf/subscribe [::loading?])
           [[spinner/big]]
           [[to-create-resource]
-           [status-flags/display-archived-toggle
-            @(rf/subscribe [::display-archived?])
-            #(rf/dispatch [::set-display-archived? %])]
+           [status-flags/display-old-toggle
+            @(rf/subscribe [::display-old?])
+            #(rf/dispatch [::set-display-old? %])]
            [resources-list
             @(rf/subscribe [::resources])
             (assoc @(rf/subscribe [::sorting]) :set-sorting #(rf/dispatch [::set-sorting %]))

--- a/src/cljs/rems/administration/resources.cljs
+++ b/src/cljs/rems/administration/resources.cljs
@@ -20,6 +20,7 @@
  ::fetch-resources
  (fn [{:keys [db]}]
    (fetch "/api/resources" {:url-params {:disabled true
+                                         :inactive (::display-archived? db)
                                          :archived (::display-archived? db)}
                             :handler #(rf/dispatch [::fetch-resources-result %])
                             :error-handler status-modal/common-error-handler!})

--- a/src/cljs/rems/administration/resources.cljs
+++ b/src/cljs/rems/administration/resources.cljs
@@ -20,7 +20,7 @@
  ::fetch-resources
  (fn [{:keys [db]}]
    (fetch "/api/resources" {:url-params {:disabled true
-                                         :inactive (::display-archived? db)
+                                         :expired (::display-archived? db)
                                          :archived (::display-archived? db)}
                             :handler #(rf/dispatch [::fetch-resources-result %])
                             :error-handler status-modal/common-error-handler!})

--- a/src/cljs/rems/administration/status_flags.cljs
+++ b/src/cljs/rems/administration/status_flags.cljs
@@ -40,14 +40,14 @@
     [archive-button item on-change]))
 
 
-(defn display-archived-toggle [display-archived? on-change]
+(defn display-old-toggle [display-old? on-change]
   [:div.form-check.form-check-inline {:style {:float "right"}}
    [:input.form-check-input {:type "checkbox"
-                             :id "display-archived"
-                             :checked display-archived?
-                             :on-change #(on-change (not display-archived?))}]
-   [:label.form-check-label {:for "display-archived"}
-    (text :t.administration/display-archived)]])
+                             :id "display-old"
+                             :checked display-old?
+                             :on-change #(on-change (not display-old?))}]
+   [:label.form-check-label {:for "display-old"}
+    (text :t.administration/display-old)]])
 
 (defn- format-update-error [{:keys [type catalogue-items resources workflows]}]
   (let [language @(rf/subscribe [:language])]

--- a/src/cljs/rems/administration/workflows.cljs
+++ b/src/cljs/rems/administration/workflows.cljs
@@ -20,7 +20,7 @@
  (fn [db]
    (fetch "/api/workflows/" {:url-params {:disabled true
                                           :archived (::display-archived? db)
-                                          :inactive (::display-archived? db)}
+                                          :expired (::display-archived? db)}
                              :handler #(rf/dispatch [::fetch-workflows-result %])})
    (assoc db ::loading? true)))
 

--- a/src/cljs/rems/administration/workflows.cljs
+++ b/src/cljs/rems/administration/workflows.cljs
@@ -12,15 +12,15 @@
 (rf/reg-event-fx
  ::enter-page
  (fn [{:keys [db]}]
-   {:db (assoc db ::display-archived? false)
+   {:db (assoc db ::display-old? false)
     :dispatch [::fetch-workflows]}))
 
 (rf/reg-event-db
  ::fetch-workflows
  (fn [db]
    (fetch "/api/workflows/" {:url-params {:disabled true
-                                          :archived (::display-archived? db)
-                                          :expired (::display-archived? db)}
+                                          :archived (::display-old? db)
+                                          :expired (::display-old? db)}
                              :handler #(rf/dispatch [::fetch-workflows-result %])})
    (assoc db ::loading? true)))
 
@@ -56,11 +56,11 @@
 (rf/reg-sub ::filtering (fn [db _] (::filtering db)))
 
 (rf/reg-event-fx
- ::set-display-archived?
- (fn [{:keys [db]} [_ display-archived?]]
-   {:db (assoc db ::display-archived? display-archived?)
+ ::set-display-old?
+ (fn [{:keys [db]} [_ display-old?]]
+   {:db (assoc db ::display-old? display-old?)
     :dispatch [::fetch-workflows]}))
-(rf/reg-sub ::display-archived? (fn [db _] (::display-archived? db)))
+(rf/reg-sub ::display-old? (fn [db _] (::display-old? db)))
 
 
 (defn- to-create-workflow []
@@ -110,9 +110,9 @@
         (if @(rf/subscribe [::loading?])
           [[spinner/big]]
           [[to-create-workflow]
-           [status-flags/display-archived-toggle
-            @(rf/subscribe [::display-archived?])
-            #(rf/dispatch [::set-display-archived? %])]
+           [status-flags/display-old-toggle
+            @(rf/subscribe [::display-old?])
+            #(rf/dispatch [::set-display-old? %])]
            [workflows-list
             @(rf/subscribe [::workflows])
             (assoc @(rf/subscribe [::sorting]) :set-sorting #(rf/dispatch [::set-sorting %]))

--- a/src/cljs/rems/administration/workflows.cljs
+++ b/src/cljs/rems/administration/workflows.cljs
@@ -18,7 +18,9 @@
 (rf/reg-event-db
  ::fetch-workflows
  (fn [db]
-   (fetch "/api/workflows/" {:url-params {:archived (::display-archived? db)}
+   (fetch "/api/workflows/" {:url-params {:disabled true
+                                          :archived (::display-archived? db)
+                                          :inactive (::display-archived? db)}
                              :handler #(rf/dispatch [::fetch-workflows-result %])})
    (assoc db ::loading? true)))
 

--- a/test/clj/rems/api/test_forms.clj
+++ b/test/clj/rems/api/test_forms.clj
@@ -178,12 +178,12 @@
                    (:fields (form/get-form-template (:id form)))))))))))
 
 (deftest forms-api-filtering-test
-  (let [unfiltered (-> (request :get "/api/forms")
+  (let [unfiltered (-> (request :get "/api/forms" {:expired true})
                        (authenticate "42" "owner")
                        handler
                        assert-response-is-ok
                        read-body)
-        filtered (-> (request :get "/api/forms" {:active true})
+        filtered (-> (request :get "/api/forms")
                      (authenticate "42" "owner")
                      handler
                      assert-response-is-ok

--- a/test/clj/rems/api/test_licenses.clj
+++ b/test/clj/rems/api/test_licenses.clj
@@ -159,12 +159,12 @@
               assert-response-is-server-error?))))))
 
 (deftest licenses-api-filtering-test
-  (let [unfiltered (-> (request :get "/api/licenses")
+  (let [unfiltered (-> (request :get "/api/licenses" {:expired true})
                        (authenticate "42" "owner")
                        handler
                        assert-response-is-ok
                        read-body)
-        filtered (-> (request :get "/api/licenses" {:active true})
+        filtered (-> (request :get "/api/licenses")
                      (authenticate "42" "owner")
                      handler
                      assert-response-is-ok

--- a/test/clj/rems/api/test_resources.clj
+++ b/test/clj/rems/api/test_resources.clj
@@ -124,12 +124,12 @@
               assert-response-is-ok))))))
 
 (deftest resources-api-filtering-test
-  (let [unfiltered (-> (request :get "/api/resources")
+  (let [unfiltered (-> (request :get "/api/resources" {:expired true})
                        (authenticate "42" "owner")
                        handler
                        assert-response-is-ok
                        read-body)
-        filtered (-> (request :get "/api/resources" {:active true})
+        filtered (-> (request :get "/api/resources")
                      (authenticate "42" "owner")
                      handler
                      assert-response-is-ok

--- a/test/clj/rems/api/test_workflows.clj
+++ b/test/clj/rems/api/test_workflows.clj
@@ -87,7 +87,7 @@
             (authenticate "42" "owner")
             handler
             assert-response-is-ok)
-        (let [workflows (-> (request :get "/api/workflows" {:archived true})
+        (let [workflows (-> (request :get "/api/workflows" {:disabled true :archived true})
                             (authenticate "42" "owner")
                             handler
                             assert-response-is-ok
@@ -97,12 +97,12 @@
                  (select-keys workflow [:id :enabled :archived]))))))))
 
 (deftest workflows-api-filtering-test
-  (let [unfiltered (-> (request :get "/api/workflows")
+  (let [unfiltered (-> (request :get "/api/workflows" {:expired true})
                        (authenticate "42" "owner")
                        handler
                        assert-response-is-ok
                        read-body)
-        filtered (-> (request :get "/api/workflows" {:active true})
+        filtered (-> (request :get "/api/workflows")
                      (authenticate "42" "owner")
                      handler
                      assert-response-is-ok


### PR DESCRIPTION
- unify disabled/archived/expired filtering in listing apis
- use expired instead of misleading active in API
- change "display archived" checkbox into "display old"

for #806