### PR TITLE
chore: bump lein-uberwar to fix leiningen problem

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -79,7 +79,7 @@
             [lein-cprop "1.0.3"]
             [lein-npm "0.6.2"]
             [lein-shell "0.5.0"]
-            [lein-uberwar "0.2.0"]
+            [lein-uberwar "0.2.1"]
             [migratus-lein "0.5.7"]]
 
   :clean-targets ["target"]


### PR DESCRIPTION
Closes #1245 

Since we use the latest build image from Circle that doesn't include Leiningen 2.9.1. we don't have this in CI yet.