### PR TITLE
feat: optimize table filtering and rendering

### DIFF
--- a/src/cljs/rems/atoms.cljs
+++ b/src/cljs/rems/atoms.cljs
@@ -21,6 +21,9 @@
 (defn search-symbol []
   [:i.fa {:class "fa-search"}])
 
+(defn close-symbol []
+  [:i.fa {:class "fa-times"}])
+
 (defn textarea [attrs]
   [autosize/textarea (merge {:min-rows 5}
                             (update attrs :class #(str/trim (str "form-control " %))))])

--- a/src/cljs/rems/cart.cljs
+++ b/src/cljs/rems/cart.cljs
@@ -26,14 +26,10 @@
 (defn add-to-cart-button
   "Hiccup fragment that contains a button that adds the given item to the cart"
   [item]
-  (let [cart @(rf/subscribe [::cart])
-        disabled? (and cart (contains? (set (map :id cart)) (:id item)))]
     [:button.btn.btn-primary.add-to-cart
      {:type "submit"
-      :disabled disabled?
-      :class (if disabled? " disabled" "")
       :on-click #(rf/dispatch [::add-item item])}
-     (text :t.cart/add)]))
+   (text :t.cart/add)])
 
 (defn remove-from-cart-button
   "Hiccup fragment that contains a button that removes the given item from the cart"

--- a/src/cljs/rems/cart.cljs
+++ b/src/cljs/rems/cart.cljs
@@ -16,7 +16,9 @@
 (rf/reg-event-db
  ::add-item
  (fn [db [_ item]]
-   (update db ::cart conj item)))
+   (if (contains? (set (map :id (::cart db))) (:id item))
+     db
+     (update db ::cart conj item))))
 
 (rf/reg-event-db
  ::remove-item

--- a/src/cljs/rems/cart.cljs
+++ b/src/cljs/rems/cart.cljs
@@ -23,7 +23,7 @@
 (rf/reg-event-db
  ::remove-item
  (fn [db [_ item-id]]
-   (update db ::cart #(remove (comp (partial = item-id) :id) %))))
+   (update db ::cart #(remove (comp #{item-id} :id) %))))
 
 (defn add-to-cart-button
   "Hiccup fragment that contains a button that adds the given item to the cart"

--- a/src/cljs/rems/cart.cljs
+++ b/src/cljs/rems/cart.cljs
@@ -28,9 +28,9 @@
 (defn add-to-cart-button
   "Hiccup fragment that contains a button that adds the given item to the cart"
   [item]
-    [:button.btn.btn-primary.add-to-cart
-     {:type "submit"
-      :on-click #(rf/dispatch [::add-item item])}
+  [:button.btn.btn-primary.add-to-cart
+   {:type "submit"
+    :on-click #(rf/dispatch [::add-item item])}
    (text :t.cart/add)])
 
 (defn remove-from-cart-button

--- a/src/cljs/rems/table.cljs
+++ b/src/cljs/rems/table.cljs
@@ -76,27 +76,27 @@
         (keys column-definitions)))
 
 (deftest test-match-filter?
- (is (match-filter? {:id {:value :id}
-                     :description {:value :description}}
-                    "bar"
-                    {:id "foo"
-                     :description "bar"})
-     "matches")
- (is (not (match-filter? {:id {:value :id}
-                          :description {:value :its-a-trap
-                                        :filter-value :description}}
-                         "willnotmatch"
-                         {:id "foo"
-                          :its-a-trap "willnotmatch"
-                          :description "bar"}))
-     "doesn't match with value if filter-value is provided")
- (is (not (match-filter? {:id {:value :id}
-                          :description {:value :description
-                                        :filterable? false}}
-                         "shouldnotmatch"
-                         {:id "foo"
-                          :description "shouldnotmatch"}))
-     "doesn't match if filterable is false"))
+  (is (match-filter? {:id {:value :id}
+                      :description {:value :description}}
+                     "bar"
+                     {:id "foo"
+                      :description "bar"})
+      "matches")
+  (is (not (match-filter? {:id {:value :id}
+                           :description {:value :its-a-trap
+                                         :filter-value :description}}
+                          "willnotmatch"
+                          {:id "foo"
+                           :its-a-trap "willnotmatch"
+                           :description "bar"}))
+      "doesn't match with value if filter-value is provided")
+  (is (not (match-filter? {:id {:value :id}
+                           :description {:value :description
+                                         :filterable? false}}
+                          "shouldnotmatch"
+                          {:id "foo"
+                           :description "shouldnotmatch"}))
+      "doesn't match if filterable is false"))
 
 (defn match-filters? [column-definitions filters item]
   (every? (fn [filter-word]
@@ -137,11 +137,11 @@
         update-current-filters (fn [event]
                                  (set-filtering (assoc filtering :filters filters-new)))]
     [:div.flex-grow-1.d-flex
-    [:input.flex-grow-1
-     {:type "text"
-      :name "table-search"
+     [:input.flex-grow-1
+      {:type "text"
+       :name "table-search"
        :default-value filters-new
-      :placeholder ""
+       :placeholder ""
        :on-change (fn [event]
                     (set-filtering (assoc filtering :filters-new (-> event .-target .-value))))
        :on-blur update-current-filters
@@ -206,12 +206,12 @@
                                      (comparable-params new)))
     :reagent-render (fn [{:keys [column-definitions visible-columns sorting filtering id-function items class]}]
                       (let [{:keys [initial-sort sort-column sort-order]} sorting
-        {:keys [show-filters filters]} filtering]
-    [:tbody
-     (map (fn [item] ^{:key (id-function item)} [row (id-function item) column-definitions visible-columns item])
-          (cond->> items
-            (and initial-sort (not sort-column)) (apply-initial-sorting column-definitions initial-sort)
-            (and show-filters filters) (apply-filtering column-definitions filters)
+                            {:keys [show-filters filters]} filtering]
+                        [:tbody
+                         (map (fn [item] ^{:key (id-function item)} [row (id-function item) column-definitions visible-columns item])
+                              (cond->> items
+                                (and initial-sort (not sort-column)) (apply-initial-sorting column-definitions initial-sort)
+                                (and show-filters filters) (apply-filtering column-definitions filters)
                                 (and sorting sort-column) (apply-sorting column-definitions sort-column sort-order)))]))}))
 
 (defn component


### PR DESCRIPTION
- use separate close symbol
- only update the search results (which is slow) on enter, blur or
  clicking the new search button
- use Form 3 component to optimize the table rendering. Unfortunately
  the anonymous functions are not equal.
- empty the filters when closing
- buttons are not disabled anymore because that forces a re-render of the whole table
- shopping cart prevents adding same item multiple times