### PR TITLE
fix extra translations in example-theme

### DIFF
--- a/example-theme/extra-translations/fi.edn
+++ b/example-theme/extra-translations/fi.edn
@@ -3,12 +3,9 @@
   :administration {:catalogue-item "Kielivara"
                    :catalogue-items "Kielivarat"
                    :create-catalogue-item "Uusi kielivara"}
-  :applications {:resource "Kielivara"}
   :cart {:apply-for-bundle "Hae näitä kielivaroja (%1 kpl) yhdessä "
          :header "%1 kielivaraa korissa"}
   :catalogue {:catalogue "Kielivarat"
               :header "Kielivarat"
               :apply-resources "Hae uusia kielivaroja"}
-  :form {:back "Takaisin kielivaroihin"}}
-  :navigation {:catalogue "Kielivarat"
-               :create-catalogue-item "Luo kielivara"}}
+  :navigation {:catalogue "Kielivarat"}}}

--- a/test/clj/rems/test_locales.clj
+++ b/test/clj/rems/test_locales.clj
@@ -99,7 +99,20 @@
     (let [translations (locales/load-translations {:languages [:en]
                                                    :translations-directory "translations/"
                                                    :theme-path "example-theme/theme.edn"})]
-      (is (= "Active" (getx-in translations [:en :t :administration :active]))))))
+      (is (= "Active" (getx-in translations [:en :t :administration :active])))))
+  ;; TODO: This should rather be part of validation of all custom themes, but
+  ;;   it's probably better to at least have it here than not at all.
+  (testing "extra translations don't add keys that are not defined in original"
+    (doseq [lang [:en :fi]]
+      (let [translations
+            (locales/load-translations {:languages [lang]
+                                        :translations-directory "translations/"
+                                        :theme-path "example-theme/theme.edn"})
+            translations-without-extras
+            (locales/load-translations {:languages [lang]
+                                        :translations-directory "translations/"})]
+        (is (= (map-structure translations)
+               (map-structure translations-without-extras)))))))
 
 (deftest theme-path-given-no-extra-translations
   (testing "translations work with theme-path in config and no extra-translations"


### PR DESCRIPTION
closes #1142 together with the corresponding change in rems-deploy repo

- there was an extra }, closing the definition of value for :t key
  before :navigation key was defined, causing an incorrect structure
  for the map

- also remove unused translations (i.e., those that are not defined
  in original translations)

- add test to robustify extra translations against typos and other
  errors that change the structure of the map