### PR TITLE
Add licenses

### DIFF
--- a/resources/translations/en.edn
+++ b/resources/translations/en.edn
@@ -50,6 +50,7 @@
             :accept-invitation-success [:div [:p "Joining the application was successful."] [:p "Next you will be taken to the application."]]
             :accept-invitation-already-member [:div [:p "You are already a member."] [:p "Next you will be taken to the application."]]
             :accept-licenses "Accept terms of use"
+            :add-licenses "Add terms of use"
             :add-member "Add member"
             :applicant "Applicant"
             :application "Application"
@@ -68,6 +69,7 @@
             :handled-approvals "Handled applications"
             :invite-member "Invite member"
             :last-activity "Last activity"
+            :licenses-selection "Require following additional terms of use"
             :load-application-states "Load application states"
             :member "Member"
             :member-name "Name"
@@ -145,6 +147,7 @@
                           :decided "Decided"
                           :decision-requested "Decision requested"
                           :draft-saved "Saved"
+                          :licenses-added "Added tems of use"
                           :licenses-accepted "Accepted terms of use"
                           :member-added "Member added"
                           :member-invited "Member invited"

--- a/resources/translations/en.edn
+++ b/resources/translations/en.edn
@@ -79,7 +79,7 @@
             :remove-member "Remove member"
             :request-comment "Request comment"
             :request-decision "Request decision"
-            :request-selection "Send request to user(s):"
+            :request-selection "Send request to users"
             :resource "Resource"
             :return "Return to applicant"
             :show-publications "Show publications"

--- a/resources/translations/fi.edn
+++ b/resources/translations/fi.edn
@@ -50,6 +50,7 @@
             :accept-invitation-success [:div [:p "Liittyminen hakemukseen onnistui."] [:p "Seuraavaksi pääset katsomaan hakemuksen tietoja."]]
             :accept-invitation-already-member [:div. [:p "Olet jo jäsen."] [:p "Seuraavaksi pääset katsomaan hakemuksen tietoja."]]
             :accept-licenses "Hyväksy käyttöehdot"
+            :add-licenses "Lisää käyttöehto"
             :add-member "Lisää jäsen"
             :applicant "Hakija"
             :application "Hakemus"
@@ -68,6 +69,7 @@
             :handled-approvals "Käsitellyt hakemukset"
             :invite-member "Kutsu jäsen"
             :last-activity "Muokattu"
+            :licenses-selection "Lisää seuraavat käyttöehdot"
             :load-application-states "Lataa hakemusten tilat"
             :member "Jäsen"
             :member-name "Nimi"
@@ -145,6 +147,7 @@
                           :decided "Päätetty"
                           :decision-requested "Pyydetty päätöstä"
                           :draft-saved "Tallennettu"
+                          :licenses-added "Käyttöehtoja lisätty"
                           :licenses-accepted "Käyttöehdot hyväksytty"
                           :member-added "Lisätty jäsen"
                           :member-invited "Kutsuttu jäsen"

--- a/resources/translations/fi.edn
+++ b/resources/translations/fi.edn
@@ -79,7 +79,7 @@
             :remove-member "Poista jäsen"
             :request-comment "Pyydä kommenttia"
             :request-decision "Pyydä päätöstä"
-            :request-selection "Lähetä pyyntö henkilölle/henkilöille:"
+            :request-selection "Lähetä pyyntö seuraaville henkilöille"
             :resource "Resurssi"
             :return "Palauta hakijalle"
             :show-publications "Näytä julkaisut"

--- a/src/clj/rems/api/applications.clj
+++ b/src/clj/rems/api/applications.clj
@@ -186,6 +186,7 @@
 
     (command-endpoint :application.command/accept-invitation commands/AcceptInvitationCommand)
     (command-endpoint :application.command/accept-licenses commands/AcceptLicensesCommand)
+    (command-endpoint :application.command/add-licenses commands/AddLicensesCommand)
     (command-endpoint :application.command/add-member commands/AddMemberCommand)
     (command-endpoint :application.command/invite-member commands/InviteMemberCommand)
     (command-endpoint :application.command/approve commands/ApproveCommand)

--- a/src/clj/rems/api/licenses.clj
+++ b/src/clj/rems/api/licenses.clj
@@ -46,7 +46,7 @@
 
     (GET "/" []
       :summary "Get licenses"
-      :roles #{:owner}
+      :roles #{:handler :owner}
       :query-params [{disabled :- (describe s/Bool "whether to include disabled licenses") false}
                      {expired :- (describe s/Bool "whether to include expired licenses") false}
                      {archived :- (describe s/Bool "whether to include archived licenses") false}]

--- a/src/clj/rems/application/commands.clj
+++ b/src/clj/rems/application/commands.clj
@@ -62,6 +62,11 @@
   (assoc CommandBase
          :comment s/Str))
 
+(s/defschema AddLicensesCommand
+  (assoc CommandBase
+         :comment s/Str
+         :licenses [s/Num]))
+
 (s/defschema AddMemberCommand
   (assoc CommandBase
          :member {:userid UserId}))
@@ -90,6 +95,7 @@
   {#_:application.command/require-license
    :application.command/accept-invitation AcceptInvitationCommand
    :application.command/accept-licenses AcceptLicensesCommand
+   :application.command/add-licenses AddLicensesCommand
    :application.command/add-member AddMemberCommand
    :application.command/invite-member InviteMemberCommand
    :application.command/approve ApproveCommand

--- a/src/clj/rems/application/events.clj
+++ b/src/clj/rems/application/events.clj
@@ -72,7 +72,7 @@
   (assoc EventBase
          :event/type (s/enum :application.event/licenses-added)
          :application/comment s/Str
-         :application/licenses #{s/Int}))
+         :application/licenses [{:license/id s/Int}]))
 (s/defschema MemberAddedEvent
   (assoc EventBase
          :event/type (s/enum :application.event/member-added)

--- a/src/clj/rems/application/events.clj
+++ b/src/clj/rems/application/events.clj
@@ -68,6 +68,11 @@
   (assoc EventBase
          :event/type (s/enum :application.event/licenses-accepted)
          :application/accepted-licenses #{s/Int}))
+(s/defschema LicensesAddedEvent
+  (assoc EventBase
+         :event/type (s/enum :application.event/licenses-added)
+         :application/comment s/Str
+         :application/licenses #{s/Int}))
 (s/defschema MemberAddedEvent
   (assoc EventBase
          :event/type (s/enum :application.event/member-added)
@@ -115,6 +120,7 @@
    :application.event/decision-requested DecisionRequestedEvent
    :application.event/draft-saved DraftSavedEvent
    :application.event/licenses-accepted LicensesAcceptedEvent
+   :application.event/licenses-added LicensesAddedEvent
    :application.event/member-added MemberAddedEvent
    :application.event/member-invited MemberInvitedEvent
    :application.event/member-joined MemberJoinedEvent

--- a/src/clj/rems/application/model.clj
+++ b/src/clj/rems/application/model.clj
@@ -205,6 +205,7 @@
 (defmethod event-type-specific-application-view :application.event/licenses-added
   [application event]
   (-> application
+      (assoc :application/modified (:event/time event))
       (update :application/licenses
               (fn [licenses]
                 (->> (:application/licenses event)

--- a/src/clj/rems/application/model.clj
+++ b/src/clj/rems/application/model.clj
@@ -172,12 +172,9 @@
              :application/members #{}
              :application/past-members #{}
              :application/invitation-tokens {}
-             :application/resources (map (fn [resource]
-                                           {:catalogue-item/id (:catalogue-item/id resource)
-                                            :resource/ext-id (:resource/ext-id resource)})
+             :application/resources (map #(select-keys % [:catalogue-item/id :resource/ext-id])
                                          (:application/resources event))
-             :application/licenses (map (fn [license]
-                                          {:license/id (:license/id license)})
+             :application/licenses (map #(select-keys % [:license/id])
                                         (:application/licenses event))
              :application/accepted-licenses {}
              :application/events []

--- a/src/clj/rems/application/model.clj
+++ b/src/clj/rems/application/model.clj
@@ -205,9 +205,8 @@
       (assoc :application/modified (:event/time event))
       (update :application/licenses
               (fn [licenses]
-                (->> (:application/licenses event)
-                     (map (fn [license-id] {:license/id license-id}))
-                     (into licenses)
+                (-> licenses
+                    (into (:application/licenses event))
                      distinct
                      vec)))))
 

--- a/src/clj/rems/application/model.clj
+++ b/src/clj/rems/application/model.clj
@@ -210,8 +210,9 @@
               (fn [licenses]
                 (->> (:application/licenses event)
                      (map (fn [license-id] {:license/id license-id}))
-                     (concat licenses)
-                     distinct)))))
+                     (into licenses)
+                     distinct
+                     vec)))))
 
 (defmethod event-type-specific-application-view :application.event/member-invited
   [application event]

--- a/src/clj/rems/application/model.clj
+++ b/src/clj/rems/application/model.clj
@@ -38,6 +38,7 @@
                                                   :application.command/accept-licenses]
                                       :member [:application.command/accept-licenses]
                                       :handler [:see-everything
+                                                :application.command/add-licenses
                                                 :application.command/add-member
                                                 :application.command/remove-member
                                                 :application.command/invite-member
@@ -200,6 +201,16 @@
   (-> application
       (assoc :application/modified (:event/time event))
       (assoc-in [:application/accepted-licenses (:event/actor event)] (:application/accepted-licenses event))))
+
+(defmethod event-type-specific-application-view :application.event/licenses-added
+  [application event]
+  (-> application
+      (update :application/licenses
+              (fn [licenses]
+                (->> (:application/licenses event)
+                     (map (fn [license-id] {:license/id license-id}))
+                     (concat licenses)
+                     distinct)))))
 
 (defmethod event-type-specific-application-view :application.event/member-invited
   [application event]

--- a/src/clj/rems/workflow/dynamic.clj
+++ b/src/clj/rems/workflow/dynamic.clj
@@ -211,8 +211,7 @@
 
 (defmethod command-handler :application.command/accept-invitation
   [cmd application injections]
-  (or (invalid-user-error (:actor cmd) injections)
-      (already-member-error application (:actor cmd))
+  (or (already-member-error application (:actor cmd))
       (invitation-token-error application (:token cmd))
       (ok {:event/type :application.event/member-joined
            :application/id (:application-id cmd)

--- a/src/clj/rems/workflow/dynamic.clj
+++ b/src/clj/rems/workflow/dynamic.clj
@@ -189,6 +189,13 @@
              :application/request-id last-request-for-actor
              :application/comment (:comment cmd)}))))
 
+(defmethod command-handler :application.command/add-licenses
+  [cmd _application injections]
+  (or (must-not-be-empty cmd :licenses)
+      (ok {:event/type :application.event/licenses-added
+           :application/licenses (set (:licenses cmd))
+           :application/comment (:comment cmd)})))
+
 (defmethod command-handler :application.command/add-member
   [cmd application injections]
   (or (invalid-user-error (:userid (:member cmd)) injections)

--- a/src/clj/rems/workflow/dynamic.clj
+++ b/src/clj/rems/workflow/dynamic.clj
@@ -193,7 +193,7 @@
   [cmd _application injections]
   (or (must-not-be-empty cmd :licenses)
       (ok {:event/type :application.event/licenses-added
-           :application/licenses (set (:licenses cmd))
+           :application/licenses (mapv (fn [id] {:license/id id}) (:licenses cmd))
            :application/comment (:comment cmd)})))
 
 (defmethod command-handler :application.command/add-member

--- a/src/cljc/rems/text.cljc
+++ b/src/cljc/rems/text.cljc
@@ -68,6 +68,7 @@
    :application.event/decided :t.applications.events/decided
    :application.event/decision-requested :t.applications.events/decision-requested
    :application.event/draft-saved :t.applications.events/draft-saved
+   :application.event/licenses-added :t.applications.events/licenses-added
    :application.event/licenses-accepted :t.applications.events/licenses-accepted
    :application.event/member-added :t.applications.events/member-added
    :application.event/member-invited :t.applications.events/member-invited

--- a/src/cljs/rems/actions/add_licenses.cljs
+++ b/src/cljs/rems/actions/add_licenses.cljs
@@ -25,10 +25,10 @@
     ::fetch-licenses [(get-in db [:identity :user])
                       #(rf/dispatch [::set-potential-licenses %])]}))
 
-(defn- assoc-search-term
-  "Prepopulate a search term with localized names and unlocalized title"
+(defn- assoc-all-titles
+  "Prepopulate `:all-titles` property to facilitate searching with localized names and unlocalized title"
   [license]
-  (assoc license :search-term (str/join "" (conj (mapcat :title (vals (:localizations license)))
+  (assoc license :all-titles (str/join "" (conj (mapcat :title (vals (:localizations license)))
                                                  (:title license)))))
 
 (rf/reg-sub ::potential-licenses (fn [db _] (::potential-licenses db)))
@@ -36,7 +36,7 @@
  ::set-potential-licenses
  (fn [db [_ licenses]]
    (assoc db
-          ::potential-licenses (set (map assoc-search-term licenses))
+          ::potential-licenses (set (map assoc-all-titles licenses))
           ::selected-licenses #{})))
 
 (rf/reg-sub ::selected-licenses (fn [db _] (::selected-licenses db)))
@@ -94,7 +94,7 @@
        :item->key :id
        :item->text #(title-of-license % language)
        :item->value identity
-       :search-fields [:search-term]
+       :search-fields [:all-titles]
        :add-fn on-add-licenses
        :remove-fn on-remove-license}]]]])
 

--- a/src/cljs/rems/actions/add_licenses.cljs
+++ b/src/cljs/rems/actions/add_licenses.cljs
@@ -1,0 +1,116 @@
+(ns rems.actions.add-licenses
+  (:require [clojure.string :as str]
+            [re-frame.core :as rf]
+            [rems.actions.action :refer [action-button action-form-view action-comment button-wrapper collapse-action-form]]
+            [rems.autocomplete :as autocomplete]
+            [rems.status-modal :as status-modal]
+            [rems.text :refer [text]]
+            [rems.util :refer [fetch post!]]))
+
+(rf/reg-fx
+ ::fetch-licenses
+ (fn [[user on-success]]
+   (fetch "/api/licenses"
+          {:handler on-success
+           :headers {"x-rems-user-id" (:eppn user)}})))
+
+(rf/reg-event-fx
+ ::open-form
+ (fn
+   [{:keys [db]} _]
+   {:db (assoc db
+               ::comment ""
+               ::potential-licenses #{}
+               ::selected-licenses #{})
+    ::fetch-licenses [(get-in db [:identity :user])
+                      #(rf/dispatch [::set-potential-licenses %])]}))
+
+(defn- assoc-search-term
+  "Prepopulate a search term with localized names and unlocalized title"
+  [license]
+  (assoc license :search-term (str/join "" (conj (mapcat :title (vals (:localizations license)))
+                                                 (:title license)))))
+
+(rf/reg-sub ::potential-licenses (fn [db _] (::potential-licenses db)))
+(rf/reg-event-db
+ ::set-potential-licenses
+ (fn [db [_ licenses]]
+   (assoc db
+          ::potential-licenses (set (map assoc-search-term licenses))
+          ::selected-licenses #{})))
+
+(rf/reg-sub ::selected-licenses (fn [db _] (::selected-licenses db)))
+(rf/reg-event-db ::set-selected-licenses (fn [db [_ licenses]] (assoc db ::selected-licenses licenses)))
+(rf/reg-event-db ::add-selected-licenses (fn [db [_ license]] (update db ::selected-licenses conj license)))
+(rf/reg-event-db ::remove-selected-license (fn [db [_ license]] (update db ::selected-licenses disj license)))
+
+(rf/reg-sub ::comment (fn [db _] (::comment db)))
+(rf/reg-event-db ::set-comment (fn [db [_ value]] (assoc db ::comment value)))
+
+(def ^:private action-form-id "add-licenses")
+
+(rf/reg-event-fx
+ ::send-add-licenses
+ (fn [_ [_ {:keys [application-id licenses comment on-finished]}]]
+   (status-modal/common-pending-handler! (text :t.actions/add-licenses))
+   (post! "/api/applications/add-licenses"
+          {:params {:application-id application-id
+                    :comment comment
+                    :licenses (map :id licenses)}
+           :handler (partial status-modal/common-success-handler! (fn [_]
+                                                                    (collapse-action-form action-form-id)
+                                                                    (on-finished)))
+           :error-handler status-modal/common-error-handler!})
+   {}))
+
+(defn add-licenses-action-button []
+  [action-button {:id action-form-id
+                  :text (text :t.actions/add-licenses)
+                  :on-click #(rf/dispatch [::open-form])}])
+
+(defn title-of-license [license language]
+  (or (get-in license [:localizations language :title])
+      (:title license)))
+
+(defn add-licenses-view
+  [{:keys [selected-licenses potential-licenses comment language on-set-comment on-add-licenses on-remove-license on-send]}]
+  [action-form-view action-form-id
+   (text :t.actions/add-licenses)
+   [[button-wrapper {:id "add-licenses"
+                     :text (text :t.actions/add-licenses)
+                     :class "btn-primary"
+                     :on-click on-send}]]
+   [:div
+    [action-comment {:id action-form-id
+                     :label (text :t.form/add-comments-shown-to-applicant)
+                     :comment comment
+                     :on-comment on-set-comment}]
+    [:div.form-group
+     [:label (text :t.actions/licenses-selection)]
+     [autocomplete/component
+      {:value (sort-by #(title-of-license % language) selected-licenses)
+       :items potential-licenses
+       :value->text #(title-of-license %2 language)
+       :item->key :id
+       :item->text #(title-of-license % language)
+       :item->value identity
+       :search-fields [:search-term]
+       :add-fn on-add-licenses
+       :remove-fn on-remove-license}]]]])
+
+(defn add-licenses-form [application-id on-finished]
+  (let [selected-licenses @(rf/subscribe [::selected-licenses])
+        potential-licenses @(rf/subscribe [::potential-licenses])
+        comment @(rf/subscribe [::comment])
+        language @(rf/subscribe [:language])]
+    [add-licenses-view {:selected-licenses selected-licenses
+                        :potential-licenses potential-licenses
+                        :comment comment
+                        :language language
+                        :on-set-comment #(rf/dispatch [::set-comment %])
+                        :on-add-licenses #(rf/dispatch [::add-selected-licenses %])
+                        :on-remove-license #(rf/dispatch [::remove-selected-license %])
+                        :on-send #(rf/dispatch [::send-add-licenses {:application-id application-id
+                                                                     :licenses selected-licenses
+                                                                     :comment comment
+                                                                     :on-finished on-finished}])}]))

--- a/src/cljs/rems/application.cljs
+++ b/src/cljs/rems/application.cljs
@@ -4,6 +4,7 @@
             [re-frame.core :as rf]
             [rems.actions.accept-licenses :refer [accept-licenses-action-button]]
             [rems.actions.action :refer [action-button action-form-view action-comment action-collapse-id button-wrapper]]
+            [rems.actions.add-licenses :refer [add-licenses-action-button add-licenses-form]]
             [rems.actions.add-member :refer [add-member-action-button add-member-form]]
             [rems.actions.approve-reject :refer [approve-reject-action-button approve-reject-form]]
             [rems.actions.close :refer [close-action-button close-form]]
@@ -799,6 +800,7 @@
                               :application.command/decide [decide-action-button]
                               :application.command/request-comment [request-comment-action-button]
                               :application.command/comment [comment-action-button]
+                              :application.command/add-licenses [add-licenses-action-button]
                               :application.command/approve [approve-reject-action-button]
                               :application.command/reject [approve-reject-action-button]
                               :application.command/close [close-action-button]]]
@@ -817,6 +819,7 @@
                 [close-form app-id reload]
                 [decide-form app-id reload]
                 [return-form app-id reload]
+                [add-licenses-form app-id reload]
                 [approve-reject-form app-id reload]]]]
     (when (seq actions)
       [collapsible/component

--- a/test/clj/rems/api/test_applications.clj
+++ b/test/clj/rems/api/test_applications.clj
@@ -172,6 +172,7 @@
         handler-id "developer"
         commenter-id "carl"
         decider-id "bob"
+        license-id 5 ;; additional licenses from test data
         application-id 11] ;; submitted dynamic application from test data
 
     (testing "getting dynamic application as applicant"
@@ -244,6 +245,21 @@
                   comment-event (get-in application [:application/events (inc eventcount)])]
               (is (= (:application/request-id request-event)
                      (:application/request-id comment-event)))))))
+
+      (testing "adding and then accepting additonal licenses"
+        (let [eventcount (count (get (get-application application-id handler-id) :events))]
+          (testing "add licenses"
+            (is (= {:success true} (send-command handler-id
+                                                 {:type :application.command/add-licenses
+                                                  :application-id application-id
+                                                  :licenses [license-id]
+                                                  :comment "Please approve these new terms"}))))
+          (testing "applicant can now accept licenses"
+            (is (= {:success true} (send-command user-id
+                                                 {:type :application.command/accept-licenses
+                                                  :application-id application-id
+                                                  :accepted-licenses [license-id]}))))))
+
       (testing "request-decision"
         (is (= {:success true} (send-command handler-id
                                              {:type :application.command/request-decision
@@ -274,6 +290,8 @@
                     "application.event/submitted"
                     "application.event/comment-requested"
                     "application.event/commented"
+                    "application.event/licenses-added"
+                    "application.event/licenses-accepted"
                     "application.event/decision-requested"
                     "application.event/decided"
                     "application.event/approved"]
@@ -283,6 +301,8 @@
                     "application.event/licenses-accepted"
                     "application.event/draft-saved"
                     "application.event/submitted"
+                    "application.event/licenses-added"
+                    "application.event/licenses-accepted"
                     "application.event/approved"]
                    applicant-event-types))))))))
 

--- a/test/clj/rems/api/test_applications.clj
+++ b/test/clj/rems/api/test_applications.clj
@@ -195,6 +195,7 @@
                  "application.command/reject"
                  "application.command/approve"
                  "application.command/return"
+                 "application.command/add-licenses"
                  "application.command/add-member"
                  "application.command/remove-member"
                  "application.command/invite-member"

--- a/test/clj/rems/application/test_model.clj
+++ b/test/clj/rems/application/test_model.clj
@@ -7,114 +7,123 @@
   (:import [java.util UUID]
            [org.joda.time DateTime]))
 
+(def ^:private get-form
+  {40 {:id 40
+       :organization "org"
+       :title "form title"
+       :items [{:id 41
+                :localizations {:en {:title "en title"
+                                     :inputprompt "en placeholder"}
+                                :fi {:title "fi title"
+                                     :inputprompt "fi placeholder"}}
+                :optional false
+                :options []
+                :maxlength 100
+                :type "description"}
+               {:id 42
+                :localizations {:en {:title "en title"
+                                     :inputprompt "en placeholder"}
+                                :fi {:title "fi title"
+                                     :inputprompt "fi placeholder"}}
+                :optional false
+                :options []
+                :maxlength 100
+                :type "text"}]
+       :start (DateTime. 100)
+       :end nil}})
+
+(def ^:private get-catalogue-item
+  {10 {:id 10
+       :resource-id 11
+       :resid "urn:11"
+       :wfid 50
+       :formid 40
+       :title "non-localized title"
+       :localizations {:en {:id 10
+                            :langcode :en
+                            :title "en title"}
+                       :fi {:id 10
+                            :langcode :fi
+                            :title "fi title"}}
+       :start (DateTime. 100)
+       :end nil
+       :enabled true
+       :archived false
+       :expired false
+       :state "enabled"}
+   20 {:id 20
+       :resource-id 21
+       :resid "urn:21"
+       :wfid 50
+       :formid 40
+       :title "non-localized title"
+       :localizations {:en {:id 20
+                            :langcode :en
+                            :title "en title"}
+                       :fi {:id 20
+                            :langcode :fi
+                            :title "fi title"}}
+       :start (DateTime. 100)
+       :end nil
+       :enabled true
+       :archived false
+       :expired false
+       :state "enabled"}})
+
+(def ^:private get-license
+  {30 {:id 30
+       :licensetype "link"
+       :title "non-localized title"
+       :textcontent "http://non-localized-license-link"
+       :localizations {:en {:title "en title"
+                            :textcontent "http://en-license-link"}
+                       :fi {:title "fi title"
+                            :textcontent "http://fi-license-link"}}
+       :start (DateTime. 100)
+       :end nil
+       :enabled true
+       :expired false
+       :archived false}
+   31 {:id 31
+       :licensetype "text"
+       :title "non-localized title"
+       :textcontent "non-localized license text"
+       :localizations {:en {:title "en title"
+                            :textcontent "en license text"}
+                       :fi {:title "fi title"
+                            :textcontent "fi license text"}}
+       :start (DateTime. 100)
+       :end nil
+       :enabled true
+       :expired false
+       :archived false}
+   32 {:id 32
+       :licensetype "attachment"
+       :title "non-localized title"
+       :textcontent "non-localized filename"
+       :attachment-id 3200
+       :localizations {:en {:title "en title"
+                            :textcontent "en filename"
+                            :attachment-id 3201}
+                       :fi {:title "fi title"
+                            :textcontent "fi filename"
+                            :attachment-id 3202}}
+       :start (DateTime. 100)
+       :end nil
+       :enabled true
+       :expired false
+       :archived false}})
+
+(def ^:private get-user
+  {"applicant" {:eppn "applicant"
+                :mail "applicant@example.com"
+                :commonName "Applicant"}})
+
 (deftest test-application-view
-  (let [injections {:get-form {40 {:id 40
-                                   :organization "org"
-                                   :title "form title"
-                                   :items [{:id 41
-                                            :localizations {:en {:title "en title"
-                                                                 :inputprompt "en placeholder"}
-                                                            :fi {:title "fi title"
-                                                                 :inputprompt "fi placeholder"}}
-                                            :optional false
-                                            :options []
-                                            :maxlength 100
-                                            :type "description"}
-                                           {:id 42
-                                            :localizations {:en {:title "en title"
-                                                                 :inputprompt "en placeholder"}
-                                                            :fi {:title "fi title"
-                                                                 :inputprompt "fi placeholder"}}
-                                            :optional false
-                                            :options []
-                                            :maxlength 100
-                                            :type "text"}]
-                                   :start (DateTime. 100)
-                                   :end nil}}
-
-                    :get-catalogue-item {10 {:id 10
-                                             :resource-id 11
-                                             :resid "urn:11"
-                                             :wfid 50
-                                             :formid 40
-                                             :title "non-localized title"
-                                             :localizations {:en {:id 10
-                                                                  :langcode :en
-                                                                  :title "en title"}
-                                                             :fi {:id 10
-                                                                  :langcode :fi
-                                                                  :title "fi title"}}
-                                             :start (DateTime. 100)
-                                             :end nil
-                                             :enabled true
-                                             :archived false
-                                             :expired false
-                                             :state "enabled"}
-                                         20 {:id 20
-                                             :resource-id 21
-                                             :resid "urn:21"
-                                             :wfid 50
-                                             :formid 40
-                                             :title "non-localized title"
-                                             :localizations {:en {:id 20
-                                                                  :langcode :en
-                                                                  :title "en title"}
-                                                             :fi {:id 20
-                                                                  :langcode :fi
-                                                                  :title "fi title"}}
-                                             :start (DateTime. 100)
-                                             :end nil
-                                             :enabled true
-                                             :archived false
-                                             :expired false
-                                             :state "enabled"}}
-
-                    :get-license {30 {:id 30
-                                      :licensetype "link"
-                                      :title "non-localized title"
-                                      :textcontent "http://non-localized-license-link"
-                                      :localizations {:en {:title "en title"
-                                                           :textcontent "http://en-license-link"}
-                                                      :fi {:title "fi title"
-                                                           :textcontent "http://fi-license-link"}}
-                                      :start (DateTime. 100)
-                                      :end nil
-                                      :enabled true
-                                      :expired false
-                                      :archived false}
-                                  31 {:id 31
-                                      :licensetype "text"
-                                      :title "non-localized title"
-                                      :textcontent "non-localized license text"
-                                      :localizations {:en {:title "en title"
-                                                           :textcontent "en license text"}
-                                                      :fi {:title "fi title"
-                                                           :textcontent "fi license text"}}
-                                      :start (DateTime. 100)
-                                      :end nil
-                                      :enabled true
-                                      :expired false
-                                      :archived false}
-                                  32 {:id 32
-                                      :licensetype "attachment"
-                                      :title "non-localized title"
-                                      :textcontent "non-localized filename"
-                                      :attachment-id 3200
-                                      :localizations {:en {:title "en title"
-                                                           :textcontent "en filename"
-                                                           :attachment-id 3201}
-                                                      :fi {:title "fi title"
-                                                           :textcontent "fi filename"
-                                                           :attachment-id 3202}}
-                                      :start (DateTime. 100)
-                                      :end nil
-                                      :enabled true
-                                      :expired false
-                                      :archived false}}
-
-                    :get-user {"applicant" {:eppn "applicant"
-                                            :mail "applicant@example.com"
-                                            :commonName "Applicant"}}}
+  (let [injections {:get-form get-form
+                    :get-catalogue-item get-catalogue-item
+                    :get-license get-license
+                    :get-user get-user}
         apply-events (fn [events]
                        (let [application (-> events
                                              events/validate-events

--- a/test/clj/rems/application/test_model.clj
+++ b/test/clj/rems/application/test_model.clj
@@ -394,48 +394,7 @@
                                                         {:application/last-activity (DateTime. 3500)
                                                          :application/modified (DateTime. 3500)
                                                          :application/events events
-                                                         :application/licenses [{:license/id 30
-                                                                                 :license/type :link
-                                                                                 :license/title {:en "en title"
-                                                                                                 :fi "fi title"
-                                                                                                 :default "non-localized title"}
-                                                                                 :license/link {:en "http://en-license-link"
-                                                                                                :fi "http://fi-license-link"
-                                                                                                :default "http://non-localized-license-link"}
-                                                                                 :license/start (DateTime. 100)
-                                                                                 :license/end nil
-                                                                                 :license/expired false
-                                                                                 :license/enabled true
-                                                                                 :license/archived false}
-                                                                                {:license/id 31
-                                                                                 :license/type :text
-                                                                                 :license/title {:en "en title"
-                                                                                                 :fi "fi title"
-                                                                                                 :default "non-localized title"}
-                                                                                 :license/text {:en "en license text"
-                                                                                                :fi "fi license text"
-                                                                                                :default "non-localized license text"}
-                                                                                 :license/start (DateTime. 100)
-                                                                                 :license/end nil
-                                                                                 :license/expired false
-                                                                                 :license/enabled true
-                                                                                 :license/archived false}
-                                                                                {:license/id 32
-                                                                                 :license/type :attachment
-                                                                                 :license/title {:en "en title"
-                                                                                                 :fi "fi title"
-                                                                                                 :default "non-localized title"}
-                                                                                 :license/attachment-id {:en 3201
-                                                                                                         :fi 3202
-                                                                                                         :default 3200}
-                                                                                 :license/attachment-filename {:en "en filename"
-                                                                                                               :fi "fi filename"
-                                                                                                               :default "non-localized filename"}
-                                                                                 :license/start (DateTime. 100)
-                                                                                 :license/end nil
-                                                                                 :license/expired false
-                                                                                 :license/enabled true
-                                                                                 :license/archived false}
+                                                         :application/licenses (conj (:application/licenses expected-application)
                                                                                 {:license/id 33
                                                                                  :license/type :attachment
                                                                                  :license/title {:en "en title"
@@ -451,7 +410,7 @@
                                                                                  :license/end nil
                                                                                  :license/expired false
                                                                                  :license/enabled true
-                                                                                 :license/archived false}]})]
+                                                                                      :license/archived false})})]
                         (is (= expected-application (apply-events events)))
 
                         (testing "> approved"

--- a/test/clj/rems/application/test_model.clj
+++ b/test/clj/rems/application/test_model.clj
@@ -388,7 +388,7 @@
                                           :event/time (DateTime. 3500)
                                           :event/actor "handler"
                                           :application/id 1
-                                          :application/licenses #{33}
+                                          :application/licenses [{:license/id 33}]
                                           :application/comment "Please sign these terms also"})
                             expected-application (merge expected-application
                                                         {:application/last-activity (DateTime. 3500)

--- a/test/clj/rems/application/test_model.clj
+++ b/test/clj/rems/application/test_model.clj
@@ -112,6 +112,22 @@
        :end nil
        :enabled true
        :expired false
+       :archived false}
+   33 {:id 33
+       :licensetype "attachment"
+       :title "non-localized title"
+       :textcontent "non-localized filename"
+       :attachment-id 3300
+       :localizations {:en {:title "en title"
+                            :textcontent "en filename"
+                            :attachment-id 3301}
+                       :fi {:title "fi title"
+                            :textcontent "fi filename"
+                            :attachment-id 3302}}
+       :start (DateTime. 100)
+       :end nil
+       :enabled true
+       :expired false
        :archived false}})
 
 (def ^:private get-user
@@ -283,262 +299,348 @@
                                                       :application/last-activity (DateTime. 2500)
                                                       :application/events events
                                                       :application/accepted-licenses {"applicant" #{30 31 32}}})]
-                (is (= expected-application (apply-events events))))
+                (is (= expected-application (apply-events events)))
 
-              (testing "> submitted"
-                (let [events (conj events {:event/type :application.event/submitted
-                                           :event/time (DateTime. 3000)
-                                           :event/actor "applicant"
-                                           :application/id 1})
-                      expected-application (merge expected-application
-                                                  {:application/last-activity (DateTime. 3000)
-                                                   :application/events events
-                                                   :application/state :application.state/submitted})]
-                  (is (= expected-application (apply-events events)))
+                (testing "> submitted"
+                  (let [events (conj events {:event/type :application.event/submitted
+                                             :event/time (DateTime. 3000)
+                                             :event/actor "applicant"
+                                             :application/id 1})
+                        expected-application (merge expected-application
+                                                    {:application/last-activity (DateTime. 3000)
+                                                     :application/events events
+                                                     :application/state :application.state/submitted})]
+                    (is (= expected-application (apply-events events)))
 
-                  (testing "> returned"
-                    (let [events (conj events {:event/type :application.event/returned
-                                               :event/time (DateTime. 4000)
-                                               :event/actor "handler"
-                                               :application/id 1
-                                               :application/comment "fix stuff"})
-                          expected-application (deep-merge expected-application
-                                                           {:application/last-activity (DateTime. 4000)
-                                                            :application/events events
-                                                            :application/state :application.state/returned
-                                                            :application/form {:form/fields [{:field/previous-value "foo"}
-                                                                                             {:field/previous-value "bar"}]}})]
-                      (is (= expected-application (apply-events events)))
+                    (testing "> returned"
+                      (let [events (conj events {:event/type :application.event/returned
+                                                 :event/time (DateTime. 4000)
+                                                 :event/actor "handler"
+                                                 :application/id 1
+                                                 :application/comment "fix stuff"})
+                            expected-application (deep-merge expected-application
+                                                             {:application/last-activity (DateTime. 4000)
+                                                              :application/events events
+                                                              :application/state :application.state/returned
+                                                              :application/form {:form/fields [{:field/previous-value "foo"}
+                                                                                               {:field/previous-value "bar"}]}})]
+                        (is (= expected-application (apply-events events)))
 
-                      (testing "> draft saved x2"
-                        (let [events (conj events
-                                           {:event/type :application.event/draft-saved
-                                            :event/time (DateTime. 5000)
-                                            :event/actor "applicant"
-                                            :application/id 1
-                                            ;; non-submitted versions should not show up as the previous value
-                                            :application/field-values {41 "intermediate draft"
-                                                                       42 "intermediate draft"}}
-                                           {:event/type :application.event/draft-saved
-                                            :event/time (DateTime. 6000)
-                                            :event/actor "applicant"
-                                            :application/id 1
-                                            :application/field-values {41 "new foo"
-                                                                       42 "new bar"}})
-                              expected-application (deep-merge expected-application
-                                                               {:application/modified (DateTime. 6000)
-                                                                :application/last-activity (DateTime. 6000)
-                                                                :application/events events
-                                                                :application/description "new foo"
-                                                                :application/form {:form/fields [{:field/value "new foo"
-                                                                                                  :field/previous-value "foo"}
-                                                                                                 {:field/value "new bar"
-                                                                                                  :field/previous-value "bar"}]}})]
-                          (is (= expected-application (apply-events events)))
+                        (testing "> draft saved x2"
+                          (let [events (conj events
+                                             {:event/type :application.event/draft-saved
+                                              :event/time (DateTime. 5000)
+                                              :event/actor "applicant"
+                                              :application/id 1
+                                              ;; non-submitted versions should not show up as the previous value
+                                              :application/field-values {41 "intermediate draft"
+                                                                         42 "intermediate draft"}}
+                                             {:event/type :application.event/draft-saved
+                                              :event/time (DateTime. 6000)
+                                              :event/actor "applicant"
+                                              :application/id 1
+                                              :application/field-values {41 "new foo"
+                                                                         42 "new bar"}})
+                                expected-application (deep-merge expected-application
+                                                                 {:application/modified (DateTime. 6000)
+                                                                  :application/last-activity (DateTime. 6000)
+                                                                  :application/events events
+                                                                  :application/description "new foo"
+                                                                  :application/form {:form/fields [{:field/value "new foo"
+                                                                                                    :field/previous-value "foo"}
+                                                                                                   {:field/value "new bar"
+                                                                                                    :field/previous-value "bar"}]}})]
+                            (is (= expected-application (apply-events events)))
 
-                          (testing "> submitted"
-                            (let [events (conj events
-                                               {:event/type :application.event/submitted
-                                                :event/time (DateTime. 7000)
-                                                :event/actor "applicant"
-                                                :application/id 1})
-                                  expected-application (merge expected-application
-                                                              {:application/last-activity (DateTime. 7000)
-                                                               :application/events events
-                                                               :application/state :application.state/submitted})]
-                              (is (= expected-application (apply-events events)))))))
+                            (testing "> submitted"
+                              (let [events (conj events
+                                                 {:event/type :application.event/submitted
+                                                  :event/time (DateTime. 7000)
+                                                  :event/actor "applicant"
+                                                  :application/id 1})
+                                    expected-application (merge expected-application
+                                                                {:application/last-activity (DateTime. 7000)
+                                                                 :application/events events
+                                                                 :application/state :application.state/submitted})]
+                                (is (= expected-application (apply-events events)))))))
 
-                      (testing "> submitted (no draft saved)"
-                        (let [events (conj events
-                                           {:event/type :application.event/submitted
-                                            :event/time (DateTime. 7000)
-                                            :event/actor "applicant"
-                                            :application/id 1})
-                              expected-application (deep-merge expected-application
-                                                               {:application/last-activity (DateTime. 7000)
-                                                                :application/events events
-                                                                :application/state :application.state/submitted
-                                                                ;; when there was no draft-saved event, the current and
-                                                                ;; previous submitted answers must be the same
-                                                                :application/form {:form/fields [{:field/value "foo"
-                                                                                                  :field/previous-value "foo"}
-                                                                                                 {:field/value "bar"
-                                                                                                  :field/previous-value "bar"}]}})]
-                          (is (= expected-application (apply-events events)))))))
+                        (testing "> submitted (no draft saved)"
+                          (let [events (conj events
+                                             {:event/type :application.event/submitted
+                                              :event/time (DateTime. 7000)
+                                              :event/actor "applicant"
+                                              :application/id 1})
+                                expected-application (deep-merge expected-application
+                                                                 {:application/last-activity (DateTime. 7000)
+                                                                  :application/events events
+                                                                  :application/state :application.state/submitted
+                                                                  ;; when there was no draft-saved event, the current and
+                                                                  ;; previous submitted answers must be the same
+                                                                  :application/form {:form/fields [{:field/value "foo"
+                                                                                                    :field/previous-value "foo"}
+                                                                                                   {:field/value "bar"
+                                                                                                    :field/previous-value "bar"}]}})]
+                            (is (= expected-application (apply-events events)))))))
 
-                  (testing "> approved"
-                    (let [events (conj events
-                                       {:event/type :application.event/approved
-                                        :event/time (DateTime. 4000)
-                                        :event/actor "handler"
-                                        :application/id 1
-                                        :application/comment "looks good"})
-                          expected-application (merge expected-application
-                                                      {:application/last-activity (DateTime. 4000)
-                                                       :application/events events
-                                                       :application/state :application.state/approved})]
-                      (is (= expected-application (apply-events events)))
+                    (testing "> licenses added"
+                      (let [events (conj events
+                                         {:event/type :application.event/licenses-added
+                                          :event/time (DateTime. 3500)
+                                          :event/actor "handler"
+                                          :application/id 1
+                                          :application/licenses #{33}
+                                          :application/comment "Please sign these terms also"})
+                            expected-application (merge expected-application
+                                                        {:application/last-activity (DateTime. 3500)
+                                                         :application/modified (DateTime. 3500)
+                                                         :application/events events
+                                                         :application/licenses [{:license/id 30
+                                                                                 :license/type :link
+                                                                                 :license/title {:en "en title"
+                                                                                                 :fi "fi title"
+                                                                                                 :default "non-localized title"}
+                                                                                 :license/link {:en "http://en-license-link"
+                                                                                                :fi "http://fi-license-link"
+                                                                                                :default "http://non-localized-license-link"}
+                                                                                 :license/start (DateTime. 100)
+                                                                                 :license/end nil
+                                                                                 :license/expired false
+                                                                                 :license/enabled true
+                                                                                 :license/archived false}
+                                                                                {:license/id 31
+                                                                                 :license/type :text
+                                                                                 :license/title {:en "en title"
+                                                                                                 :fi "fi title"
+                                                                                                 :default "non-localized title"}
+                                                                                 :license/text {:en "en license text"
+                                                                                                :fi "fi license text"
+                                                                                                :default "non-localized license text"}
+                                                                                 :license/start (DateTime. 100)
+                                                                                 :license/end nil
+                                                                                 :license/expired false
+                                                                                 :license/enabled true
+                                                                                 :license/archived false}
+                                                                                {:license/id 32
+                                                                                 :license/type :attachment
+                                                                                 :license/title {:en "en title"
+                                                                                                 :fi "fi title"
+                                                                                                 :default "non-localized title"}
+                                                                                 :license/attachment-id {:en 3201
+                                                                                                         :fi 3202
+                                                                                                         :default 3200}
+                                                                                 :license/attachment-filename {:en "en filename"
+                                                                                                               :fi "fi filename"
+                                                                                                               :default "non-localized filename"}
+                                                                                 :license/start (DateTime. 100)
+                                                                                 :license/end nil
+                                                                                 :license/expired false
+                                                                                 :license/enabled true
+                                                                                 :license/archived false}
+                                                                                {:license/id 33
+                                                                                 :license/type :attachment
+                                                                                 :license/title {:en "en title"
+                                                                                                 :fi "fi title"
+                                                                                                 :default "non-localized title"}
+                                                                                 :license/attachment-id {:en 3301
+                                                                                                         :fi 3302
+                                                                                                         :default 3300}
+                                                                                 :license/attachment-filename {:en "en filename"
+                                                                                                               :fi "fi filename"
+                                                                                                               :default "non-localized filename"}
+                                                                                 :license/start (DateTime. 100)
+                                                                                 :license/end nil
+                                                                                 :license/expired false
+                                                                                 :license/enabled true
+                                                                                 :license/archived false}]})]
+                        (is (= expected-application (apply-events events)))
 
-                      (testing "> closed"
-                        (let [events (conj events
-                                           {:event/type :application.event/closed
-                                            :event/time (DateTime. 5000)
-                                            :event/actor "handler"
-                                            :application/id 1
-                                            :application/comment "the project is finished"})
-                              expected-application (merge expected-application
-                                                          {:application/last-activity (DateTime. 5000)
-                                                           :application/events events
-                                                           :application/state :application.state/closed})]
-                          (is (= expected-application (apply-events events)))))))
+                        (testing "> approved"
+                          (let [events (conj events
+                                             {:event/type :application.event/approved
+                                              :event/time (DateTime. 4000)
+                                              :event/actor "handler"
+                                              :application/id 1
+                                              :application/comment "looks good"})
+                                expected-application (merge expected-application
+                                                            {:application/last-activity (DateTime. 4000)
+                                                             :application/events events
+                                                             :application/state :application.state/approved})]
+                            (is (= expected-application (apply-events events)))
 
-                  (testing "> rejected"
-                    (let [events (conj events
-                                       {:event/type :application.event/rejected
-                                        :event/time (DateTime. 4000)
-                                        :event/actor "handler"
-                                        :application/id 1
-                                        :application/comment "never gonna happen"})
-                          expected-application (merge expected-application
-                                                      {:application/last-activity (DateTime. 4000)
-                                                       :application/events events
-                                                       :application/state :application.state/rejected})]
-                      (is (= expected-application (apply-events events)))))
+                            (testing "> licenses accepted"
+                              (let [events (conj events
+                                                 {:event/type :application.event/licenses-accepted
+                                                  :event/time (DateTime. 4500)
+                                                  :event/actor "applicant"
+                                                  :application/id 1
+                                                  :application/accepted-licenses #{30 31 32 33}})
+                                    expected-application (merge expected-application
+                                                                {:application/modified (DateTime. 4500)
+                                                                 :application/last-activity (DateTime. 4500)
+                                                                 :application/events events
+                                                                 :application/accepted-licenses {"applicant" #{30 31 32 33}}})]
+                                (is (= expected-application (apply-events events)))
 
-                  (testing "> comment requested"
-                    (let [request-id (UUID/fromString "4de6c2b0-bb2e-4745-8f92-bd1d1f1e8298")
-                          events (conj events
-                                       {:event/type :application.event/comment-requested
-                                        :event/time (DateTime. 4000)
-                                        :event/actor "handler"
-                                        :application/id 1
-                                        :application/request-id request-id
-                                        :application/commenters ["commenter"]
-                                        :application/comment "please comment"})
-                          expected-application (deep-merge expected-application
-                                                           {:application/last-activity (DateTime. 4000)
-                                                            :application/events events
-                                                            :application/workflow {:workflow.dynamic/awaiting-commenters #{"commenter"}}})]
-                      (is (= expected-application (apply-events events)))
+                                (testing "> closed"
+                                  (let [events (conj events
+                                                     {:event/type :application.event/closed
+                                                      :event/time (DateTime. 5000)
+                                                      :event/actor "handler"
+                                                      :application/id 1
+                                                      :application/comment "the project is finished"})
+                                        expected-application (merge expected-application
+                                                                    {:application/last-activity (DateTime. 5000)
+                                                                     :application/events events
+                                                                     :application/state :application.state/closed})]
+                                    (is (= expected-application (apply-events events)))))))))
 
-                      (testing "> commented"
-                        (let [events (conj events
-                                           {:event/type :application.event/commented
-                                            :event/time (DateTime. 5000)
-                                            :event/actor "commenter"
-                                            :application/id 1
-                                            :application/request-id request-id
-                                            :application/comment "looks good"})
-                              expected-application (deep-merge expected-application
-                                                               {:application/last-activity (DateTime. 5000)
-                                                                :application/events events
-                                                                :application/workflow {:workflow.dynamic/awaiting-commenters #{}}})]
-                          (is (= expected-application (apply-events events)))))))
+                        (testing "> rejected"
+                          (let [events (conj events
+                                             {:event/type :application.event/rejected
+                                              :event/time (DateTime. 4000)
+                                              :event/actor "handler"
+                                              :application/id 1
+                                              :application/comment "never gonna happen"})
+                                expected-application (merge expected-application
+                                                            {:application/last-activity (DateTime. 4000)
+                                                             :application/events events
+                                                             :application/state :application.state/rejected})]
+                            (is (= expected-application (apply-events events)))))
 
-                  (testing "> decision requested"
-                    (let [request-id (UUID/fromString "db9c7fd6-53be-4b04-b15d-a3a8e0a45e49")
-                          events (conj events
-                                       {:event/type :application.event/decision-requested
-                                        :event/time (DateTime. 4000)
-                                        :event/actor "handler"
-                                        :application/id 1
-                                        :application/request-id request-id
-                                        :application/deciders ["decider"]
-                                        :application/comment "please decide"})
-                          expected-application (deep-merge expected-application
-                                                           {:application/last-activity (DateTime. 4000)
-                                                            :application/events events
-                                                            :application/workflow {:workflow.dynamic/awaiting-deciders #{"decider"}}})]
-                      (is (= expected-application (apply-events events)))
+                        (testing "> comment requested"
+                          (let [request-id (UUID/fromString "4de6c2b0-bb2e-4745-8f92-bd1d1f1e8298")
+                                events (conj events
+                                             {:event/type :application.event/comment-requested
+                                              :event/time (DateTime. 4000)
+                                              :event/actor "handler"
+                                              :application/id 1
+                                              :application/request-id request-id
+                                              :application/commenters ["commenter"]
+                                              :application/comment "please comment"})
+                                expected-application (deep-merge expected-application
+                                                                 {:application/last-activity (DateTime. 4000)
+                                                                  :application/events events
+                                                                  :application/workflow {:workflow.dynamic/awaiting-commenters #{"commenter"}}})]
+                            (is (= expected-application (apply-events events)))
 
-                      (testing "> decided"
-                        (let [events (conj events
-                                           {:event/type :application.event/decided
-                                            :event/time (DateTime. 5000)
-                                            :event/actor "decider"
-                                            :application/id 1
-                                            :application/request-id request-id
-                                            :application/decision :approved
-                                            :application/comment "I approve this"})
-                              expected-application (deep-merge expected-application
-                                                               {:application/last-activity (DateTime. 5000)
-                                                                :application/events events
-                                                                :application/workflow {:workflow.dynamic/awaiting-deciders #{}}})]
-                          (is (= expected-application (apply-events events)))))))
+                            (testing "> commented"
+                              (let [events (conj events
+                                                 {:event/type :application.event/commented
+                                                  :event/time (DateTime. 5000)
+                                                  :event/actor "commenter"
+                                                  :application/id 1
+                                                  :application/request-id request-id
+                                                  :application/comment "looks good"})
+                                    expected-application (deep-merge expected-application
+                                                                     {:application/last-activity (DateTime. 5000)
+                                                                      :application/events events
+                                                                      :application/workflow {:workflow.dynamic/awaiting-commenters #{}}})]
+                                (is (= expected-application (apply-events events)))))))
 
-                  (testing "> member invited"
-                    (let [token "b187bda7b9da9053a5d8b815b029e4ba"
-                          events (conj events
-                                       {:event/type :application.event/member-invited
-                                        :event/time (DateTime. 4000)
-                                        :event/actor "applicant"
-                                        :application/id 1
-                                        :application/member {:name "Mr. Member"
-                                                             :email "member@example.com"}
-                                        :invitation/token token})
-                          expected-application (deep-merge expected-application
-                                                           {:application/last-activity (DateTime. 4000)
-                                                            :application/events events
-                                                            :application/invitation-tokens {token {:name "Mr. Member"
-                                                                                                   :email "member@example.com"}}})]
-                      (is (= expected-application (apply-events events)))
+                        (testing "> decision requested"
+                          (let [request-id (UUID/fromString "db9c7fd6-53be-4b04-b15d-a3a8e0a45e49")
+                                events (conj events
+                                             {:event/type :application.event/decision-requested
+                                              :event/time (DateTime. 4000)
+                                              :event/actor "handler"
+                                              :application/id 1
+                                              :application/request-id request-id
+                                              :application/deciders ["decider"]
+                                              :application/comment "please decide"})
+                                expected-application (deep-merge expected-application
+                                                                 {:application/last-activity (DateTime. 4000)
+                                                                  :application/events events
+                                                                  :application/workflow {:workflow.dynamic/awaiting-deciders #{"decider"}}})]
+                            (is (= expected-application (apply-events events)))
 
-                      (testing "> member uninvited"
-                        (let [events (conj events
-                                           {:event/type :application.event/member-uninvited
-                                            :event/time (DateTime. 5000)
-                                            :event/actor "applicant"
-                                            :application/id 1
-                                            :application/member {:name "Mr. Member"
-                                                                 :email "member@example.com"}
-                                            :application/comment "he left the project"})
-                              expected-application (merge expected-application
-                                                          {:application/last-activity (DateTime. 5000)
-                                                           :application/events events
-                                                           :application/invitation-tokens {}})]
-                          (is (= expected-application (apply-events events)))))
+                            (testing "> decided"
+                              (let [events (conj events
+                                                 {:event/type :application.event/decided
+                                                  :event/time (DateTime. 5000)
+                                                  :event/actor "decider"
+                                                  :application/id 1
+                                                  :application/request-id request-id
+                                                  :application/decision :approved
+                                                  :application/comment "I approve this"})
+                                    expected-application (deep-merge expected-application
+                                                                     {:application/last-activity (DateTime. 5000)
+                                                                      :application/events events
+                                                                      :application/workflow {:workflow.dynamic/awaiting-deciders #{}}})]
+                                (is (= expected-application (apply-events events)))))))
 
-                      (testing "> member joined"
-                        (let [events (conj events
-                                           {:event/type :application.event/member-joined
-                                            :event/time (DateTime. 5000)
-                                            :event/actor "member"
-                                            :application/id 1
-                                            :invitation/token token})
-                              expected-application (merge expected-application
-                                                          {:application/last-activity (DateTime. 5000)
-                                                           :application/events events
-                                                           :application/members #{{:userid "member"}}
-                                                           :application/invitation-tokens {}})]
-                          (is (= expected-application (apply-events events)))))))
+                        (testing "> member invited"
+                          (let [token "b187bda7b9da9053a5d8b815b029e4ba"
+                                events (conj events
+                                             {:event/type :application.event/member-invited
+                                              :event/time (DateTime. 4000)
+                                              :event/actor "applicant"
+                                              :application/id 1
+                                              :application/member {:name "Mr. Member"
+                                                                   :email "member@example.com"}
+                                              :invitation/token token})
+                                expected-application (deep-merge expected-application
+                                                                 {:application/last-activity (DateTime. 4000)
+                                                                  :application/events events
+                                                                  :application/invitation-tokens {token {:name "Mr. Member"
+                                                                                                         :email "member@example.com"}}})]
+                            (is (= expected-application (apply-events events)))
 
-                  (testing "> member added"
-                    (let [events (conj events
-                                       {:event/type :application.event/member-added
-                                        :event/time (DateTime. 4000)
-                                        :event/actor "handler"
-                                        :application/id 1
-                                        :application/member {:userid "member"}})
-                          expected-application (merge expected-application
-                                                      {:application/last-activity (DateTime. 4000)
-                                                       :application/events events
-                                                       :application/members #{{:userid "member"}}})]
-                      (is (= expected-application (apply-events events)))
+                            (testing "> member uninvited"
+                              (let [events (conj events
+                                                 {:event/type :application.event/member-uninvited
+                                                  :event/time (DateTime. 5000)
+                                                  :event/actor "applicant"
+                                                  :application/id 1
+                                                  :application/member {:name "Mr. Member"
+                                                                       :email "member@example.com"}
+                                                  :application/comment "he left the project"})
+                                    expected-application (merge expected-application
+                                                                {:application/last-activity (DateTime. 5000)
+                                                                 :application/events events
+                                                                 :application/invitation-tokens {}})]
+                                (is (= expected-application (apply-events events)))))
 
-                      (testing "> member removed"
-                        (let [events (conj events
-                                           {:event/type :application.event/member-removed
-                                            :event/time (DateTime. 5000)
-                                            :event/actor "applicant"
-                                            :application/id 1
-                                            :application/member {:userid "member"}
-                                            :application/comment "he left the project"})
-                              expected-application (merge expected-application
-                                                          {:application/last-activity (DateTime. 5000)
-                                                           :application/events events
-                                                           :application/members #{}
-                                                           :application/past-members #{{:userid "member"}}})]
-                          (is (= expected-application (apply-events events))))))))))))))))
+                            (testing "> member joined"
+                              (let [events (conj events
+                                                 {:event/type :application.event/member-joined
+                                                  :event/time (DateTime. 5000)
+                                                  :event/actor "member"
+                                                  :application/id 1
+                                                  :invitation/token token})
+                                    expected-application (merge expected-application
+                                                                {:application/last-activity (DateTime. 5000)
+                                                                 :application/events events
+                                                                 :application/members #{{:userid "member"}}
+                                                                 :application/invitation-tokens {}})]
+                                (is (= expected-application (apply-events events)))))))
+
+                        (testing "> member added"
+                          (let [events (conj events
+                                             {:event/type :application.event/member-added
+                                              :event/time (DateTime. 4000)
+                                              :event/actor "handler"
+                                              :application/id 1
+                                              :application/member {:userid "member"}})
+                                expected-application (merge expected-application
+                                                            {:application/last-activity (DateTime. 4000)
+                                                             :application/events events
+                                                             :application/members #{{:userid "member"}}})]
+                            (is (= expected-application (apply-events events)))
+
+                            (testing "> member removed"
+                              (let [events (conj events
+                                                 {:event/type :application.event/member-removed
+                                                  :event/time (DateTime. 5000)
+                                                  :event/actor "applicant"
+                                                  :application/id 1
+                                                  :application/member {:userid "member"}
+                                                  :application/comment "he left the project"})
+                                    expected-application (merge expected-application
+                                                                {:application/last-activity (DateTime. 5000)
+                                                                 :application/events events
+                                                                 :application/members #{}
+                                                                 :application/past-members #{{:userid "member"}}})]
+                                (is (= expected-application (apply-events events)))))))))))))))))))
 
 (deftest test-calculate-permissions
   ;; TODO: is this what we want? wouldn't it be useful to be able to write more than one comment?

--- a/test/clj/rems/workflow/test_dynamic.clj
+++ b/test/clj/rems/workflow/test_dynamic.clj
@@ -146,6 +146,29 @@
                         :actor applicant-user-id
                         :accepted-licenses #{1 2}})))))
 
+(deftest test-add-licenses
+  (let [application (apply-events nil [dummy-created-event
+                                       {:event/type :application.event/submitted
+                                        :event/time test-time
+                                        :event/actor applicant-user-id
+                                        :application/id 123}])]
+    (is (= [{:event/type :application.event/licenses-added
+             :event/time test-time
+             :event/actor handler-user-id
+             :application/id 123
+             :application/comment "comment"
+             :application/licenses #{1 2}}]
+           (ok-command application
+                       {:type :application.command/add-licenses
+                        :actor handler-user-id
+                        :comment "comment"
+                        :licenses [1 2]})))
+    (is (= {:errors [{:type :must-not-be-empty :key :licenses}]}
+           (fail-command application
+                         {:type :application.command/add-licenses
+                          :actor handler-user-id
+                          :comment "comment"
+                          :licenses []})))))
 
 (deftest test-submit
   (let [injections {:validate-form-answers fake-validate-form-answers}

--- a/test/clj/rems/workflow/test_dynamic.clj
+++ b/test/clj/rems/workflow/test_dynamic.clj
@@ -157,7 +157,7 @@
              :event/actor handler-user-id
              :application/id 123
              :application/comment "comment"
-             :application/licenses #{1 2}}]
+             :application/licenses [{:license/id 1} {:license/id 2}]}]
            (ok-command application
                        {:type :application.command/add-licenses
                         :actor handler-user-id

--- a/test/clj/rems/workflow/test_dynamic.clj
+++ b/test/clj/rems/workflow/test_dynamic.clj
@@ -136,16 +136,16 @@
 
 (deftest test-accept-licenses
   (let [application (apply-events nil [dummy-created-event])]
-    (testing "accepts licenses"
-      (is (= [{:event/type :application.event/licenses-accepted
-               :event/time test-time
-               :event/actor applicant-user-id
-               :application/id 123
-               :application/accepted-licenses #{1 2}}]
-             (ok-command application
-                         {:type :application.command/accept-licenses
-                          :actor applicant-user-id
-                          :accepted-licenses #{1 2}}))))))
+    (is (= [{:event/type :application.event/licenses-accepted
+             :event/time test-time
+             :event/actor applicant-user-id
+             :application/id 123
+             :application/accepted-licenses #{1 2}}]
+           (ok-command application
+                       {:type :application.command/accept-licenses
+                        :actor applicant-user-id
+                        :accepted-licenses #{1 2}})))))
+
 
 (deftest test-submit
   (let [injections {:validate-form-answers fake-validate-form-answers}


### PR DESCRIPTION
Implements #830 by the way of using the regular licenses.
- `add-licenses` command, `licenses-added` event and an action UI `add_licenses.cljs`.
- Regular accept licenses workflow for the acceptance part.

Open questions:
- Currently owner is able to add new licenses and a handler doesn't. Should it be possible for a handler to admin or how would an ad-hoc license for one application be created?
- Does not refactor adding licenses away from the created away. Perhaps it does not make sense after all.