### PR TITLE
Transaction stuff

### DIFF
--- a/src/clj/rems/application/events_cache.clj
+++ b/src/clj/rems/application/events_cache.clj
@@ -12,24 +12,28 @@
 (defn new []
   (atom empty-cache))
 
+(defn- update-with-new-events [cached update-fn]
+  (conman/with-transaction [*db* {:isolation :serializable
+                                  :read-only? true}]
+    (let [new-events (applications/get-all-events-since (:last-processed-event-id cached))]
+      (if (empty? new-events)
+        cached
+        {:state (update-fn (:state cached) new-events)
+         :last-processed-event-id (:event/id (last new-events))}))))
+
 (defn refresh!
   "Refreshes the cache with new events and returns the latest state.
    `update-fn` should be a function which takes as parameters the previously
    cached state and a list of new events, and returns the updated state."
   [cache update-fn]
-  (conman/with-transaction [*db* {:isolation :serializable
-                                  :read-only? true}]
-    (let [cache-enabled? (atom? cache)
-          cached (if cache-enabled? @cache empty-cache)
-          new-events (applications/get-all-events-since (:last-processed-event-id cached))]
-      (if (empty? new-events)
-        (:state cached)
-        (let [updated {:state (update-fn (:state cached) new-events)
-                       :last-processed-event-id (:event/id (last new-events))}]
-          ;; with concurrent requests, only one of them will update the cache
-          (when cache-enabled?
-            (compare-and-set! cache cached updated))
-          (:state updated))))))
+  (let [cache-enabled? (atom? cache)
+        cached (if cache-enabled? @cache empty-cache)
+        updated (update-with-new-events cached update-fn)]
+    (when (and cache-enabled?
+               (not (identical? cached updated)))
+      ;; with concurrent requests, only one of them will update the cache
+      (compare-and-set! cache cached updated))
+    (:state updated)))
 
 (defn empty! [cache]
   (when (atom? cache)


### PR DESCRIPTION
"When relying on Serializable transactions to prevent anomalies, it is
important that any data read from a permanent user table not be
considered valid until the transaction which read it has successfully
committed. This is true even for read-only transactions"
https://www.postgresql.org/docs/11/transaction-iso.html