### PR TITLE
a couple of changes to the styling to improve accessibility

### DIFF
--- a/example-theme/theme.edn
+++ b/example-theme/theme.edn
@@ -55,4 +55,6 @@
  :table-shadow "10px -12px 21px -14px rgba(0,0,0,0.75)"
  :link-color "#025b96"
  :footer-color "#595959"
- :footer-bgcolor "#dfe1e3"}
+ :footer-bgcolor "#dfe1e3"
+ :button-font-weight 400
+ :link-font-weight 400}

--- a/src/clj/rems/css/styles.clj
+++ b/src/clj/rems/css/styles.clj
@@ -303,7 +303,13 @@
                     :flex-grow 1}]
    [:.main-content.page-create-form {:max-width :unset}]
    [(s/> :.spaced-sections "*:not(:first-child)") {:margin-top (u/rem 1)}]
-   [:.btn {:white-space :nowrap}]
+   [:.btn {:white-space :nowrap
+           ;; Default font-weight to 700 so the text is considered
+           ;; 'large text' and thus requires smaller contrast ratio for
+           ;; accessibility.
+           :font-weight
+           (util/get-theme-attribute :button-font-weight 700)
+           :font-size (u/px 18)}]
    ;; Bootstrap has inaccessible focus indicators in particular
    ;; for .btn-link and .btn-secondary, so we define our own.
    [:a:focus :button:focus :.btn.focus :.btn:focus
@@ -404,7 +410,8 @@
                   :background-color (util/get-theme-attribute :alert-dark-bgcolor)
                   :border-color (util/get-theme-attribute :alert-dark-bordercolor :alert-dark-color)}]
    [:.navbar
-    {:max-width content-width}
+    {:max-width content-width
+     :font-size (u/px 18)}
     [:.nav-link :.btn-link
      {:background-color :inherit}]]
    [:.navbar-top-bar {:width (u/percent 100)
@@ -415,10 +422,16 @@
                        :background-color (util/get-theme-attribute :color4)}]
    [:.navbar-top-right {:flex 1
                         :background-color (util/get-theme-attribute :color2)}]
+   [:.navbar-text {:font-size (u/px 16)}]
    [:.navbar-toggler {:border-color (util/get-theme-attribute :color1)}]
    [:.nav-link
     :.btn-link
     {:color (util/get-theme-attribute :nav-color :link-color :color3)
+     ;; Default font-weight to 700 so the text is considered
+     ;; 'large text' and thus requires smaller contrast ratio for
+     ;; accessibility.
+     :font-weight
+     (util/get-theme-attribute :link-font-weight 700)
      :border 0} ; for button links
     [:&.active
      {:color (util/get-theme-attribute :nav-active-color :color4)}]
@@ -439,7 +452,8 @@
                                  :background-position [[:center :center]]
                                  :background-origin (util/get-theme-attribute :logo-content-origin)
                                  :padding-left (u/px 20)
-                                 :padding-right (u/px 20)}]
+                                 :padding-right (u/px 20)
+                                 :padding-top (u/px 8)}]
    [:footer {:width "100%"
              :height (u/px 53.6)
              :color (util/get-theme-attribute :footer-color :table-heading-color "#fff")


### PR DESCRIPTION
- use font-size 18px instead of 16px in navbar (navigation links,
  language switcher, user-name and sign out button)

- add padding-top to the logo to compensate for the changes
  a larger font does in displaying the logo

- however, use font-size 16px in page footer, which displays some
  plain text

- default to showing all text in navbar links and buttons using
  font-weight 700. together with font-size 18px, this makes the text
  "large text", thus easing up contrast ratio requirements for
  accessibility.

- add the option to set the font-weight for navbar links and buttons in
  theme so that lighter text can be used when the color theme has high
  enough contrast for that.

- set example theme to use such lighter text