### PR TITLE
do not override column name "applicant" with "members" in example-theme

### DIFF
--- a/example-theme/extra-translations/en.edn
+++ b/example-theme/extra-translations/en.edn
@@ -1,3 +1,3 @@
 {:t
  {:administration {:catalogue-items "Catalogue"}
-  :actions {:applicant "Members"}}}
+  :create-license {:license-text "Licence text"}}}

--- a/test/clj/rems/test_locales.clj
+++ b/test/clj/rems/test_locales.clj
@@ -94,7 +94,7 @@
                                                    :translations-directory "translations/"
                                                    :theme-path "./example-theme/theme.edn"})]
       (is (= "Catalogue" (getx-in translations [:en :t :administration :catalogue-items])))
-      (is (= "Members" (getx-in translations [:en :t :actions :applicant])))))
+      (is (= "Licence text" (getx-in translations [:en :t :create-license :license-text])))))
   (testing "extra translations don't override keys that are not defined in extras"
     (let [translations (locales/load-translations {:languages [:en]
                                                    :translations-directory "translations/"


### PR DESCRIPTION
closes #1126 

instead, change test for overriding translations to use a translation
that changes American spelling to British spelling, less likely
to cause confusion.