### PR TITLE
Fix Firefox not showing the last columns on admin catalogue items page

### DIFF
--- a/src/clj/rems/css/styles.clj
+++ b/src/clj/rems/css/styles.clj
@@ -146,8 +146,7 @@
    [:.table-border {:padding 0
                     :margin "1em 0"
                     :border (util/get-theme-attribute :table-border "1px solid #ccc")
-                    :border-radius (u/rem 0.4)
-                    :overflow :hidden}]
+                    :border-radius (u/rem 0.4)}]
    [:.rems-table {:min-width "100%"
                   :background-color (util/get-theme-attribute :table-bgcolor :color1)
                   :box-shadow (util/get-theme-attribute :table-shadow)


### PR DESCRIPTION
Closes #1179

This PR makes them visible. Alternatively, using overflow: auto would add a horizontal scroll bar, though you could not see it when it's at the bottom of the page.

In the long term, adjusting the page max width or removing columns would produce a cleaner outcome.

![after](https://user-images.githubusercontent.com/42678/56904544-28512500-6aa7-11e9-8fb4-c8e09b55a110.png)
