### PR TITLE
fix /api/licenses/<id> again

### DIFF
--- a/src/clj/rems/api/schema.clj
+++ b/src/clj/rems/api/schema.clj
@@ -93,7 +93,7 @@
    :catalogue-item/active s/Bool
    :catalogue-item/archived s/Bool})
 
-(s/defschema License
+(s/defschema V2License
   {:license/id s/Int
    :license/accepted s/Bool
    :license/type (s/enum :text :link :attachment)
@@ -138,7 +138,7 @@
    :application/invited-members #{{:name s/Str
                                    :email s/Str}}
    :application/resources [V2Resource]
-   :application/licenses [License]
+   :application/licenses [V2License]
    :application/accepted-licenses (s/maybe {s/Str #{s/Num}})
    :application/events [Event]
    :application/description s/Str

--- a/test/clj/rems/api/test_forms.clj
+++ b/test/clj/rems/api/test_forms.clj
@@ -15,7 +15,7 @@
   (let [api-key "42"
         user-id "owner"]
 
-    (testing "get"
+    (testing "get all"
       (let [data (-> (request :get "/api/forms")
                      (authenticate api-key user-id)
                      handler

--- a/test/clj/rems/api/test_licenses.clj
+++ b/test/clj/rems/api/test_licenses.clj
@@ -37,21 +37,21 @@
                                           :attachment-id nil}
                                      :fi {:title "fi title"
                                           :textcontent "http://example.com/license/fi"
-                                          :attachment-id nil}}}]
-        (-> (request :post "/api/licenses/create")
-            (authenticate api-key user-id)
-            (json-body command)
-            handler
-            assert-response-is-ok)
+                                          :attachment-id nil}}}
+            id (-> (request :post "/api/licenses/create")
+                   (authenticate api-key user-id)
+                   (json-body command)
+                   handler
+                   assert-response-is-ok
+                   read-body
+                   :id)]
         (testing "and fetch"
-          (let [body (-> (request :get "/api/licenses")
-                         (authenticate api-key user-id)
-                         handler
-                         assert-response-is-ok
-                         read-body)
-                license (->> body
-                             (filter #(= (:title %) (:title command)))
-                             first)]
+          (let [license (-> (request :get (str "/api/licenses/" id))
+                            (authenticate api-key user-id)
+                            handler
+                            assert-response-is-ok
+                            read-body)]
+            (is id)
             (is license)
             (is (= command (select-keys license (keys command))))))))
 
@@ -65,21 +65,20 @@
                                           :attachment-id nil}
                                      :fi {:title "fi title"
                                           :textcontent "fi text"
-                                          :attachment-id nil}}}]
-        (-> (request :post "/api/licenses/create")
-            (authenticate api-key user-id)
-            (json-body command)
-            handler
-            assert-response-is-ok)
+                                          :attachment-id nil}}}
+            id (-> (request :post "/api/licenses/create")
+                   (authenticate api-key user-id)
+                   (json-body command)
+                   handler
+                   assert-response-is-ok
+                   read-body
+                   :id)]
         (testing "and fetch"
-          (let [body (-> (request :get "/api/licenses")
-                         (authenticate api-key user-id)
-                         handler
-                         assert-response-is-ok
-                         read-body)
-                license (->> body
-                             (filter #(= (:title %) (:title command)))
-                             first)]
+          (let [license (-> (request :get (str "/api/licenses/" id))
+                            (authenticate api-key user-id)
+                            handler
+                            assert-response-is-ok
+                            read-body)]
             (is license)
             (is (= command (select-keys license (keys command))))))))
 
@@ -132,22 +131,21 @@
                                           :attachment-id attachment-id}
                                      :fi {:title "fi title"
                                           :textcontent "fi text"
-                                          :attachment-id attachment-id}}}]
-        (-> (request :post "/api/licenses/create")
-            (authenticate api-key user-id)
-            (json-body command)
-            handler
-            assert-response-is-ok)
+                                          :attachment-id attachment-id}}}
+            license-id (-> (request :post "/api/licenses/create")
+                           (authenticate api-key user-id)
+                           (json-body command)
+                           handler
+                           assert-response-is-ok
+                           read-body
+                           :id)]
 
         (testing "and fetch"
-          (let [body (-> (request :get "/api/licenses")
-                         (authenticate api-key user-id)
-                         handler
-                         assert-response-is-ok
-                         read-body)
-                license (->> body
-                             (filter #(= (:title %) (:title command)))
-                             first)]
+          (let [license (-> (request :get (str "/api/licenses/" license-id))
+                            (authenticate api-key user-id)
+                            handler
+                            assert-response-is-ok
+                            read-body)]
             (is license)
             (is (= command (select-keys license (keys command))))))
 

--- a/test/clj/rems/api/test_licenses.clj
+++ b/test/clj/rems/api/test_licenses.clj
@@ -45,13 +45,13 @@
                    assert-response-is-ok
                    read-body
                    :id)]
+        (is id)
         (testing "and fetch"
           (let [license (-> (request :get (str "/api/licenses/" id))
                             (authenticate api-key user-id)
                             handler
                             assert-response-is-ok
                             read-body)]
-            (is id)
             (is license)
             (is (= command (select-keys license (keys command))))))))
 
@@ -70,15 +70,14 @@
                    (authenticate api-key user-id)
                    (json-body command)
                    handler
-                   assert-response-is-ok
-                   read-body
+                   read-ok-body
                    :id)]
+        (is id)
         (testing "and fetch"
           (let [license (-> (request :get (str "/api/licenses/" id))
                             (authenticate api-key user-id)
                             handler
-                            assert-response-is-ok
-                            read-body)]
+                            read-ok-body)]
             (is license)
             (is (= command (select-keys license (keys command))))))))
 
@@ -119,9 +118,8 @@
                               (assoc :multipart-params {"file" filecontent})
                               (authenticate api-key user-id)
                               handler
-                              assert-response-is-ok
-                              read-body
-                              (get :id))
+                              read-ok-body
+                              :id)
             command {:title (str "license title " (UUID/randomUUID))
                      :licensetype "text"
                      :textcontent "license text"
@@ -136,16 +134,14 @@
                            (authenticate api-key user-id)
                            (json-body command)
                            handler
-                           assert-response-is-ok
-                           read-body
+                           read-ok-body
                            :id)]
 
         (testing "and fetch"
           (let [license (-> (request :get (str "/api/licenses/" license-id))
                             (authenticate api-key user-id)
                             handler
-                            assert-response-is-ok
-                            read-body)]
+                            read-ok-body)]
             (is license)
             (is (= command (select-keys license (keys command))))))
 

--- a/test/clj/rems/api/test_licenses.clj
+++ b/test/clj/rems/api/test_licenses.clj
@@ -19,7 +19,7 @@
 (deftest licenses-api-test
   (let [api-key "42"
         user-id "owner"]
-    (testing "get"
+    (testing "get all"
       (let [data (-> (request :get "/api/licenses")
                      (authenticate api-key user-id)
                      handler

--- a/test/clj/rems/api/test_resources.clj
+++ b/test/clj/rems/api/test_resources.clj
@@ -26,7 +26,7 @@
 (deftest resources-api-test
   (let [api-key "42"
         user-id "owner"]
-    (testing "get"
+    (testing "get all"
       (testing "returns stuff"
         (let [data (-> (request :get "/api/resources")
                        (authenticate api-key user-id)

--- a/test/clj/rems/api/test_resources.clj
+++ b/test/clj/rems/api/test_resources.clj
@@ -86,21 +86,22 @@
             (is (contains? app-ids archived-id))))))
     (testing "create"
       (let [licid 1
-            resid "RESOURCE-API-TEST"]
-        (-> (request :post "/api/resources/create")
-            (authenticate api-key user-id)
-            (json-body {:resid resid
-                        :organization "TEST-ORGANIZATION"
-                        :licenses [licid]})
-            handler
-            assert-response-is-ok)
+            resid "RESOURCE-API-TEST"
+            id (-> (request :post "/api/resources/create")
+                   (authenticate api-key user-id)
+                   (json-body {:resid resid
+                               :organization "TEST-ORGANIZATION"
+                               :licenses [licid]})
+                   handler
+                   read-ok-body
+                   :id)]
+        (is id)
         (testing "and fetch"
-          (let [data (-> (request :get "/api/resources")
-                         (authenticate api-key user-id)
-                         handler
-                         assert-response-is-ok
-                         read-body)
-                resource (some #(when (= resid (:resid %)) %) data)]
+          (let [resource (-> (request :get (str "/api/resources/" id))
+                             (authenticate api-key user-id)
+                             handler
+                             assert-response-is-ok
+                             read-body)]
             (is resource)
             (is (= [licid] (map :id (:licenses resource))))))
         (testing "duplicate resource ID is not allowed within one organization"


### PR DESCRIPTION
- there were two conflicting License schemas
- the single license GET api wasn't tested

part of #852
caused by #1064
see also #1061