### PR TITLE
Enable diff notification for attachements

### DIFF
--- a/src/cljs/rems/application.cljs
+++ b/src/cljs/rems/application.cljs
@@ -304,7 +304,7 @@
                [fields/field (assoc fld
                                     :on-change #(rf/dispatch [::set-field-value (:field/id fld) %])
                                     :on-set-attachment #(rf/dispatch [::save-attachment (:field/id fld) %1 %2])
-                                    :on-remove-attachment #(rf/dispatch [::remove-attachment (:field/id fld) %1 %2])
+                                    :on-remove-attachment #(rf/dispatch [::remove-attachment (:field/id fld) %])
                                     :on-toggle-diff #(rf/dispatch [::toggle-diff (:field/id fld)])
                                     :field/value (get field-values (:field/id fld))
                                     :diff (get show-diff (:field/id fld))

--- a/src/cljs/rems/fields.cljs
+++ b/src/cljs/rems/fields.cljs
@@ -1,9 +1,10 @@
 (ns rems.fields
   "UI components for form fields"
   (:require [clojure.string :as str]
+            [cljs-time.core :as time]
             [rems.atoms :refer [external-link textarea]]
             [rems.guide-utils :refer [lipsum-short lipsum-paragraphs]]
-            [rems.text :refer [localized text text-format]]
+            [rems.text :refer [localized text text-format localize-time]]
             [rems.util :refer [encode-option-keys decode-option-keys linkify]])
   (:require-macros [rems.guide-macros :refer [component-info example]]))
 
@@ -228,7 +229,7 @@
                                                   filename (.-name filecontent)
                                                   form-data (doto (js/FormData.)
                                                               (.append "file" filecontent))]
-                                              (on-change filename)
+                                              (on-change (str filename " (" (localize-time (time/now)) ")"))
                                               (on-set-attachment form-data title)))}]
                       [:button.btn.btn-secondary {:on-click click-upload}
                        (text :t.form/upload)]]
@@ -382,6 +383,38 @@
                      :field/type :attachment
                      :field/title {:en "Title"}
                      :field/value "test.txt"}]])
+   (example "field of type \"attachment\", previous and new file uploaded, diff shown"
+            [:form
+             [field {:app-id 5
+                     :field/id 6
+                     :field/type :attachment
+                     :field/title {:en "Title"}
+                     :field/value "new.txt"
+                     :field/previous-value "old.txt"
+                     :diff true}]])
+   (example "field of type \"attachment\", previous and new file uploaded, diff hidden"
+            [:form
+             [field {:app-id 5
+                     :field/id 6
+                     :field/type :attachment
+                     :field/title {:en "Title"}
+                     :field/value "new.txt"
+                     :field/previous-value "old.txt"}]])
+   (example "field of type \"attachment\", previous file uploaded, new deleted, diff shown"
+            [:form
+             [field {:app-id 5
+                     :field/id 6
+                     :field/type :attachment
+                     :field/title {:en "Title"}
+                     :field/previous-value "old.txt"
+                     :diff true}]])
+   (example "field of type \"attachment\", previous file uploaded, new deleted, diff hidden"
+            [:form
+             [field {:app-id 5
+                     :field/id 6
+                     :field/type :attachment
+                     :field/title {:en "Title"}
+                     :field/previous-value "old.txt"}]])
    (example "non-editable field of type \"attachment\""
             [:form
              [field {:app-id 5


### PR DESCRIPTION
Closes #978. Note that old versions of files are not saved, this merely
alerts the reader that the file has changed. Date and time is appended
to the name so that users wouldn't accidentally mask this by using a new
file with same name (there are no API level checks for this, so anyone
with a curl could fake it, though).

![image](https://user-images.githubusercontent.com/119247/56801653-a3f06f00-6826-11e9-9c53-8f7fa6236fbc.png)
