### PR TITLE
"More options" ellipsis using CSS

### DIFF
--- a/src/clj/rems/css/styles.clj
+++ b/src/clj/rems/css/styles.clj
@@ -526,14 +526,7 @@
    [(s/> :.form-actions "*:not(:first-child)")
     (s/> :.commands "*:not(:first-child)")
     {:margin-left (u/em 0.5)}]
-   [".btn-opens-more::after" {:display "inline-block"
-                              :font-style "normal"
-                              :font-variant "normal"
-                              :text-rendering "auto"
-                              :-webkit-font-smoothing "antialiased"
-                              :font-family "'Font Awesome 5 Free'"
-                              :font-weight 900
-                              :content "'\\a0\\f141'"}] ; nbsp and ellipsis-h
+   [".btn-opens-more::after" {:content "'...'"}]
 
    ;; form inputs
    ["input[type=date].form-control" {:width (u/em 12)}]

--- a/src/clj/rems/css/styles.clj
+++ b/src/clj/rems/css/styles.clj
@@ -526,14 +526,14 @@
    [(s/> :.form-actions "*:not(:first-child)")
     (s/> :.commands "*:not(:first-child)")
     {:margin-left (u/em 0.5)}]
-   [".more-options::after" {:display "inline-block"
-                            :font-style "normal"
-                            :font-variant "normal"
-                            :text-rendering "auto"
-                            :-webkit-font-smoothing "antialiased"
-                            :font-family "'Font Awesome 5 Free'"
-                            :font-weight 900
-                            :content "'\\a0\\f141'"}] ; nbsp and ellipsis-h
+   [".btn-opens-more::after" {:display "inline-block"
+                              :font-style "normal"
+                              :font-variant "normal"
+                              :text-rendering "auto"
+                              :-webkit-font-smoothing "antialiased"
+                              :font-family "'Font Awesome 5 Free'"
+                              :font-weight 900
+                              :content "'\\a0\\f141'"}] ; nbsp and ellipsis-h
 
    ;; form inputs
    ["input[type=date].form-control" {:width (u/em 12)}]

--- a/src/clj/rems/css/styles.clj
+++ b/src/clj/rems/css/styles.clj
@@ -335,7 +335,7 @@
      :background-color "#aaa"
      :border-color "#aaa"}]
    [:.button-min-width {:min-width (u/rem 5)}]
-   [:.icon-link {:color "#6c757d"  ; same color as bootstrap's default for .btn-secondary
+   [:.icon-link {:color "#6c757d" ; same color as bootstrap's default for .btn-secondary
                  :cursor "pointer"}
     [:&:hover {:color "#5a6268"}]]
    [:.modal--title [:.link
@@ -526,6 +526,14 @@
    [(s/> :.form-actions "*:not(:first-child)")
     (s/> :.commands "*:not(:first-child)")
     {:margin-left (u/em 0.5)}]
+   [".more-options::after" {:display "inline-block"
+                            :font-style "normal"
+                            :font-variant "normal"
+                            :text-rendering "auto"
+                            :-webkit-font-smoothing "antialiased"
+                            :font-family "'Font Awesome 5 Free'"
+                            :font-weight 900
+                            :content "'\\a0\\f141'"}] ; nbsp and ellipsis-h
 
    ;; form inputs
    ["input[type=date].form-control" {:width (u/em 12)}]

--- a/src/cljs/rems/actions/action.cljs
+++ b/src/cljs/rems/actions/action.cljs
@@ -49,9 +49,10 @@
 (defn action-button [{:keys [id text class on-click]}]
   [:button.btn.mr-3
    {:id (str id "-action-button")
-    :class (or class "btn-secondary")
+    :class (str (or class "btn-secondary")
+                " more-options")
     :type "button"
     :data-toggle "collapse"
     :data-target (str "#" (action-collapse-id id))
     :on-click on-click}
-   (str text " ...")])
+   text])

--- a/src/cljs/rems/actions/action.cljs
+++ b/src/cljs/rems/actions/action.cljs
@@ -50,7 +50,7 @@
   [:button.btn.mr-3
    {:id (str id "-action-button")
     :class (str (or class "btn-secondary")
-                " more-options")
+                " btn-opens-more")
     :type "button"
     :data-toggle "collapse"
     :data-target (str "#" (action-collapse-id id))

--- a/src/cljs/rems/application.cljs
+++ b/src/cljs/rems/application.cljs
@@ -17,7 +17,7 @@
             [rems.actions.request-decision :refer [request-decision-action-button request-decision-form]]
             [rems.actions.return-action :refer [return-action-button return-form]]
             [rems.application-util :refer [accepted-licenses? form-fields-editable?]]
-            [rems.atoms :refer [external-link more-options flash-message info-field readonly-checkbox textarea]]
+            [rems.atoms :refer [external-link flash-message info-field readonly-checkbox textarea]]
             [rems.catalogue-util :refer [get-catalogue-item-title]]
             [rems.collapsible :as collapsible]
             [rems.common-util :refer [index-by]]
@@ -268,7 +268,7 @@
                                      :href (str "#collapse" id)
                                      :aria-expanded "false"
                                      :aria-controls (str "collapse" id)}
-        title " " (more-options)]]
+        title]]
       [:div.collapse {:id (str "collapse" id)}
        [:div.license-block (str/trim (str text))]]]]))
 

--- a/src/cljs/rems/application.cljs
+++ b/src/cljs/rems/application.cljs
@@ -17,7 +17,7 @@
             [rems.actions.request-decision :refer [request-decision-action-button request-decision-form]]
             [rems.actions.return-action :refer [return-action-button return-form]]
             [rems.application-util :refer [accepted-licenses? form-fields-editable?]]
-            [rems.atoms :refer [external-link flash-message info-field readonly-checkbox textarea]]
+            [rems.atoms :refer [external-link more-options flash-message info-field readonly-checkbox textarea]]
             [rems.catalogue-util :refer [get-catalogue-item-title]]
             [rems.collapsible :as collapsible]
             [rems.common-util :refer [index-by]]
@@ -268,7 +268,7 @@
                                      :href (str "#collapse" id)
                                      :aria-expanded "false"
                                      :aria-controls (str "collapse" id)}
-        title " " [:i {:class "fa fa-ellipsis-h"}]]]
+        title " " (more-options)]]
       [:div.collapse {:id (str "collapse" id)}
        [:div.license-block (str/trim (str text))]]]]))
 

--- a/src/cljs/rems/atoms.cljs
+++ b/src/cljs/rems/atoms.cljs
@@ -7,9 +7,6 @@
 (defn external-link []
   [:i {:class "fa fa-external-link-alt"}])
 
-(defn more-options []
-  [:i {:class "fa fa-ellipsis-h"}])
-
 (defn link-to [opts uri title]
   [:a (merge opts {:href uri}) title])
 

--- a/src/cljs/rems/atoms.cljs
+++ b/src/cljs/rems/atoms.cljs
@@ -7,6 +7,9 @@
 (defn external-link []
   [:i {:class "fa fa-external-link-alt"}])
 
+(defn more-options []
+  [:i {:class "fa fa-ellipsis-h"}])
+
 (defn link-to [opts uri title]
   [:a (merge opts {:href uri}) title])
 


### PR DESCRIPTION
This changes the "..." in buttons to be produced using CSS, so that it could be hidden using theme specific CSS:

```css
.btn-opens-more::after {
    content: "";
}
```

See #1176