### PR TITLE
Change text-highlight color from lightened color4 to color3

### DIFF
--- a/src/clj/rems/css/styles.clj
+++ b/src/clj/rems/css/styles.clj
@@ -185,7 +185,10 @@
                   :font-weight "bold"}]
    [:.cart-item {:padding-right (u/em 1)}
     [:>span {:display :inline-block :vertical-align :middle}]]
-   [:.text-highlight {:color (when (util/get-theme-attribute :color4) (c/lighten (util/get-theme-attribute :color4) 20))}]))
+   ;; TODO: Change naming of :color3? It is used as text color here,
+   ;;   which means that it should have a good contrast with light background.
+   ;;   This could be made explicit by changing the name accordingly.
+   [:.text-highlight {:color (util/get-theme-attribute :color3)}]))
 
 (def ^:private dashed-form-group {:position "relative"
                                   :border "2px dashed #ccc"


### PR DESCRIPTION
The vague idea here is that color3 could be such that it has good
contrast with many different backgrounds, making it useful as a
text color in normal-sized text, whereas color4 would not need to
have that. Maybe color3/4 could be renamed in the future to reflect
those properties.