### PR TITLE
rems.modal: ensure modal title and buttons stay visible

### DIFF
--- a/src/cljs/rems/modal.cljs
+++ b/src/cljs/rems/modal.cljs
@@ -44,7 +44,8 @@
                            [:i.fa.fa-times {:style {:margin 0}}]]]
                   :title-class title-class
                   :always [:div.full
-                           [:div.modal--content content]
+                           ;; max-height in order to keep header and controls visible
+                           [:div.modal--content {:style {:max-height "70vh" :overflow :auto}} content]
                            (into [:div.modal--commands.commands {:style {:padding 0}}]
                                  commands)]
                   :open? true}]]


### PR DESCRIPTION
even with lots of content

for some reason, setting a max-height in shade-wrapper didn't work

fixes #1238