### PR TITLE
Fix testing

### DIFF
--- a/test-config.edn
+++ b/test-config.edn
@@ -1,6 +1,7 @@
 {:dev true
  :port 3001
  :nrepl-port 7001
+ :public-url "http://localhost:3001/"
  :database-url "postgresql://localhost/rems_test?user=rems_test"
  :test-database-url "postgresql://localhost/rems_test?user=rems_test"
  :authentication :fake-shibboleth}

--- a/test-config.edn
+++ b/test-config.edn
@@ -3,11 +3,4 @@
  :nrepl-port 7001
  :database-url "postgresql://localhost/rems_test?user=rems_test"
  :test-database-url "postgresql://localhost/rems_test?user=rems_test"
- :authentication :fake-shibboleth
- :public-url "http://localhost:3001/"
- :extra-pages [{:id "test"
-                :translations {:fi {:title "Testi"
-                                    :filename "test-fi.md"}
-                               :en {:title "Test"
-                                    :filename "test-en.md"}}}]
- :extra-pages-path "./test-data/extra-pages/"}
+ :authentication :fake-shibboleth}

--- a/test/clj/rems/api/test_extra_pages.clj
+++ b/test/clj/rems/api/test_extra_pages.clj
@@ -11,12 +11,19 @@
 (deftest extra-pages-api-test
   (let [api-key "42"
         user-id "owner"]
-    (testing "fetch existing extra-page"
-      (let [response (api-call :get "/api/extra-pages/test" {} api-key user-id)]
-        (is (= (set (keys response)) #{:en :fi}))
-        (is (= (:en response) "This is a test.\n"))))
-    (testing "try to fetch non-existing extra-page"
-      (let [response (-> (request :get "/api/extra-pages/test2")
-                         (authenticate api-key user-id)
-                         handler)]
-        (is (response-is-not-found? response))))))
+    (with-redefs [rems.config/env (assoc rems.config/env
+                                         :extra-pages [{:id "test"
+                                                        :translations {:fi {:title "Testi"
+                                                                            :filename "test-fi.md"}
+                                                                       :en {:title "Test"
+                                                                            :filename "test-en.md"}}}]
+                                         :extra-pages-path "./test-data/extra-pages/")]
+      (testing "fetch existing extra-page"
+        (let [response (api-call :get "/api/extra-pages/test" {} api-key user-id)]
+          (is (= (set (keys response)) #{:en :fi}))
+          (is (= (:en response) "This is a test.\n"))))
+      (testing "try to fetch non-existing extra-page"
+        (let [response (-> (request :get "/api/extra-pages/test2")
+                           (authenticate api-key user-id)
+                           handler)]
+          (is (response-is-not-found? response)))))))

--- a/test/clj/rems/api/test_extra_pages.clj
+++ b/test/clj/rems/api/test_extra_pages.clj
@@ -16,7 +16,7 @@
         (is (= (set (keys response)) #{:en :fi}))
         (is (= (:en response) "This is a test.\n"))))
     (testing "try to fetch non-existing extra-page"
-      (let [response (-> (request :get "api/extra-pages/test2")
+      (let [response (-> (request :get "/api/extra-pages/test2")
                          (authenticate api-key user-id)
                          handler)]
         (is (response-is-not-found? response))))))

--- a/test/clj/rems/poller/test_email.clj
+++ b/test/clj/rems/poller/test_email.clj
@@ -47,135 +47,134 @@
       (fn [] (mapv #(sort-emails (#'rems.poller.email/event-to-emails-impl % application)) events)))))
 
 (deftest test-event-to-emails-impl
-  (with-redefs [rems.config/env (assoc rems.config/env :public-url "https://rems.server:8443/")]
-    (let [base-events [{:application/id 7
-                        :application/external-id "2001/3"
-                        :event/type :application.event/created
-                        :event/actor "applicant"
-                        :application/resources [{:catalogue-item/id 10
-                                                 :resource/ext-id "urn:11"}
-                                                {:catalogue-item/id 20
-                                                 :resource/ext-id "urn:21"}]
-                        :workflow/id 5
-                        :workflow/type :workflow/dynamic}
-                       {:application/id 7
-                        :event/type :application.event/submitted
-                        :event/actor "applicant"}]]
-      (let [events (into
-                    base-events
-                    [{:application/id 7
-                      :event/type :application.event/member-invited
+  (let [base-events [{:application/id 7
+                      :application/external-id "2001/3"
+                      :event/type :application.event/created
                       :event/actor "applicant"
-                      :application/member {:name "Some Body" :email "somebody@example.com"}
-                      :invitation/token "abc"}
+                      :application/resources [{:catalogue-item/id 10
+                                               :resource/ext-id "urn:11"}
+                                              {:catalogue-item/id 20
+                                               :resource/ext-id "urn:21"}]
+                      :workflow/id 5
+                      :workflow/type :workflow/dynamic}
                      {:application/id 7
-                      :event/type :application.event/comment-requested
-                      :event/actor "handler"
-                      :application/request-id "r1"
-                      :application/commenters ["commenter1" "commenter2"]}
-                     {:application/id 7
-                      :event/type :application.event/member-joined
-                      :event/actor "somebody"}
-                     {:application/id 7
-                      :event/type :application.event/commented
-                      :event/actor "commenter2"
-                      :application/request-id "r1"
-                      :application/comment ["this is a comment"]}
-                     {:application/id 7
-                      :event/type :application.event/member-added
-                      :event/actor "handler"
-                      :application/member {:userid "member"}}
-                     {:application/id 7
-                      :event/type :application.event/decision-requested
-                      :event/actor "assistant"
-                      :application/request-id "r2"
-                      :application/deciders ["decider"]}
-                     {:application/id 7
-                      :event/type :application.event/decided
-                      :event/actor "decider"
-                      :application/decision :approved}
-                     {:application/id 7
-                      :event/type :application.event/approved
-                      :event/actor "handler"}
-                     {:application/id 7
-                      :event/type :application.event/closed
-                      :event/actor "assistant"}])]
+                      :event/type :application.event/submitted
+                      :event/actor "applicant"}]]
+    (let [events (into
+                  base-events
+                  [{:application/id 7
+                    :event/type :application.event/member-invited
+                    :event/actor "applicant"
+                    :application/member {:name "Some Body" :email "somebody@example.com"}
+                    :invitation/token "abc"}
+                   {:application/id 7
+                    :event/type :application.event/comment-requested
+                    :event/actor "handler"
+                    :application/request-id "r1"
+                    :application/commenters ["commenter1" "commenter2"]}
+                   {:application/id 7
+                    :event/type :application.event/member-joined
+                    :event/actor "somebody"}
+                   {:application/id 7
+                    :event/type :application.event/commented
+                    :event/actor "commenter2"
+                    :application/request-id "r1"
+                    :application/comment ["this is a comment"]}
+                   {:application/id 7
+                    :event/type :application.event/member-added
+                    :event/actor "handler"
+                    :application/member {:userid "member"}}
+                   {:application/id 7
+                    :event/type :application.event/decision-requested
+                    :event/actor "assistant"
+                    :application/request-id "r2"
+                    :application/deciders ["decider"]}
+                   {:application/id 7
+                    :event/type :application.event/decided
+                    :event/actor "decider"
+                    :application/decision :approved}
+                   {:application/id 7
+                    :event/type :application.event/approved
+                    :event/actor "handler"}
+                   {:application/id 7
+                    :event/type :application.event/closed
+                    :event/actor "assistant"}])]
+      (is (= [[]
+              [{:to-user "assistant",
+                :subject "A new application has been submitted",
+                :body "Dear assistant,\nUser applicant has submitted a new application 2001/3 for the resource(s) en title 11, en title 21.\nView the application: http://localhost:3001/#/application/7"}
+               {:to-user "handler",
+                :subject "A new application has been submitted",
+                :body "Dear handler,\nUser applicant has submitted a new application 2001/3 for the resource(s) en title 11, en title 21.\nView the application: http://localhost:3001/#/application/7"}]
+              [{:to "somebody@example.com",
+                :subject "Invitation to participate in an application",
+                :body "Hello,\nThis email address (somebody@example.com) has been invited to participate in an application.\nParticipate with this link: http://localhost:3001/accept-invitation?token=abc"}]
+              [{:to-user "commenter1",
+                :subject "Comment request",
+                :body "Dear commenter1,\nUser handler has requested your comment on application 2001/3.\nComment here: http://localhost:3001/#/application/7"}
+               {:to-user "commenter2",
+                :subject "Comment request",
+                :body "Dear commenter2,\nUser handler has requested your comment on application 2001/3.\nComment here: http://localhost:3001/#/application/7"}]
+              []
+              [{:to-user "assistant",
+                :subject "New comment notification",
+                :body "Dear assistant,\nUser commenter2 has posted a comment on application 2001/3.\nView the application: http://localhost:3001/#/application/7"}
+               {:to-user "handler",
+                :subject "New comment notification",
+                :body "Dear handler,\nUser commenter2 has posted a comment on application 2001/3.\nView the application: http://localhost:3001/#/application/7"}]
+              [{:to-user "member",
+                :subject "You've been added as a member to an application",
+                :body "Dear member,\nYou've been added as a member to application 2001/3.\nView the application: http://localhost:3001/#/application/7"}]
+              [{:to-user "decider",
+                :subject "Decision request",
+                :body "Dear decider,\nUser assistant has requested your decision on application 2001/3.\nView the application: http://localhost:3001/#/application/7"}]
+              [{:to-user "assistant",
+                :subject "New decision notification",
+                :body "Dear assistant,\nUser decider has sent a decision on application 2001/3.\nView the application: http://localhost:3001/#/application/7"}
+               {:to-user "handler",
+                :subject "New decision notification",
+                :body "Dear handler,\nUser decider has sent a decision on application 2001/3.\nView the application: http://localhost:3001/#/application/7"}]
+              [{:to-user "applicant",
+                :subject "Your application has been approved",
+                :body "Dear applicant,\nYour application 2001/3 has been approved.\nView your application: http://localhost:3001/#/application/7"}
+               {:to-user "member",
+                :subject "Your application has been approved",
+                :body "Dear member,\nYour application 2001/3 has been approved.\nView your application: http://localhost:3001/#/application/7"}
+               {:to-user "somebody",
+                :subject "Your application has been approved",
+                :body "Dear somebody,\nYour application 2001/3 has been approved.\nView your application: http://localhost:3001/#/application/7"}]
+              [{:to-user "applicant",
+                :subject "Your application has been closed",
+                :body "Dear applicant,\nYour application 2001/3 has been closed.\nView your application: http://localhost:3001/#/application/7"}
+               {:to-user "member",
+                :subject "Your application has been closed",
+                :body "Dear member,\nYour application 2001/3 has been closed.\nView your application: http://localhost:3001/#/application/7"}
+               {:to-user "somebody",
+                :subject "Your application has been closed",
+                :body "Dear somebody,\nYour application 2001/3 has been closed.\nView your application: http://localhost:3001/#/application/7"}]]
+             (events-to-emails events))))
+    (let [events (conj base-events
+                       {:application/id 7
+                        :event/type :application.event/rejected
+                        :event/actor "handler"})]
+      (is (= [[]
+              [{:to-user "assistant",
+                :subject "A new application has been submitted",
+                :body "Dear assistant,\nUser applicant has submitted a new application 2001/3 for the resource(s) en title 11, en title 21.\nView the application: http://localhost:3001/#/application/7"}
+               {:to-user "handler",
+                :subject "A new application has been submitted",
+                :body "Dear handler,\nUser applicant has submitted a new application 2001/3 for the resource(s) en title 11, en title 21.\nView the application: http://localhost:3001/#/application/7"}]
+              [{:subject "Your application has been rejected",
+                :body "Dear applicant,\nYour application 2001/3 has been rejected.\nView your application: http://localhost:3001/#/application/7",
+                :to-user "applicant"}]]
+             (events-to-emails events))))
+    (testing "id field can be overrided"
+      (with-redefs [rems.config/env (assoc rems.config/env :application-id-column :id)]
         (is (= [[]
-                [{:to-user "assistant",
-                  :subject "A new application has been submitted",
-                  :body "Dear assistant,\nUser applicant has submitted a new application 2001/3 for the resource(s) en title 11, en title 21.\nView the application: https://rems.server:8443/#/application/7"}
-                 {:to-user "handler",
-                  :subject "A new application has been submitted",
-                  :body "Dear handler,\nUser applicant has submitted a new application 2001/3 for the resource(s) en title 11, en title 21.\nView the application: https://rems.server:8443/#/application/7"}]
-                [{:to "somebody@example.com",
-                  :subject "Invitation to participate in an application",
-                  :body "Hello,\nThis email address (somebody@example.com) has been invited to participate in an application.\nParticipate with this link: https://rems.server:8443/accept-invitation?token=abc"}]
-                [{:to-user "commenter1",
-                  :subject "Comment request",
-                  :body "Dear commenter1,\nUser handler has requested your comment on application 2001/3.\nComment here: https://rems.server:8443/#/application/7"}
-                 {:to-user "commenter2",
-                  :subject "Comment request",
-                  :body "Dear commenter2,\nUser handler has requested your comment on application 2001/3.\nComment here: https://rems.server:8443/#/application/7"}]
-                []
-                [{:to-user "assistant",
-                  :subject "New comment notification",
-                  :body "Dear assistant,\nUser commenter2 has posted a comment on application 2001/3.\nView the application: https://rems.server:8443/#/application/7"}
-                 {:to-user "handler",
-                  :subject "New comment notification",
-                  :body "Dear handler,\nUser commenter2 has posted a comment on application 2001/3.\nView the application: https://rems.server:8443/#/application/7"}]
-                [{:to-user "member",
-                  :subject "You've been added as a member to an application",
-                  :body "Dear member,\nYou've been added as a member to application 2001/3.\nView the application: https://rems.server:8443/#/application/7"}]
-                [{:to-user "decider",
-                  :subject "Decision request",
-                  :body "Dear decider,\nUser assistant has requested your decision on application 2001/3.\nView the application: https://rems.server:8443/#/application/7"}]
-                [{:to-user "assistant",
-                  :subject "New decision notification",
-                  :body "Dear assistant,\nUser decider has sent a decision on application 2001/3.\nView the application: https://rems.server:8443/#/application/7"}
-                 {:to-user "handler",
-                  :subject "New decision notification",
-                  :body "Dear handler,\nUser decider has sent a decision on application 2001/3.\nView the application: https://rems.server:8443/#/application/7"}]
-                [{:to-user "applicant",
-                  :subject "Your application has been approved",
-                  :body "Dear applicant,\nYour application 2001/3 has been approved.\nView your application: https://rems.server:8443/#/application/7"}
-                 {:to-user "member",
-                  :subject "Your application has been approved",
-                  :body "Dear member,\nYour application 2001/3 has been approved.\nView your application: https://rems.server:8443/#/application/7"}
-                 {:to-user "somebody",
-                  :subject "Your application has been approved",
-                  :body "Dear somebody,\nYour application 2001/3 has been approved.\nView your application: https://rems.server:8443/#/application/7"}]
-                [{:to-user "applicant",
-                  :subject "Your application has been closed",
-                  :body "Dear applicant,\nYour application 2001/3 has been closed.\nView your application: https://rems.server:8443/#/application/7"}
-                 {:to-user "member",
-                  :subject "Your application has been closed",
-                  :body "Dear member,\nYour application 2001/3 has been closed.\nView your application: https://rems.server:8443/#/application/7"}
-                 {:to-user "somebody",
-                  :subject "Your application has been closed",
-                  :body "Dear somebody,\nYour application 2001/3 has been closed.\nView your application: https://rems.server:8443/#/application/7"}]]
-               (events-to-emails events))))
-      (let [events (conj base-events
-                         {:application/id 7
-                          :event/type :application.event/rejected
-                          :event/actor "handler"})]
-        (is (= [[]
-                [{:to-user "assistant",
-                  :subject "A new application has been submitted",
-                  :body "Dear assistant,\nUser applicant has submitted a new application 2001/3 for the resource(s) en title 11, en title 21.\nView the application: https://rems.server:8443/#/application/7"}
-                 {:to-user "handler",
-                  :subject "A new application has been submitted",
-                  :body "Dear handler,\nUser applicant has submitted a new application 2001/3 for the resource(s) en title 11, en title 21.\nView the application: https://rems.server:8443/#/application/7"}]
-                [{:subject "Your application has been rejected",
-                  :body "Dear applicant,\nYour application 2001/3 has been rejected.\nView your application: https://rems.server:8443/#/application/7",
-                  :to-user "applicant"}]]
-               (events-to-emails events))))
-      (testing "id field can be overrided"
-        (with-redefs [rems.config/env (assoc rems.config/env :application-id-column :id)]
-          (is (= [[]
-                  [{:to-user "assistant"
-                    :subject "A new application has been submitted"
-                    :body "Dear assistant,\nUser applicant has submitted a new application 7 for the resource(s) en title 11, en title 21.\nView the application: https://rems.server:8443/#/application/7"}
-                   {:to-user "handler"
-                    :subject "A new application has been submitted"
-                    :body "Dear handler,\nUser applicant has submitted a new application 7 for the resource(s) en title 11, en title 21.\nView the application: https://rems.server:8443/#/application/7"}]]
-                 (events-to-emails base-events))))))))
+                [{:to-user "assistant"
+                  :subject "A new application has been submitted"
+                  :body "Dear assistant,\nUser applicant has submitted a new application 7 for the resource(s) en title 11, en title 21.\nView the application: http://localhost:3001/#/application/7"}
+                 {:to-user "handler"
+                  :subject "A new application has been submitted"
+                  :body "Dear handler,\nUser applicant has submitted a new application 7 for the resource(s) en title 11, en title 21.\nView the application: http://localhost:3001/#/application/7"}]]
+               (events-to-emails base-events)))))))

--- a/test/clj/rems/poller/test_email.clj
+++ b/test/clj/rems/poller/test_email.clj
@@ -47,134 +47,135 @@
       (fn [] (mapv #(sort-emails (#'rems.poller.email/event-to-emails-impl % application)) events)))))
 
 (deftest test-event-to-emails-impl
-  (let [base-events [{:application/id 7
-                      :application/external-id "2001/3"
-                      :event/type :application.event/created
-                      :event/actor "applicant"
-                      :application/resources [{:catalogue-item/id 10
-                                               :resource/ext-id "urn:11"}
-                                              {:catalogue-item/id 20
-                                               :resource/ext-id "urn:21"}]
-                      :workflow/id 5
-                      :workflow/type :workflow/dynamic}
-                     {:application/id 7
-                      :event/type :application.event/submitted
-                      :event/actor "applicant"}]]
-    (let [events (into
-                  base-events
-                  [{:application/id 7
-                    :event/type :application.event/member-invited
-                    :event/actor "applicant"
-                    :application/member {:name "Some Body" :email "somebody@example.com"}
-                    :invitation/token "abc"}
-                   {:application/id 7
-                    :event/type :application.event/comment-requested
-                    :event/actor "handler"
-                    :application/request-id "r1"
-                    :application/commenters ["commenter1" "commenter2"]}
-                   {:application/id 7
-                    :event/type :application.event/member-joined
-                    :event/actor "somebody"}
-                   {:application/id 7
-                    :event/type :application.event/commented
-                    :event/actor "commenter2"
-                    :application/request-id "r1"
-                    :application/comment ["this is a comment"]}
-                   {:application/id 7
-                    :event/type :application.event/member-added
-                    :event/actor "handler"
-                    :application/member {:userid "member"}}
-                   {:application/id 7
-                    :event/type :application.event/decision-requested
-                    :event/actor "assistant"
-                    :application/request-id "r2"
-                    :application/deciders ["decider"]}
-                   {:application/id 7
-                    :event/type :application.event/decided
-                    :event/actor "decider"
-                    :application/decision :approved}
-                   {:application/id 7
-                    :event/type :application.event/approved
-                    :event/actor "handler"}
-                   {:application/id 7
-                    :event/type :application.event/closed
-                    :event/actor "assistant"}])]
-      (is (= [[]
-              [{:to-user "assistant",
-                :subject "A new application has been submitted",
-                :body "Dear assistant,\nUser applicant has submitted a new application 2001/3 for the resource(s) en title 11, en title 21.\nView the application: http://localhost:3001/#/application/7"}
-               {:to-user "handler",
-                :subject "A new application has been submitted",
-                :body "Dear handler,\nUser applicant has submitted a new application 2001/3 for the resource(s) en title 11, en title 21.\nView the application: http://localhost:3001/#/application/7"}]
-              [{:to "somebody@example.com",
-                :subject "Invitation to participate in an application",
-                :body "Hello,\nThis email address (somebody@example.com) has been invited to participate in an application.\nParticipate with this link: http://localhost:3001/accept-invitation?token=abc"}]
-              [{:to-user "commenter1",
-                :subject "Comment request",
-                :body "Dear commenter1,\nUser handler has requested your comment on application 2001/3.\nComment here: http://localhost:3001/#/application/7"}
-               {:to-user "commenter2",
-                :subject "Comment request",
-                :body "Dear commenter2,\nUser handler has requested your comment on application 2001/3.\nComment here: http://localhost:3001/#/application/7"}]
-              []
-              [{:to-user "assistant",
-                :subject "New comment notification",
-                :body "Dear assistant,\nUser commenter2 has posted a comment on application 2001/3.\nView the application: http://localhost:3001/#/application/7"}
-               {:to-user "handler",
-                :subject "New comment notification",
-                :body "Dear handler,\nUser commenter2 has posted a comment on application 2001/3.\nView the application: http://localhost:3001/#/application/7"}]
-              [{:to-user "member",
-                :subject "You've been added as a member to an application",
-                :body "Dear member,\nYou've been added as a member to application 2001/3.\nView the application: http://localhost:3001/#/application/7"}]
-              [{:to-user "decider",
-                :subject "Decision request",
-                :body "Dear decider,\nUser assistant has requested your decision on application 2001/3.\nView the application: http://localhost:3001/#/application/7"}]
-              [{:to-user "assistant",
-                :subject "New decision notification",
-                :body "Dear assistant,\nUser decider has sent a decision on application 2001/3.\nView the application: http://localhost:3001/#/application/7"}
-               {:to-user "handler",
-                :subject "New decision notification",
-                :body "Dear handler,\nUser decider has sent a decision on application 2001/3.\nView the application: http://localhost:3001/#/application/7"}]
-              [{:to-user "applicant",
-                :subject "Your application has been approved",
-                :body "Dear applicant,\nYour application 2001/3 has been approved.\nView your application: http://localhost:3001/#/application/7"}
-               {:to-user "member",
-                :subject "Your application has been approved",
-                :body "Dear member,\nYour application 2001/3 has been approved.\nView your application: http://localhost:3001/#/application/7"}
-               {:to-user "somebody",
-                :subject "Your application has been approved",
-                :body "Dear somebody,\nYour application 2001/3 has been approved.\nView your application: http://localhost:3001/#/application/7"}]
-              [{:to-user "applicant",
-                :subject "Your application has been closed",
-                :body "Dear applicant,\nYour application 2001/3 has been closed.\nView your application: http://localhost:3001/#/application/7"}
-               {:to-user "member",
-                :subject "Your application has been closed",
-                :body "Dear member,\nYour application 2001/3 has been closed.\nView your application: http://localhost:3001/#/application/7"}
-               {:to-user "somebody",
-                :subject "Your application has been closed",
-                :body "Dear somebody,\nYour application 2001/3 has been closed.\nView your application: http://localhost:3001/#/application/7"}]]
-             (events-to-emails events))))
-    (let [events (conj base-events
+  (with-redefs [rems.config/env (assoc rems.config/env :public-url "https://rems.server:8443/")]
+    (let [base-events [{:application/id 7
+                        :application/external-id "2001/3"
+                        :event/type :application.event/created
+                        :event/actor "applicant"
+                        :application/resources [{:catalogue-item/id 10
+                                                 :resource/ext-id "urn:11"}
+                                                {:catalogue-item/id 20
+                                                 :resource/ext-id "urn:21"}]
+                        :workflow/id 5
+                        :workflow/type :workflow/dynamic}
                        {:application/id 7
-                        :event/type :application.event/rejected
-                        :event/actor "handler"})]
-      (is (= [[]
-              [{:to-user "assistant",
-                :subject "A new application has been submitted",
-                :body "Dear assistant,\nUser applicant has submitted a new application 2001/3 for the resource(s) en title 11, en title 21.\nView the application: http://localhost:3001/#/application/7"}
-               {:to-user "handler",
-                :subject "A new application has been submitted",
-                :body "Dear handler,\nUser applicant has submitted a new application 2001/3 for the resource(s) en title 11, en title 21.\nView the application: http://localhost:3001/#/application/7"}]
-              [{:subject "Your application has been rejected",
-                :body "Dear applicant,\nYour application 2001/3 has been rejected.\nView your application: http://localhost:3001/#/application/7",
-                :to-user "applicant"}]]
-             (events-to-emails events))))
-    (testing "id field can be overrided"
-      (with-redefs [rems.config/env (assoc rems.config/env :application-id-column :id)]
+                        :event/type :application.event/submitted
+                        :event/actor "applicant"}]]
+      (let [events (into
+                    base-events
+                    [{:application/id 7
+                      :event/type :application.event/member-invited
+                      :event/actor "applicant"
+                      :application/member {:name "Some Body" :email "somebody@example.com"}
+                      :invitation/token "abc"}
+                     {:application/id 7
+                      :event/type :application.event/comment-requested
+                      :event/actor "handler"
+                      :application/request-id "r1"
+                      :application/commenters ["commenter1" "commenter2"]}
+                     {:application/id 7
+                      :event/type :application.event/member-joined
+                      :event/actor "somebody"}
+                     {:application/id 7
+                      :event/type :application.event/commented
+                      :event/actor "commenter2"
+                      :application/request-id "r1"
+                      :application/comment ["this is a comment"]}
+                     {:application/id 7
+                      :event/type :application.event/member-added
+                      :event/actor "handler"
+                      :application/member {:userid "member"}}
+                     {:application/id 7
+                      :event/type :application.event/decision-requested
+                      :event/actor "assistant"
+                      :application/request-id "r2"
+                      :application/deciders ["decider"]}
+                     {:application/id 7
+                      :event/type :application.event/decided
+                      :event/actor "decider"
+                      :application/decision :approved}
+                     {:application/id 7
+                      :event/type :application.event/approved
+                      :event/actor "handler"}
+                     {:application/id 7
+                      :event/type :application.event/closed
+                      :event/actor "assistant"}])]
         (is (= [[]
-                [{:to-user "assistant"
-                  :subject "A new application has been submitted"
-                  :body "Dear assistant,\nUser applicant has submitted a new application 7 for the resource(s) en title 11, en title 21.\nView the application: http://localhost:3001/#/application/7"}
-                 {:to-user "handler"
-                  :subject "A new application has been submitted"
-                  :body "Dear handler,\nUser applicant has submitted a new application 7 for the resource(s) en title 11, en title 21.\nView the application: http://localhost:3001/#/application/7"}]]
-               (events-to-emails base-events)))))))
+                [{:to-user "assistant",
+                  :subject "A new application has been submitted",
+                  :body "Dear assistant,\nUser applicant has submitted a new application 2001/3 for the resource(s) en title 11, en title 21.\nView the application: https://rems.server:8443/#/application/7"}
+                 {:to-user "handler",
+                  :subject "A new application has been submitted",
+                  :body "Dear handler,\nUser applicant has submitted a new application 2001/3 for the resource(s) en title 11, en title 21.\nView the application: https://rems.server:8443/#/application/7"}]
+                [{:to "somebody@example.com",
+                  :subject "Invitation to participate in an application",
+                  :body "Hello,\nThis email address (somebody@example.com) has been invited to participate in an application.\nParticipate with this link: https://rems.server:8443/accept-invitation?token=abc"}]
+                [{:to-user "commenter1",
+                  :subject "Comment request",
+                  :body "Dear commenter1,\nUser handler has requested your comment on application 2001/3.\nComment here: https://rems.server:8443/#/application/7"}
+                 {:to-user "commenter2",
+                  :subject "Comment request",
+                  :body "Dear commenter2,\nUser handler has requested your comment on application 2001/3.\nComment here: https://rems.server:8443/#/application/7"}]
+                []
+                [{:to-user "assistant",
+                  :subject "New comment notification",
+                  :body "Dear assistant,\nUser commenter2 has posted a comment on application 2001/3.\nView the application: https://rems.server:8443/#/application/7"}
+                 {:to-user "handler",
+                  :subject "New comment notification",
+                  :body "Dear handler,\nUser commenter2 has posted a comment on application 2001/3.\nView the application: https://rems.server:8443/#/application/7"}]
+                [{:to-user "member",
+                  :subject "You've been added as a member to an application",
+                  :body "Dear member,\nYou've been added as a member to application 2001/3.\nView the application: https://rems.server:8443/#/application/7"}]
+                [{:to-user "decider",
+                  :subject "Decision request",
+                  :body "Dear decider,\nUser assistant has requested your decision on application 2001/3.\nView the application: https://rems.server:8443/#/application/7"}]
+                [{:to-user "assistant",
+                  :subject "New decision notification",
+                  :body "Dear assistant,\nUser decider has sent a decision on application 2001/3.\nView the application: https://rems.server:8443/#/application/7"}
+                 {:to-user "handler",
+                  :subject "New decision notification",
+                  :body "Dear handler,\nUser decider has sent a decision on application 2001/3.\nView the application: https://rems.server:8443/#/application/7"}]
+                [{:to-user "applicant",
+                  :subject "Your application has been approved",
+                  :body "Dear applicant,\nYour application 2001/3 has been approved.\nView your application: https://rems.server:8443/#/application/7"}
+                 {:to-user "member",
+                  :subject "Your application has been approved",
+                  :body "Dear member,\nYour application 2001/3 has been approved.\nView your application: https://rems.server:8443/#/application/7"}
+                 {:to-user "somebody",
+                  :subject "Your application has been approved",
+                  :body "Dear somebody,\nYour application 2001/3 has been approved.\nView your application: https://rems.server:8443/#/application/7"}]
+                [{:to-user "applicant",
+                  :subject "Your application has been closed",
+                  :body "Dear applicant,\nYour application 2001/3 has been closed.\nView your application: https://rems.server:8443/#/application/7"}
+                 {:to-user "member",
+                  :subject "Your application has been closed",
+                  :body "Dear member,\nYour application 2001/3 has been closed.\nView your application: https://rems.server:8443/#/application/7"}
+                 {:to-user "somebody",
+                  :subject "Your application has been closed",
+                  :body "Dear somebody,\nYour application 2001/3 has been closed.\nView your application: https://rems.server:8443/#/application/7"}]]
+               (events-to-emails events))))
+      (let [events (conj base-events
+                         {:application/id 7
+                          :event/type :application.event/rejected
+                          :event/actor "handler"})]
+        (is (= [[]
+                [{:to-user "assistant",
+                  :subject "A new application has been submitted",
+                  :body "Dear assistant,\nUser applicant has submitted a new application 2001/3 for the resource(s) en title 11, en title 21.\nView the application: https://rems.server:8443/#/application/7"}
+                 {:to-user "handler",
+                  :subject "A new application has been submitted",
+                  :body "Dear handler,\nUser applicant has submitted a new application 2001/3 for the resource(s) en title 11, en title 21.\nView the application: https://rems.server:8443/#/application/7"}]
+                [{:subject "Your application has been rejected",
+                  :body "Dear applicant,\nYour application 2001/3 has been rejected.\nView your application: https://rems.server:8443/#/application/7",
+                  :to-user "applicant"}]]
+               (events-to-emails events))))
+      (testing "id field can be overrided"
+        (with-redefs [rems.config/env (assoc rems.config/env :application-id-column :id)]
+          (is (= [[]
+                  [{:to-user "assistant"
+                    :subject "A new application has been submitted"
+                    :body "Dear assistant,\nUser applicant has submitted a new application 7 for the resource(s) en title 11, en title 21.\nView the application: https://rems.server:8443/#/application/7"}
+                   {:to-user "handler"
+                    :subject "A new application has been submitted"
+                    :body "Dear handler,\nUser applicant has submitted a new application 7 for the resource(s) en title 11, en title 21.\nView the application: https://rems.server:8443/#/application/7"}]]
+                 (events-to-emails base-events))))))))


### PR DESCRIPTION
Previously I could not run these tests in Emacs since it didn't use the test profile for running the (individual) tests.
- move email test setup into the test itself
- move extra pages setup into the test itself
- fix "typo" in url of failing test