### PR TITLE
Fix keyboard navigation for "Show more/less" links

### DIFF
--- a/src/cljs/rems/collapsible.cljs
+++ b/src/cljs/rems/collapsible.cljs
@@ -10,19 +10,25 @@
 (defn- show-more-button
   [id expanded callback]
   [:div.mb-3.collapse.collapse-toggle {:class (str (str id "more ") (when-not expanded "show"))}
-   [:a {:on-click #(do (.collapse (js/$ (str "#" id "collapse")) "show")
-                       (.collapse (js/$ (str "." id "more")) "hide")
-                       (when callback
-                         (callback))
-                       (.collapse (js/$ (str "." id "less")) "show"))}
+   [:a {:href "#"
+        :on-click (fn [event]
+                    (.preventDefault event)
+                    (.collapse (js/$ (str "#" id "collapse")) "show")
+                    (.collapse (js/$ (str "." id "more")) "hide")
+                    (when callback
+                      (callback))
+                    (.collapse (js/$ (str "." id "less")) "show"))}
     (text :t.collapse/show-more)]])
 
 (defn- show-less-button
   [id expanded]
   [:div.mb-3.collapse.collapse-toggle {:class (str (str id "less ") (when expanded "show"))}
-   [:a {:on-click #(do (.collapse (js/$ (str "#" id "collapse")) "hide")
-                       (.collapse (js/$ (str "." id "more")) "show")
-                       (.collapse (js/$ (str "." id "less")) "hide"))}
+   [:a {:href "#"
+        :on-click (fn [event]
+                    (.preventDefault event)
+                    (.collapse (js/$ (str "#" id "collapse")) "hide")
+                    (.collapse (js/$ (str "." id "more")) "show")
+                    (.collapse (js/$ (str "." id "less")) "hide"))}
     (text :t.collapse/show-less)]])
 
 (defn- block [id expanded callback content-always content-hideable content-footer top-less-button? bottom-less-button?]


### PR DESCRIPTION
It was not possible to focus the links with Tab.

#1172