### PR TITLE
Visible focus indicators

### DIFF
--- a/resources/translations/en.edn
+++ b/resources/translations/en.edn
@@ -303,6 +303,7 @@
           :text "Login by using your Haka credentials"
           :title "Login"}
   :missing "Missing translation %1"
+  :modal {:close-dialog "Close dialog"}
   :navigation {:about "About"
                :actions "Actions"
                :administration "Administration"

--- a/resources/translations/fi.edn
+++ b/resources/translations/fi.edn
@@ -303,6 +303,7 @@
           :text "Kirjaudu sisään Haka-tunnuksillasi"
           :title "Kirjaudu sisään"}
   :missing "Käännös puuttuu %1"
+  :modal {:close-dialog "Sulje ilmoitus"}
   :navigation {:about "Info"
                :actions "Toiminnot"
                :administration "Ylläpito"

--- a/src/clj/rems/css/styles.clj
+++ b/src/clj/rems/css/styles.clj
@@ -299,6 +299,11 @@
    [:.main-content.page-create-form {:max-width :unset}]
    [(s/> :.spaced-sections "*:not(:first-child)") {:margin-top (u/rem 1)}]
    [:.btn {:white-space :nowrap}]
+   ;; Bootstrap has inaccessible focus indicators in particular
+   ;; for .btn-link and .btn-secondary, so we define our own.
+   [:a:focus :button:focus :.btn.focus :.btn:focus
+    {:outline 0
+     :box-shadow "0 0 0 0.2rem rgba(38,143,255,.5) !important"}]
    [:.btn-primary
     [:&:hover
      :&:focus

--- a/src/cljs/rems/language_switcher.cljs
+++ b/src/cljs/rems/language_switcher.cljs
@@ -6,8 +6,8 @@
 
 (defn lang-link-classes [current-language language]
   (if (= current-language language)
-    "nav-link active"
-    "nav-link"))
+    "btn btn-link active"
+    "btn btn-link"))
 
 (defn language-switcher
   "Language switcher widget"
@@ -18,13 +18,9 @@
           (for [language languages]
             (let [lang-str (str/upper-case (name language))]
               [:form.inline
-               [:a {:href "#"
-                    :on-click (fn [event]
-                                (.preventDefault event)
-                                (rf/dispatch [:set-current-language language]))
-                    :class (lang-link-classes current-language language)
-                    :style {:padding 0}}
-                lang-str]])))))
+               #_(anti-forgery-field)
+               [:button {:class (lang-link-classes current-language language) :type "button"
+                         :on-click #(rf/dispatch [:set-current-language language])} lang-str]])))))
 
 (defn guide []
   [:div

--- a/src/cljs/rems/language_switcher.cljs
+++ b/src/cljs/rems/language_switcher.cljs
@@ -6,8 +6,8 @@
 
 (defn lang-link-classes [current-language language]
   (if (= current-language language)
-    "btn btn-link active"
-    "btn btn-link"))
+    "nav-link active"
+    "nav-link"))
 
 (defn language-switcher
   "Language switcher widget"
@@ -18,9 +18,13 @@
           (for [language languages]
             (let [lang-str (str/upper-case (name language))]
               [:form.inline
-               #_(anti-forgery-field)
-               [:button {:class (lang-link-classes current-language language) :type "button"
-                         :on-click #(rf/dispatch [:set-current-language language])} lang-str]])))))
+               [:a {:href "#"
+                    :on-click (fn [event]
+                                (.preventDefault event)
+                                (rf/dispatch [:set-current-language language]))
+                    :class (lang-link-classes current-language language)
+                    :style {:padding 0}}
+                lang-str]])))))
 
 (defn guide []
   [:div

--- a/src/cljs/rems/modal.cljs
+++ b/src/cljs/rems/modal.cljs
@@ -40,7 +40,8 @@
                                                      :space-between
                                                      :align-items :center}}
                           title
-                          [:button.btn.btn-link.link.ml-3 {:on-click on-close}
+                          [:button.btn.btn-link.link.ml-3 {:on-click on-close
+                                                           :aria-label (text :t.modal/close-dialog)}
                            [:i.fa.fa-times {:style {:margin 0}}]]]
                   :title-class title-class
                   :always [:div.full


### PR DESCRIPTION
Closes #1213

- Adds focus indicators to language switcher and modal close button
- Makes the focus indicators of secondary buttons more visible
- Makes the focus indicators be the same on all browsers
- Add aria label for close dialog button