### PR TITLE
Hide past members from public API

### DIFF
--- a/src/clj/rems/api/schema.clj
+++ b/src/clj/rems/api/schema.clj
@@ -135,8 +135,6 @@
    :application/applicant-attributes {s/Keyword s/Str}
    :application/members #{{:userid s/Str
                            s/Keyword s/Str}}
-   :application/past-members #{{:userid s/Str
-                                s/Keyword s/Str}}
    :application/invited-members #{{:name s/Str
                                    :email s/Str}}
    :application/resources [V2Resource]

--- a/src/clj/rems/application/model.clj
+++ b/src/clj/rems/application/model.clj
@@ -532,7 +532,8 @@
       ;; these are not used by the UI, so no need to expose them (especially the user IDs)
       (update-in [:application/workflow] dissoc
                  :workflow.dynamic/awaiting-commenters
-                 :workflow.dynamic/awaiting-deciders)))
+                 :workflow.dynamic/awaiting-deciders)
+      (dissoc :application/past-members)))
 
 (defn apply-user-permissions [application user-id]
   (let [see-application? (see-application? application user-id)

--- a/src/clj/rems/application/model.clj
+++ b/src/clj/rems/application/model.clj
@@ -524,7 +524,7 @@
       (update :application/events hide-sensitive-events)
       (update :application/workflow dissoc :workflow.dynamic/handlers)))
 
-(defn- hide-very-sensitive-information [application]
+(defn- hide-non-public-information [application]
   (-> application
       ;; the keys are invitation tokens and must be kept secret
       (dissoc :application/invitation-tokens)
@@ -543,7 +543,7 @@
       (-> (if see-everything?
             application
             (hide-sensitive-information application))
-          (hide-very-sensitive-information)
+          (hide-non-public-information)
           (assoc :application/permissions permissions)
           (assoc :application/roles roles)
           (permissions/cleanup)))))


### PR DESCRIPTION
It's only needed for removing entitlements. To avoid outsiders starting to depend on it, this PR hides it from the public API.