### PR TITLE
rems.db.testing: tear down existing system at start of test-db-fixture

### DIFF
--- a/test/clj/rems/db/testing.clj
+++ b/test/clj/rems/db/testing.clj
@@ -8,6 +8,7 @@
             [rems.db.test-data :as test-data]))
 
 (defn test-db-fixture [f]
+  (mount/stop) ;; during interactive development, app might be running when tests start. we need to tear it down
   (mount/start-with-args {:test true}
                          #'rems.config/env
                          #'rems.db.core/*db*)


### PR DESCRIPTION
otherwise mount/start-with-args won't take effect if the app is
already running

for #1072