### PR TITLE
allow setting text-transform attribute in theme for big-navbar

### DIFF
--- a/src/clj/rems/css/styles.clj
+++ b/src/clj/rems/css/styles.clj
@@ -473,6 +473,7 @@
               :padding-right 0
               :letter-spacing (u/rem 0.015)
               :color (util/get-theme-attribute :navbar-color "#111")}]
+   [:#big-navbar {:text-transform (util/get-theme-attribute :big-navbar-text-transform "none")}]
    [(s/descendant :.navbar-text :.language-switcher)
     {:margin-right (u/rem 1)}]
    [:.example-page {:margin (u/rem 2)}]


### PR DESCRIPTION
closes #1155 together with corresponding change in rems-deploy repo