### PR TITLE
Define button type to avoid browser-specific defaults

### DIFF
--- a/src/clj/rems/auth/ldap.clj
+++ b/src/clj/rems/auth/ldap.clj
@@ -52,7 +52,7 @@
     [:input.form-control {:type "text" :placeholder (text :t.ldap/username) :name "username" :required true}]
     [:input.form-control {:type "password" :placeholder (text :t.ldap/password) :name "password" :required true}]
     (anti-forgery-field)
-    [:button.btn.btn-lg.btn-primary.btn-block {:type "submit"} (text :t.ldap/login)]]])
+    [:button.btn.btn-lg.btn-primary.btn-block {:type :submit} (text :t.ldap/login)]]])
 
 (defn login-url []
   "/ldap/login")

--- a/src/cljs/rems/actions.cljs
+++ b/src/cljs/rems/actions.cljs
@@ -88,7 +88,7 @@
 
 ;; TODO not implemented
 (defn- load-application-states-button []
-  [:button.btn.btn-secondary {:type "button" :data-toggle "modal" :data-target "#load-application-states-modal" :disabled true}
+  [:button.btn.btn-secondary {:type :button :data-toggle "modal" :data-target "#load-application-states-modal" :disabled true}
    (text :t.actions/load-application-states)])
 
 (defn- export-entitlements-button []
@@ -98,12 +98,12 @@
 
 ;; TODO not implemented
 (defn- show-publications-button []
-  [:button.btn.btn-secondary {:type "button" :data-toggle "modal" :data-target "#show-publications-modal" :disabled true}
+  [:button.btn.btn-secondary {:type :button :data-toggle "modal" :data-target "#show-publications-modal" :disabled true}
    (text :t.actions/show-publications)])
 
 ;; TODO not implemented
 (defn- show-throughput-times-button []
-  [:button.btn.btn-secondary {:type "button" :data-toggle "modal" :data-target "#show-throughput-times-modal" :disabled true}
+  [:button.btn.btn-secondary {:type :button :data-toggle "modal" :data-target "#show-throughput-times-modal" :disabled true}
    (text :t.actions/show-throughput-times)])
 
 (defn- report-buttons []

--- a/src/cljs/rems/actions/action.cljs
+++ b/src/cljs/rems/actions/action.cljs
@@ -7,9 +7,9 @@
 
 (defn button-wrapper [{:keys [text class] :as props}]
   [:button.btn
-   (merge
-    {:class (or class :btn-secondary)}
-    (dissoc props :class :text))
+   (merge {:type "button"
+           :class (or class :btn-secondary)}
+          (dissoc props :class :text))
    text])
 
 (defn collapse-action-form [id]
@@ -17,7 +17,8 @@
 
 (defn cancel-action-button [id]
   [:button.btn.btn-secondary
-   {:id (str "cancel-" id)
+   {:type "button"
+    :id (str "cancel-" id)
     :data-toggle "collapse"
     :data-target (str "#" (action-collapse-id id))}
    (text :t.actions/cancel)])
@@ -48,10 +49,10 @@
 
 (defn action-button [{:keys [id text class on-click]}]
   [:button.btn.mr-3
-   {:id (str id "-action-button")
+   {:type "button"
+    :id (str id "-action-button")
     :class (str (or class "btn-secondary")
                 " btn-opens-more")
-    :type "button"
     :data-toggle "collapse"
     :data-target (str "#" (action-collapse-id id))
     :on-click on-click}

--- a/src/cljs/rems/actions/action.cljs
+++ b/src/cljs/rems/actions/action.cljs
@@ -7,7 +7,7 @@
 
 (defn button-wrapper [{:keys [text class] :as props}]
   [:button.btn
-   (merge {:type "button"
+   (merge {:type :button
            :class (or class :btn-secondary)}
           (dissoc props :class :text))
    text])
@@ -17,7 +17,7 @@
 
 (defn cancel-action-button [id]
   [:button.btn.btn-secondary
-   {:type "button"
+   {:type :button
     :id (str "cancel-" id)
     :data-toggle "collapse"
     :data-target (str "#" (action-collapse-id id))}
@@ -49,7 +49,7 @@
 
 (defn action-button [{:keys [id text class on-click]}]
   [:button.btn.mr-3
-   {:type "button"
+   {:type :button
     :id (str id "-action-button")
     :class (str (or class "btn-secondary")
                 " btn-opens-more")

--- a/src/cljs/rems/administration/catalogue_item.cljs
+++ b/src/cljs/rems/administration/catalogue_item.cljs
@@ -33,7 +33,8 @@
 
 (defn- back-button []
   [:button.btn.btn-secondary
-   {:on-click #(dispatch! "/#/administration/catalogue-items")}
+   {:type "button"
+    :on-click #(dispatch! "/#/administration/catalogue-items")}
    (text :t.administration/back)])
 
 (defn- to-create-catalogue-item []

--- a/src/cljs/rems/administration/catalogue_item.cljs
+++ b/src/cljs/rems/administration/catalogue_item.cljs
@@ -33,7 +33,7 @@
 
 (defn- back-button []
   [:button.btn.btn-secondary
-   {:type "button"
+   {:type :button
     :on-click #(dispatch! "/#/administration/catalogue-items")}
    (text :t.administration/back)])
 

--- a/src/cljs/rems/administration/create_catalogue_item.cljs
+++ b/src/cljs/rems/administration/create_catalogue_item.cljs
@@ -170,13 +170,15 @@
 
 (defn- cancel-button []
   [:button.btn.btn-secondary
-   {:on-click #(dispatch! "/#/administration/catalogue-items")}
+   {:type "button"
+    :on-click #(dispatch! "/#/administration/catalogue-items")}
    (text :t.administration/cancel)])
 
 (defn- save-catalogue-item-button [form on-click]
   (let [request (build-request form)]
     [:button.btn.btn-primary
-     {:on-click #(on-click request)
+     {:type "button"
+      :on-click #(on-click request)
       :disabled (nil? request)}
      (text :t.administration/save)]))
 

--- a/src/cljs/rems/administration/create_catalogue_item.cljs
+++ b/src/cljs/rems/administration/create_catalogue_item.cljs
@@ -170,14 +170,14 @@
 
 (defn- cancel-button []
   [:button.btn.btn-secondary
-   {:type "button"
+   {:type :button
     :on-click #(dispatch! "/#/administration/catalogue-items")}
    (text :t.administration/cancel)])
 
 (defn- save-catalogue-item-button [form on-click]
   (let [request (build-request form)]
     [:button.btn.btn-primary
-     {:type "button"
+     {:type :button
       :on-click #(on-click request)
       :disabled (nil? request)}
      (text :t.administration/save)]))

--- a/src/cljs/rems/administration/create_form.cljs
+++ b/src/cljs/rems/administration/create_form.cljs
@@ -244,7 +244,7 @@
         languages @(rf/subscribe [:languages])
         request (build-request form languages)]
     [:button.btn.btn-primary
-     {:type "button"
+     {:type :button
       :on-click #(on-click request)
       :disabled (nil? request)}
      (text :t.administration/save)]))

--- a/src/cljs/rems/administration/create_form.cljs
+++ b/src/cljs/rems/administration/create_form.cljs
@@ -244,13 +244,15 @@
         languages @(rf/subscribe [:languages])
         request (build-request form languages)]
     [:button.btn.btn-primary
-     {:on-click #(on-click request)
+     {:type "button"
+      :on-click #(on-click request)
       :disabled (nil? request)}
      (text :t.administration/save)]))
 
 (defn- cancel-button []
   [:button.btn.btn-secondary
-   {:on-click #(dispatch! "/#/administration/forms")}
+   {:button "type"
+    :on-click #(dispatch! "/#/administration/forms")}
    (text :t.administration/cancel)])
 
 (defn- form-fields [fields]

--- a/src/cljs/rems/administration/create_license.cljs
+++ b/src/cljs/rems/administration/create_license.cljs
@@ -165,11 +165,11 @@
                                  :accept ".pdf, .doc, .docx, .ppt, .pptx, .txt, image/*"
                                  :on-change (set-attachment-event language)}]
                         [:button.btn.btn-secondary
-                         {:type "button"
+                         {:type :button
                           :on-click #(.click (.getElementById js/document "upload-license-button"))}
                          (text :t.form/upload)]]
           remove-button [:button.btn.btn-secondary.mr-2
-                         {:type "button"
+                         {:type :button
                           :on-click (remove-attachment-event language attachment-id)}
                          (text :t.form/attachment-remove)]]
       (if (empty? filename)
@@ -184,14 +184,14 @@
         languages @(rf/subscribe [:languages])
         request (build-request form default-language languages)]
     [:button.btn.btn-primary
-     {:type "button"
+     {:type :button
       :on-click #(on-click request)
       :disabled (nil? request)}
      (text :t.administration/save)]))
 
 (defn- cancel-button []
   [:button.btn.btn-secondary
-   {:type "button"
+   {:type :button
     :on-click #(dispatch! "/#/administration/licenses")}
    (text :t.administration/cancel)])
 

--- a/src/cljs/rems/administration/create_license.cljs
+++ b/src/cljs/rems/administration/create_license.cljs
@@ -164,10 +164,13 @@
                                  :id "upload-license-button"
                                  :accept ".pdf, .doc, .docx, .ppt, .pptx, .txt, image/*"
                                  :on-change (set-attachment-event language)}]
-                        [:button.btn.btn-secondary {:on-click #(.click (.getElementById js/document "upload-license-button"))}
+                        [:button.btn.btn-secondary
+                         {:type "button"
+                          :on-click #(.click (.getElementById js/document "upload-license-button"))}
                          (text :t.form/upload)]]
           remove-button [:button.btn.btn-secondary.mr-2
-                         {:on-click (remove-attachment-event language attachment-id)}
+                         {:type "button"
+                          :on-click (remove-attachment-event language attachment-id)}
                          (text :t.form/attachment-remove)]]
       (if (empty? filename)
         upload-field
@@ -181,13 +184,15 @@
         languages @(rf/subscribe [:languages])
         request (build-request form default-language languages)]
     [:button.btn.btn-primary
-     {:on-click #(on-click request)
+     {:type "button"
+      :on-click #(on-click request)
       :disabled (nil? request)}
      (text :t.administration/save)]))
 
 (defn- cancel-button []
   [:button.btn.btn-secondary
-   {:on-click #(dispatch! "/#/administration/licenses")}
+   {:type "button"
+    :on-click #(dispatch! "/#/administration/licenses")}
    (text :t.administration/cancel)])
 
 (defn create-license-page []

--- a/src/cljs/rems/administration/create_resource.cljs
+++ b/src/cljs/rems/administration/create_resource.cljs
@@ -112,13 +112,15 @@
 (defn- save-resource-button [form]
   (let [request (build-request form)]
     [:button.btn.btn-primary
-     {:on-click #(rf/dispatch [::create-resource request])
+     {:type "button"
+      :on-click #(rf/dispatch [::create-resource request])
       :disabled (nil? request)}
      (text :t.administration/save)]))
 
 (defn- cancel-button [on-click]
   [:button.btn.btn-secondary
-   {:on-click on-click}
+   {:type "button"
+    :on-click on-click}
    (text :t.administration/cancel)])
 
 (defn create-resource-page []

--- a/src/cljs/rems/administration/create_resource.cljs
+++ b/src/cljs/rems/administration/create_resource.cljs
@@ -112,14 +112,14 @@
 (defn- save-resource-button [form]
   (let [request (build-request form)]
     [:button.btn.btn-primary
-     {:type "button"
+     {:type :button
       :on-click #(rf/dispatch [::create-resource request])
       :disabled (nil? request)}
      (text :t.administration/save)]))
 
 (defn- cancel-button [on-click]
   [:button.btn.btn-secondary
-   {:type "button"
+   {:type :button
     :on-click on-click}
    (text :t.administration/cancel)])
 

--- a/src/cljs/rems/administration/create_workflow.cljs
+++ b/src/cljs/rems/administration/create_workflow.cljs
@@ -164,7 +164,8 @@
                   (build-update-request id form)
                   (build-create-request form))]
     [:button.btn.btn-primary
-     {:on-click #(if id
+     {:type "button"
+      :on-click #(if id
                    (rf/dispatch [::update-workflow (build-update-request id form)])
                    (rf/dispatch [::create-workflow (build-create-request form)]))
       :disabled (nil? request)}
@@ -172,7 +173,8 @@
 
 (defn- cancel-button []
   [:button.btn.btn-secondary
-   {:on-click #(dispatch! "/#/administration/workflows")}
+   {:type "button"
+    :on-click #(dispatch! "/#/administration/workflows")}
    (text :t.administration/cancel)])
 
 (defn workflow-type-description [description]

--- a/src/cljs/rems/administration/create_workflow.cljs
+++ b/src/cljs/rems/administration/create_workflow.cljs
@@ -164,7 +164,7 @@
                   (build-update-request id form)
                   (build-create-request form))]
     [:button.btn.btn-primary
-     {:type "button"
+     {:type :button
       :on-click #(if id
                    (rf/dispatch [::update-workflow (build-update-request id form)])
                    (rf/dispatch [::create-workflow (build-create-request form)]))
@@ -173,7 +173,7 @@
 
 (defn- cancel-button []
   [:button.btn.btn-secondary
-   {:type "button"
+   {:type :button
     :on-click #(dispatch! "/#/administration/workflows")}
    (text :t.administration/cancel)])
 

--- a/src/cljs/rems/administration/form.cljs
+++ b/src/cljs/rems/administration/form.cljs
@@ -34,7 +34,7 @@
 
 (defn- back-button []
   [:button.btn.btn-secondary
-   {:type "button"
+   {:type :button
     :on-click #(dispatch! "/#/administration/forms")}
    (text :t.administration/back)])
 

--- a/src/cljs/rems/administration/form.cljs
+++ b/src/cljs/rems/administration/form.cljs
@@ -34,7 +34,8 @@
 
 (defn- back-button []
   [:button.btn.btn-secondary
-   {:on-click #(dispatch! "/#/administration/forms")}
+   {:type "button"
+    :on-click #(dispatch! "/#/administration/forms")}
    (text :t.administration/back)])
 
 (defn form-view [form language]

--- a/src/cljs/rems/administration/license.cljs
+++ b/src/cljs/rems/administration/license.cljs
@@ -33,7 +33,8 @@
 
 (defn- back-button []
   [:button.btn.btn-secondary
-   {:on-click #(dispatch! "/#/administration/licenses")}
+   {:type "button"
+    :on-click #(dispatch! "/#/administration/licenses")}
    (text :t.administration/back)])
 
 (defn- to-create-license []

--- a/src/cljs/rems/administration/license.cljs
+++ b/src/cljs/rems/administration/license.cljs
@@ -33,7 +33,7 @@
 
 (defn- back-button []
   [:button.btn.btn-secondary
-   {:type "button"
+   {:type :button
     :on-click #(dispatch! "/#/administration/licenses")}
    (text :t.administration/back)])
 

--- a/src/cljs/rems/administration/resource.cljs
+++ b/src/cljs/rems/administration/resource.cljs
@@ -34,7 +34,8 @@
 
 (defn- back-button []
   [:button.btn.btn-secondary
-   {:on-click #(dispatch! "/#/administration/resources")}
+   {:type "button"
+    :on-click #(dispatch! "/#/administration/resources")}
    (text :t.administration/back)])
 
 (defn- to-create-resource []

--- a/src/cljs/rems/administration/resource.cljs
+++ b/src/cljs/rems/administration/resource.cljs
@@ -34,7 +34,7 @@
 
 (defn- back-button []
   [:button.btn.btn-secondary
-   {:type "button"
+   {:type :button
     :on-click #(dispatch! "/#/administration/resources")}
    (text :t.administration/back)])
 

--- a/src/cljs/rems/administration/status_flags.cljs
+++ b/src/cljs/rems/administration/status_flags.cljs
@@ -6,13 +6,13 @@
 
 (defn- disable-button [item on-change]
   [:button.btn.btn-secondary.button-min-width
-   {:type "button"
+   {:type :button
     :on-click #(on-change (assoc item :enabled false) (text :t.administration/disable))}
    (text :t.administration/disable)])
 
 (defn- enable-button [item on-change]
   [:button.btn.btn-primary.button-min-width
-   {:type "button"
+   {:type :button
     :on-click #(on-change (assoc item :enabled true) (text :t.administration/enable))}
    (text :t.administration/enable)])
 
@@ -24,13 +24,13 @@
 
 (defn- archive-button [item on-change]
   [:button.btn.btn-secondary.button-min-width
-   {:type "button"
+   {:type :button
     :on-click #(on-change (assoc item :archived true) (text :t.administration/archive))}
    (text :t.administration/archive)])
 
 (defn- unarchive-button [item on-change]
   [:button.btn.btn-primary.button-min-width
-   {:type "button"
+   {:type :button
     :on-click #(on-change (assoc item :archived false) (text :t.administration/unarchive))}
    (text :t.administration/unarchive)])
 

--- a/src/cljs/rems/administration/workflow.cljs
+++ b/src/cljs/rems/administration/workflow.cljs
@@ -34,13 +34,13 @@
 
 (defn- back-button []
   [:button.btn.btn-secondary
-   {:type "button"
+   {:type :button
     :on-click #(dispatch! "/#/administration/workflows")}
    (text :t.administration/back)])
 
 (defn- edit-button [id]
   [:button.btn.btn-primary
-   {:type "button"
+   {:type :button
     :on-click #(dispatch! (str "/#/administration/edit-workflow/" id))}
    (text :t.administration/edit)])
 

--- a/src/cljs/rems/administration/workflow.cljs
+++ b/src/cljs/rems/administration/workflow.cljs
@@ -34,12 +34,14 @@
 
 (defn- back-button []
   [:button.btn.btn-secondary
-   {:on-click #(dispatch! "/#/administration/workflows")}
+   {:type "button"
+    :on-click #(dispatch! "/#/administration/workflows")}
    (text :t.administration/back)])
 
 (defn- edit-button [id]
   [:button.btn.btn-primary
-   {:on-click #(dispatch! (str "/#/administration/edit-workflow/" id))}
+   {:type "button"
+    :on-click #(dispatch! (str "/#/administration/edit-workflow/" id))}
    (text :t.administration/edit)])
 
 (defn get-localized-value [field key language]

--- a/src/cljs/rems/auth/ldap.cljs
+++ b/src/cljs/rems/auth/ldap.cljs
@@ -10,4 +10,4 @@
     [:input.form-control {:type "text" :placeholder (text :t.ldap/username) :name "username" :required true}]
     [:input.form-control {:type "password" :placeholder (text :t.ldap/password) :name "password" :required true}]
     #_(anti-forgery-field)
-    [:button.btn.btn-lg.btn-primary.btn-block {:type "submit"} (text :t.ldap/login)]]])
+    [:button.btn.btn-lg.btn-primary.btn-block {:type :submit} (text :t.ldap/login)]]])

--- a/src/cljs/rems/cart.cljs
+++ b/src/cljs/rems/cart.cljs
@@ -29,7 +29,7 @@
   "Hiccup fragment that contains a button that adds the given item to the cart"
   [item]
   [:button.btn.btn-primary.add-to-cart
-   {:type "submit"
+   {:type "button"
     :on-click #(rf/dispatch [::add-item item])}
    (text :t.cart/add)])
 
@@ -37,7 +37,7 @@
   "Hiccup fragment that contains a button that removes the given item from the cart"
   [item]
   [:button.btn.btn-secondary.remove-from-cart
-   {:type "submit"
+   {:type "button"
     :on-click #(rf/dispatch [::remove-item (:id item)])}
    (text :t.cart/remove)])
 
@@ -47,7 +47,9 @@
        (mapv edn/read-string)))
 
 (defn- apply-button [items]
-  [:button.btn.btn-primary.apply-for-catalogue-items {:on-click #(application/apply-for items)}
+  [:button.btn.btn-primary.apply-for-catalogue-items
+   {:type "button"
+    :on-click #(application/apply-for items)}
    (text :t.cart/apply)])
 
 (defn- item-view [item language & [apply-button?]]

--- a/src/cljs/rems/cart.cljs
+++ b/src/cljs/rems/cart.cljs
@@ -29,7 +29,7 @@
   "Hiccup fragment that contains a button that adds the given item to the cart"
   [item]
   [:button.btn.btn-primary.add-to-cart
-   {:type "button"
+   {:type :button
     :on-click #(rf/dispatch [::add-item item])}
    (text :t.cart/add)])
 
@@ -37,7 +37,7 @@
   "Hiccup fragment that contains a button that removes the given item from the cart"
   [item]
   [:button.btn.btn-secondary.remove-from-cart
-   {:type "button"
+   {:type :button
     :on-click #(rf/dispatch [::remove-item (:id item)])}
    (text :t.cart/remove)])
 
@@ -48,7 +48,7 @@
 
 (defn- apply-button [items]
   [:button.btn.btn-primary.apply-for-catalogue-items
-   {:type "button"
+   {:type :button
     :on-click #(application/apply-for items)}
    (text :t.cart/apply)])
 

--- a/src/cljs/rems/fields.cljs
+++ b/src/cljs/rems/fields.cljs
@@ -236,11 +236,11 @@
                                               (on-change (str filename " (" (localize-time (time/now)) ")"))
                                               (on-set-attachment form-data title)))}]
                       [:button.btn.btn-secondary
-                       {:type "button"
+                       {:type :button
                         :on-click click-upload}
                        (text :t.form/upload)]]
         remove-button [:button.btn.btn-secondary.mr-2
-                       {:type "button"
+                       {:type :button
                         :on-click (fn [event]
                                     (on-change "")
                                     (on-remove-attachment))}

--- a/src/cljs/rems/fields.cljs
+++ b/src/cljs/rems/fields.cljs
@@ -235,10 +235,13 @@
                                                               (.append "file" filecontent))]
                                               (on-change (str filename " (" (localize-time (time/now)) ")"))
                                               (on-set-attachment form-data title)))}]
-                      [:button.btn.btn-secondary {:on-click click-upload}
+                      [:button.btn.btn-secondary
+                       {:type "button"
+                        :on-click click-upload}
                        (text :t.form/upload)]]
         remove-button [:button.btn.btn-secondary.mr-2
-                       {:on-click (fn [event]
+                       {:type "button"
+                        :on-click (fn [event]
                                     (on-change "")
                                     (on-remove-attachment))}
                        (text :t.form/attachment-remove)]]

--- a/src/cljs/rems/language_switcher.cljs
+++ b/src/cljs/rems/language_switcher.cljs
@@ -18,7 +18,8 @@
           (for [language languages]
             (let [lang-str (str/upper-case (name language))]
               [:form.inline
-               [:button {:class (lang-link-classes current-language language) :type "button"
+               [:button {:type "button"
+                         :class (lang-link-classes current-language language)
                          :on-click (fn []
                                      (rf/dispatch [:set-current-language language])
                                      (rf/dispatch [:rems.spa/user-triggered-navigation]))}

--- a/src/cljs/rems/language_switcher.cljs
+++ b/src/cljs/rems/language_switcher.cljs
@@ -18,7 +18,7 @@
           (for [language languages]
             (let [lang-str (str/upper-case (name language))]
               [:form.inline
-               [:button {:type "button"
+               [:button {:type :button
                          :class (lang-link-classes current-language language)
                          :on-click (fn []
                                      (rf/dispatch [:set-current-language language])

--- a/src/cljs/rems/modal.cljs
+++ b/src/cljs/rems/modal.cljs
@@ -40,8 +40,10 @@
                                                      :space-between
                                                      :align-items :center}}
                           title
-                          [:button.btn.btn-link.link.ml-3 {:on-click on-close
-                                                           :aria-label (text :t.modal/close-dialog)}
+                          [:button.btn.btn-link.link.ml-3
+                           {:type "button"
+                            :on-click on-close
+                            :aria-label (text :t.modal/close-dialog)}
                            [:i.fa.fa-times {:style {:margin 0}}]]]
                   :title-class title-class
                   :always [:div.full
@@ -62,7 +64,10 @@
 
   See `modal/component` for options."
   [{:keys [title title-class content on-close shade?] :as opts}]
-  [component (assoc opts :commands [[:button#modal-ok.btn.btn-primary {:on-click on-close} (text :t.actions/ok)]])])
+  [component (assoc opts :commands [[:button#modal-ok.btn.btn-primary
+                                     {:type "button"
+                                      :on-click on-close}
+                                     (text :t.actions/ok)]])])
 
 (defn guide
   []
@@ -71,7 +76,8 @@
    (example "modal component"
             [component {:title "Hello World"
                         :content [:div "Hello world!"]
-                        :commands [[:button.btn.btn-secondary "Say"] [:button.btn.btn-primary "IT"]]
+                        :commands [[:button.btn.btn-secondary {:type "button"} "Say"]
+                                   [:button.btn.btn-primary {:type "button"} "IT"]]
                         :on-close #(.alert js/window "close")
                         :shade? false}])
    (component-info notification)

--- a/src/cljs/rems/modal.cljs
+++ b/src/cljs/rems/modal.cljs
@@ -41,7 +41,7 @@
                                                      :align-items :center}}
                           title
                           [:button.btn.btn-link.link.ml-3
-                           {:type "button"
+                           {:type :button
                             :on-click on-close
                             :aria-label (text :t.modal/close-dialog)}
                            [:i.fa.fa-times {:style {:margin 0}}]]]
@@ -65,7 +65,7 @@
   See `modal/component` for options."
   [{:keys [title title-class content on-close shade?] :as opts}]
   [component (assoc opts :commands [[:button#modal-ok.btn.btn-primary
-                                     {:type "button"
+                                     {:type :button
                                       :on-click on-close}
                                      (text :t.actions/ok)]])])
 
@@ -76,8 +76,8 @@
    (example "modal component"
             [component {:title "Hello World"
                         :content [:div "Hello world!"]
-                        :commands [[:button.btn.btn-secondary {:type "button"} "Say"]
-                                   [:button.btn.btn-primary {:type "button"} "IT"]]
+                        :commands [[:button.btn.btn-secondary {:type :button} "Say"]
+                                   [:button.btn.btn-primary {:type :button} "IT"]]
                         :on-close #(.alert js/window "close")
                         :shade? false}])
    (component-info notification)

--- a/src/cljs/rems/navbar.cljs
+++ b/src/cljs/rems/navbar.cljs
@@ -60,7 +60,7 @@
   [:div.navbar-flex
    [:nav.navbar.navbar-expand-sm {:role "navigation"}
     [:button.navbar-toggler
-     {:type "button" :data-toggle "collapse" :data-target "#small-navbar"}
+     {:type :button :data-toggle "collapse" :data-target "#small-navbar"}
      "\u2630"]
     [navbar-items :div#big-navbar.collapse.navbar-collapse.mr-3 page-id identity]]
    [:div.navbar [user-widget (:user identity)]]])

--- a/src/cljs/rems/table.cljs
+++ b/src/cljs/rems/table.cljs
@@ -151,7 +151,8 @@
                          (.preventDefault event)
                          (update-current-filters event)))}]
      [:button.btn.btn-primary
-      {:on-click update-current-filters
+      {:type "button"
+       :on-click update-current-filters
        :aria-label (text :t.search/search)}
       [search-symbol]]]))
 
@@ -159,7 +160,8 @@
   (when filtering
     [:div.rems-table-search-toggle.d-flex.flex-row-reverse
      [:button.btn
-      {:class (if show-filters "btn-secondary" "btn-primary")
+      {:type "button"
+       :class (if show-filters "btn-secondary" "btn-primary")
        :aria-label (if show-filters (text :t.search/close-search) (text :t.search/open-search))
        ;; TODO: focus needs to be moved to the search field after opening it, especially for screen readers
        :on-click #(set-filtering (-> filtering

--- a/src/cljs/rems/table.cljs
+++ b/src/cljs/rems/table.cljs
@@ -151,7 +151,7 @@
                          (.preventDefault event)
                          (update-current-filters event)))}]
      [:button.btn.btn-primary
-      {:type "button"
+      {:type :button
        :on-click update-current-filters
        :aria-label (text :t.search/search)}
       [search-symbol]]]))
@@ -160,7 +160,7 @@
   (when filtering
     [:div.rems-table-search-toggle.d-flex.flex-row-reverse
      [:button.btn
-      {:type "button"
+      {:type :button
        :class (if show-filters "btn-secondary" "btn-primary")
        :aria-label (if show-filters (text :t.search/close-search) (text :t.search/open-search))
        ;; TODO: focus needs to be moved to the search field after opening it, especially for screen readers


### PR DESCRIPTION
The default is type=submit, but we don't really use HTML forms which could be submitted. Also IIRC, IE had some different defaults.