### PR TITLE
Use rems.table2 for application lists

### DIFF
--- a/resources/translations/en.edn
+++ b/resources/translations/en.edn
@@ -25,7 +25,7 @@
             :empty "You don't have any applications to process."
             :errors {:invalid-token [:div [:p "Joining the application failed."] [:p "Check the invitation token " [:code "%1"]]]}
             :export-entitlements "Export entitlements as csv"
-            :handled-approvals "Processed applications"
+            :handled-applications "Processed applications"
             :id "Id"
             :invite-member "Invite member"
             :last-activity "Last activity"
@@ -36,7 +36,7 @@
             :member-email "Email"
             :no-handled-yet "You have not processed any applications yet."
             :ok "Ok"
-            :open-approvals "Open applications"
+            :todo-applications "Open applications"
             :reject "Reject"
             :remove-member "Remove member"
             :request-comment "Request comment"

--- a/resources/translations/fi.edn
+++ b/resources/translations/fi.edn
@@ -25,7 +25,7 @@
             :empty "Sinulla ei ole hakemuksia käsiteltäväksi."
             :errors {:invalid-token [:div [:p "Hakemukseen liittyminen epäonnistui."] [:p "Tarkista kutsukoodi " [:code "%1"]]]}
             :export-entitlements "Lataa käyttöoikeudet csv-tiedostona"
-            :handled-approvals "Käsitellyt hakemukset"
+            :handled-applications "Käsitellyt hakemukset"
             :id "Tunniste"
             :invite-member "Kutsu jäsen"
             :last-activity "Muokattu"
@@ -36,7 +36,7 @@
             :member-email "Sähköposti"
             :no-handled-yet "Et ole käsitellyt hakemuksia vielä."
             :ok "Ok"
-            :open-approvals "Avoimet hakemukset"
+            :todo-applications "Avoimet hakemukset"
             :reject "Hylkää"
             :remove-member "Poista jäsen"
             :request-comment "Pyydä kommenttia"

--- a/src/clj/rems/css/styles.clj
+++ b/src/clj/rems/css/styles.clj
@@ -157,16 +157,8 @@
                   :background-color (util/get-theme-attribute :table-bgcolor :color1)
                   :box-shadow (util/get-theme-attribute :table-shadow)
                   :color (util/get-theme-attribute :table-text-color)}
-    [:.column-header {:white-space "nowrap"}]
-    [:.column-filter {:position "relative"}
-     [:input
-      {:width "100%"}]
-     [:.reset-button
-      {:position "absolute"
-       :right "0px"
-       :top "50%"
-       :margin-top "-0.5em"}]]
-    [:th {:color (util/get-theme-attribute :table-heading-color "#fff")
+    [:th {:white-space "nowrap"
+          :color (util/get-theme-attribute :table-heading-color "#fff")
           :background-color (util/get-theme-attribute :table-heading-bgcolor :color3)}]
     [:th
      :td

--- a/src/clj/rems/css/styles.clj
+++ b/src/clj/rems/css/styles.clj
@@ -637,7 +637,7 @@
    [:h2 {:margin [[(u/rem 1) 0]]}]
 
    ;; application list
-   [:.applications
+   [:.rems-table
     [:.application-description {:overflow :hidden
                                 :text-overflow :ellipsis
                                 :white-space :nowrap

--- a/src/cljs/rems/actions.cljs
+++ b/src/cljs/rems/actions.cljs
@@ -12,60 +12,60 @@
 (rf/reg-event-fx
  ::enter-page
  (fn [{:keys [db]} _]
-   {:db (dissoc db ::actions ::handled-actions) ; zero state that should be reloaded, good for performance
-    :dispatch [::fetch-actions]}))
+   {:db (dissoc db ::todo-applications ::handled-applications)
+    :dispatch [::fetch-todo-applications]}))
 
-;;;; actions
+;;;; applications to do
 
 (rf/reg-event-fx
- ::fetch-actions
+ ::fetch-todo-applications
  (fn [{:keys [db]} _]
    (fetch "/api/applications/todo"
-          {:handler #(rf/dispatch [::fetch-actions-result %])})
-   {:db (assoc db ::loading-actions? true)}))
+          {:handler #(rf/dispatch [::fetch-todo-applications-result %])})
+   {:db (assoc db ::loading-todo-applications? true)}))
 
 (rf/reg-event-db
- ::fetch-actions-result
+ ::fetch-todo-applications-result
  (fn [db [_ result]]
    (-> db
-       (assoc ::actions result)
-       (dissoc ::loading-actions?))))
+       (assoc ::todo-applications result)
+       (dissoc ::loading-todo-applications?))))
 
 (rf/reg-sub
- ::actions
+ ::todo-applications
  (fn [db _]
-   (::actions db)))
+   (::todo-applications db)))
 
 (rf/reg-sub
- ::loading-actions?
+ ::loading-todo-applications?
  (fn [db _]
-   (::loading-actions? db)))
+   (::loading-todo-applications? db)))
 
-;;;; handled actions
+;;;; handled applications
 
 (rf/reg-event-fx
- ::fetch-handled-actions
+ ::fetch-handled-applications
  (fn [{:keys [db]} _]
    (fetch "/api/applications/handled"
-          {:handler #(rf/dispatch [::fetch-handled-actions-result %])})
-   {:db (assoc db ::loading-handled-actions? true)}))
+          {:handler #(rf/dispatch [::fetch-handled-applications-result %])})
+   {:db (assoc db ::loading-handled-applications? true)}))
 
 (rf/reg-event-db
- ::fetch-handled-actions-result
+ ::fetch-handled-applications-result
  (fn [db [_ result]]
    (-> db
-       (assoc ::handled-actions result)
-       (dissoc ::loading-handled-actions?))))
+       (assoc ::handled-applications result)
+       (dissoc ::loading-handled-applications?))))
 
 (rf/reg-sub
- ::handled-actions
+ ::handled-applications
  (fn [db _]
-   (::handled-actions db)))
+   (::handled-applications db)))
 
 (rf/reg-sub
- ::loading-handled-actions?
+ ::loading-handled-applications?
  (fn [db _]
-   (::loading-handled-actions? db)))
+   (::loading-handled-applications? db)))
 
 ;;;; UI
 
@@ -103,19 +103,19 @@
      :default-sort-column :last-activity
      :default-sort-order :desc}))
 
-(defn- open-applications []
-  (let [applications ::actions]
+(defn- todo-applications []
+  (let [applications ::todo-applications]
     (if (empty? @(rf/subscribe [applications]))
       [:div.actions.alert.alert-success (text :t.actions/empty)]
       [application-list/component2
        (-> (application-list-defaults)
-           (assoc :id ::open-applications
+           (assoc :id applications
                   :applications applications))])))
 
 (defn- handled-applications []
-  (let [applications ::handled-actions]
+  (let [applications ::handled-applications]
     (cond
-      @(rf/subscribe [::loading-handled-actions?])
+      @(rf/subscribe [::loading-handled-applications?])
       [spinner/big]
 
       (empty? @(rf/subscribe [applications]))
@@ -125,22 +125,22 @@
       [application-list/component2
        (-> (application-list-defaults)
            (update :visible-columns disj :submitted)
-           (assoc :id ::handled-applications
+           (assoc :id applications
                   :applications applications))])))
 
 (defn actions-page []
   [:div
    [document-title (text :t.navigation/actions)]
-   (if @(rf/subscribe [::loading-actions?])
+   (if @(rf/subscribe [::loading-todo-applications?])
      [spinner/big]
      [:div.spaced-sections
       [collapsible/component
-       {:id "open-approvals"
+       {:id "todo-applications"
         :open? true
-        :title (text :t.actions/open-approvals)
-        :collapse [open-applications]}]
+        :title (text :t.actions/todo-applications)
+        :collapse [todo-applications]}]
       [collapsible/component
-       {:id "handled-approvals"
-        :on-open #(rf/dispatch [::fetch-handled-actions])
-        :title (text :t.actions/handled-approvals)
+       {:id "handled-applications"
+        :on-open #(rf/dispatch [::fetch-handled-applications])
+        :title (text :t.actions/handled-applications)
         :collapse [handled-applications]}]])])

--- a/src/cljs/rems/actions.cljs
+++ b/src/cljs/rems/actions.cljs
@@ -13,7 +13,8 @@
  ::enter-page
  (fn [{:keys [db]} _]
    {:db (dissoc db ::todo-applications ::handled-applications)
-    :dispatch [::fetch-todo-applications]}))
+    :dispatch-n [[::fetch-todo-applications]
+                 [:rems.table2/reset]]}))
 
 ;;;; applications to do
 

--- a/src/cljs/rems/actions.cljs
+++ b/src/cljs/rems/actions.cljs
@@ -107,7 +107,7 @@
   (let [applications ::todo-applications]
     (if (empty? @(rf/subscribe [applications]))
       [:div.actions.alert.alert-success (text :t.actions/empty)]
-      [application-list/component2
+      [application-list/component
        (-> (application-list-defaults)
            (assoc :id applications
                   :applications applications))])))
@@ -122,7 +122,7 @@
       [:div.actions.alert.alert-success (text :t.actions/no-handled-yet)]
 
       :else
-      [application-list/component2
+      [application-list/component
        (-> (application-list-defaults)
            (update :visible-columns disj :submitted)
            (assoc :id applications

--- a/src/cljs/rems/actions.cljs
+++ b/src/cljs/rems/actions.cljs
@@ -113,18 +113,18 @@
    [show-publications-button]
    [show-throughput-times-button]])
 
-(defn- open-applications
-  [apps]
-  (if (empty? apps)
-    [:div.actions.alert.alert-success (text :t.actions/empty)]
-    [application-list/component
-     {:visible-columns (into [(get @(rf/subscribe [:rems.config/config]) :application-id-column :id)]
-                             [:description :resource :applicant :state :submitted :last-activity :view])
-      :sorting (assoc @(rf/subscribe [::sorting ::open-applications])
-                      :set-sorting #(rf/dispatch [::set-sorting ::open-applications %]))
-      :filtering (assoc @(rf/subscribe [::filtering ::open-applications])
-                        :set-filtering #(rf/dispatch [::set-filtering ::open-applications %]))
-      :items apps}]))
+(defn- open-applications []
+  (let [apps @(rf/subscribe [::actions])
+        config @(rf/subscribe [:rems.config/config])
+        id-column (get config :application-id-column :id)]
+    (if (empty? apps)
+      [:div.actions.alert.alert-success (text :t.actions/empty)]
+      [application-list/component2
+       {:id ::open-applications
+        :applications ::actions
+        :visible-columns #{id-column :description :resource :applicant :state :submitted :last-activity :view}
+        :default-sort-column :last-activity
+        :default-sort-order :desc}])))
 
 (defn- handled-applications
   "Creates a table containing a list of handled applications.
@@ -150,8 +150,7 @@
          :items apps}]])))
 
 (defn actions-page []
-  (let [actions @(rf/subscribe [::actions])
-        handled-actions @(rf/subscribe [::handled-actions])]
+  (let [handled-actions @(rf/subscribe [::handled-actions])]
     [:div
      [document-title (text :t.navigation/actions)]
      (if @(rf/subscribe [::loading-actions?])
@@ -161,7 +160,7 @@
          {:id "open-approvals"
           :open? true
           :title (text :t.actions/open-approvals)
-          :collapse [open-applications actions]}]
+          :collapse [open-applications]}]
         [collapsible/component
          {:id "handled-approvals"
           :on-open #(rf/dispatch [::fetch-handled-actions])

--- a/src/cljs/rems/application_list.cljs
+++ b/src/cljs/rems/application_list.cljs
@@ -77,43 +77,24 @@
 
 (defn component [{:keys [id applications visible-columns default-sort-column default-sort-order filterable?]}]
   (let [all-columns [{:key :id
-                      :title (text :t.actions/id)
-                      :sortable? true
-                      :filterable? true}
+                      :title (text :t.actions/id)}
                      {:key :external-id
-                      :title (text :t.actions/id)
-                      :sortable? true
-                      :filterable? true}
+                      :title (text :t.actions/id)}
                      {:key :description
-                      :title (text :t.actions/description)
-                      :sortable? true
-                      :filterable? true}
+                      :title (text :t.actions/description)}
                      {:key :resource
-                      :title (text :t.actions/resource)
-                      :sortable? true
-                      :filterable? true}
+                      :title (text :t.actions/resource)}
                      {:key :applicant
-                      :title (text :t.actions/applicant)
-                      :sortable? true
-                      :filterable? true}
+                      :title (text :t.actions/applicant)}
                      {:key :state
-                      :title (text :t.actions/state)
-                      :sortable? true
-                      :filterable? true}
+                      :title (text :t.actions/state)}
                      {:key :created
-                      :title (text :t.actions/created)
-                      :sortable? true
-                      :filterable? true}
+                      :title (text :t.actions/created)}
                      {:key :submitted
-                      :title (text :t.actions/submitted)
-                      :sortable? true
-                      :filterable? true}
+                      :title (text :t.actions/submitted)}
                      {:key :last-activity
-                      :title (text :t.actions/last-activity)
-                      :sortable? true
-                      :filterable? true}
+                      :title (text :t.actions/last-activity)}
                      {:key :view
-                      :title ""
                       :sortable? false
                       :filterable? false}]
         visible-columns (or visible-columns (constantly true))

--- a/src/cljs/rems/application_list.cljs
+++ b/src/cljs/rems/application_list.cljs
@@ -37,6 +37,7 @@
                                 :id {:value :application/id
                                      :header #(text :t.actions/id)}
                                 :description {:value format-description
+                                              :sort-value :application/description
                                               :header #(text :t.actions/description)}
                                 :resource {:value format-catalogue-items
                                            :header #(text :t.actions/resource)}
@@ -66,30 +67,39 @@
  (fn [[_ apps-sub] _]
    [(rf/subscribe [apps-sub])])
  (fn [[apps] _]
-   ;; TODO: sorting and filtering
+   ;; TODO: filtering
    (map (fn [app]
-          {:external-id {:td [:td.external-id
-                              (:application/external-id app)]}
-           :id {:td [:td.id
-                     (:application/id app)]}
-           :description {:td [:td.description
-                              (format-description app)]}
-           :resource {:td [:td.resource
-                           (format-catalogue-items app)]}
-           :applicant {:td [:td.applicant
-                            (:application/applicant app)]}
-           :state {:td [:td.state
-                        {:class (when (application-util/form-fields-editable? app)
-                                  "text-highlight")}
-                        (localize-state (:application/state app))]}
-           :created {:td [:td.created
-                          (localize-time (:application/created app))]}
-           :submitted {:td [:td.submitted
-                            (localize-time (:application/first-submitted app))]}
-           :last-activity {:td [:td.last-activity
-                                (localize-time (:application/last-activity app))]}
-           :view {:td [:td.view
-                       [view-button app]]}})
+          {:external-id (let [value (:application/external-id app)]
+                          {:td [:td.external-id value]
+                           :sort-value value})
+           :id (let [value (:application/id app)]
+                 {:td [:td.id value]
+                  :sort-value value})
+           :description {:td [:td.description (format-description app)]
+                         :sort-value (:application/description app)}
+           :resource (let [value (format-catalogue-items app)]
+                       {:td [:td.resource value]
+                        :sort-value value})
+           :applicant (let [value (:application/applicant app)]
+                        {:td [:td.applicant value]
+                         :sort-value value})
+           :state (let [value (localize-state (:application/state app))]
+                    {:td [:td.state
+                          {:class (when (application-util/form-fields-editable? app)
+                                    "text-highlight")}
+                          value]
+                     :sort-value value})
+           :created (let [value (:application/created app)]
+                      {:td [:td.created
+                            (localize-time value)]
+                       :sort-value value})
+           :submitted (let [value (:application/first-submitted app)]
+                        {:td [:td.submitted (localize-time value)]
+                         :sort-value value})
+           :last-activity (let [value (:application/last-activity app)]
+                            {:td [:td.last-activity (localize-time value)]
+                             :sort-value value})
+           :view {:td [:td.view [view-button app]]}})
         apps)))
 
 (defn component2 [{:keys [id applications visible-columns default-sort-column default-sort-order]}]

--- a/src/cljs/rems/application_list.cljs
+++ b/src/cljs/rems/application_list.cljs
@@ -114,7 +114,7 @@
            :view {:td [:td.view [view-button app]]}})
         apps)))
 
-(defn component2 [{:keys [id applications visible-columns default-sort-column default-sort-order]}]
+(defn component2 [{:keys [id applications visible-columns default-sort-column default-sort-order filterable?]}]
   (let [all-columns [{:key :id
                       :title (text :t.actions/id)
                       :sortable? true
@@ -162,7 +162,8 @@
                            :default-sort-column default-sort-column
                            :default-sort-order default-sort-order}]
     [:div
-     [table2/search application-table]
+     (when-not (false? filterable?)
+       [table2/search application-table])
      [table2/table application-table]]))
 
 (defn guide []
@@ -207,7 +208,7 @@
        :application/last-activity "2017-01-01T01:01:01:001Z"}]))
 
   [:div
-   (component-info component)
+   (component-info component2)
    (example "empty list"
             [component2 {:id ::example1
                          :applications ::no-applications

--- a/src/cljs/rems/application_list.cljs
+++ b/src/cljs/rems/application_list.cljs
@@ -67,39 +67,50 @@
  (fn [[_ apps-sub] _]
    [(rf/subscribe [apps-sub])])
  (fn [[apps] _]
-   ;; TODO: filtering
    (map (fn [app]
           {:key (:application/id app)
            :external-id (let [value (:application/external-id app)]
                           {:td [:td.external-id value]
-                           :sort-value value})
+                           :sort-value value
+                           :filter-value (str/lower-case value)})
            :id (let [value (:application/id app)]
                  {:td [:td.id value]
-                  :sort-value value})
-           :description {:td [:td.description (format-description app)]
-                         :sort-value (:application/description app)}
+                  :sort-value value
+                  :filter-value (str/lower-case (str value))})
+           :description (let [value (:application/description app)]
+                          {:td [:td.description (format-description app)]
+                           :sort-value value
+                           :filter-value (str/lower-case value)})
            :resource (let [value (format-catalogue-items app)]
                        {:td [:td.resource value]
-                        :sort-value value})
+                        :sort-value value
+                        :filter-value (str/lower-case value)})
            :applicant (let [value (:application/applicant app)]
                         {:td [:td.applicant value]
-                         :sort-value value})
+                         :sort-value value
+                         :filter-value (str/lower-case value)})
            :state (let [value (localize-state (:application/state app))]
                     {:td [:td.state
                           {:class (when (application-util/form-fields-editable? app)
                                     "text-highlight")}
                           value]
-                     :sort-value value})
-           :created (let [value (:application/created app)]
-                      {:td [:td.created
-                            (localize-time value)]
-                       :sort-value value})
-           :submitted (let [value (:application/first-submitted app)]
-                        {:td [:td.submitted (localize-time value)]
-                         :sort-value value})
-           :last-activity (let [value (:application/last-activity app)]
-                            {:td [:td.last-activity (localize-time value)]
-                             :sort-value value})
+                     :sort-value value
+                     :filter-value (str/lower-case value)})
+           :created (let [value (:application/created app)
+                          display-value (localize-time value)]
+                      {:td [:td.created display-value]
+                       :sort-value value
+                       :filter-value (str/lower-case display-value)})
+           :submitted (let [value (:application/first-submitted app)
+                            display-value (localize-time value)]
+                        {:td [:td.submitted display-value]
+                         :sort-value value
+                         :filter-value (str/lower-case (str display-value))})
+           :last-activity (let [value (:application/last-activity app)
+                                display-value (localize-time value)]
+                            {:td [:td.last-activity display-value]
+                             :sort-value value
+                             :filter-value (str/lower-case display-value)})
            :view {:td [:td.view [view-button app]]}})
         apps)))
 
@@ -150,7 +161,9 @@
                            :rows [::table-rows applications]
                            :default-sort-column default-sort-column
                            :default-sort-order default-sort-order}]
-    [table2/table application-table]))
+    [:div
+     [table2/search application-table]
+     [table2/table application-table]]))
 
 (def ^:private +example-applications+
   [{:application/id 1

--- a/src/cljs/rems/application_list.cljs
+++ b/src/cljs/rems/application_list.cljs
@@ -69,7 +69,8 @@
  (fn [[apps] _]
    ;; TODO: filtering
    (map (fn [app]
-          {:external-id (let [value (:application/external-id app)]
+          {:key (:application/id app)
+           :external-id (let [value (:application/external-id app)]
                           {:td [:td.external-id value]
                            :sort-value value})
            :id (let [value (:application/id app)]

--- a/src/cljs/rems/application_list.cljs
+++ b/src/cljs/rems/application_list.cljs
@@ -162,6 +162,5 @@
    (example "applications, descending date, all columns"
             [component {:id ::example3
                         :applications ::example-applications
-                        :visible-columns (constantly true)
                         :default-sort-column :created
                         :default-sort-order :desc}])])

--- a/src/cljs/rems/application_list.cljs
+++ b/src/cljs/rems/application_list.cljs
@@ -1,5 +1,6 @@
 (ns rems.application-list
   (:require [clojure.string :as str]
+            [re-frame.core :as rf]
             [rems.application-util :as application-util]
             [rems.guide-functions]
             [rems.table :as table]
@@ -60,6 +61,25 @@
            :class "applications"}
           opts)])
 
+(rf/reg-sub
+ ::table-rows
+ (fn [[_ apps-sub] _]
+   [(rf/subscribe [apps-sub])])
+ (fn [[apps] _]
+   ;; TODO
+   (map (fn [app]
+          {:external-id {:td [:td.external-id "x"]}
+           :id {:td [:td.id "x"]}
+           :description {:td [:td.description "x"]}
+           :resource {:td [:td.resource "x"]}
+           :applicant {:td [:td.applicant "x"]}
+           :state {:td [:td.state "x"]}
+           :created {:td [:td.created "x"]}
+           :submitted {:td [:td.submitted "x"]}
+           :last-activity {:td [:td.last-activity "x"]}
+           :view {:td [:td.view "x"]}})
+        apps)))
+
 (defn component2 [{:keys [id applications visible-columns default-sort-column default-sort-order]}]
   (let [all-columns [{:key :external-id
                       :title (text :t.actions/id)
@@ -104,7 +124,7 @@
         visible-columns (or visible-columns (constantly true))
         application-table {:id id
                            :columns (filter #(visible-columns (:key %)) all-columns)
-                           :rows applications ; TODO: preprocess subscription
+                           :rows [::table-rows applications]
                            :default-sort-column default-sort-column
                            :default-sort-order default-sort-order}]
     [table2/table application-table]))

--- a/src/cljs/rems/application_list.cljs
+++ b/src/cljs/rems/application_list.cljs
@@ -3,7 +3,6 @@
             [re-frame.core :as rf]
             [rems.application-util :as application-util]
             [rems.guide-functions]
-            [rems.table :as table]
             [rems.table2 :as table2]
             [rems.text :refer [localize-state localize-time localized text]])
   (:require-macros [rems.guide-macros :refer [component-info example]]))
@@ -23,44 +22,6 @@
   [:div {:class "application-description"
          :title (:application/description app)}
    (:application/description app)])
-
-(defn component
-  "A table of applications.
-
-  See `table/component`.
-
-  Binds the column definitions for you and the visible columns should be a subsequence."
-  [opts]
-  [table/component
-   (merge {:column-definitions {:external-id {:value :application/external-id
-                                              :header #(text :t.actions/id)}
-                                :id {:value :application/id
-                                     :header #(text :t.actions/id)}
-                                :description {:value format-description
-                                              :sort-value :application/description
-                                              :header #(text :t.actions/description)}
-                                :resource {:value format-catalogue-items
-                                           :header #(text :t.actions/resource)}
-                                :applicant {:value :application/applicant
-                                            :header #(text :t.actions/applicant)}
-                                :state {:value #(localize-state (:application/state %))
-                                        :header #(text :t.actions/state)
-                                        :class #(if (application-util/form-fields-editable? %) "state text-highlight" "state")}
-                                :created {:value #(localize-time (:application/created %))
-                                          :sort-value :application/created
-                                          :header #(text :t.actions/created)}
-                                :submitted {:value #(localize-time (:application/first-submitted %))
-                                            :sort-value :application/first-submitted
-                                            :header #(text :t.actions/submitted)}
-                                :last-activity {:value #(localize-time (:application/last-activity %))
-                                                :sort-value :application/last-activity
-                                                :header #(text :t.actions/last-activity)}
-                                :view {:value view-button
-                                       :sortable? false
-                                       :filterable? false}}
-           :id-function #(str "application-" (:application/id %))
-           :class "applications"}
-          opts)])
 
 (rf/reg-sub
  ::table-rows
@@ -114,7 +75,7 @@
            :view {:td [:td.view [view-button app]]}})
         apps)))
 
-(defn component2 [{:keys [id applications visible-columns default-sort-column default-sort-order filterable?]}]
+(defn component [{:keys [id applications visible-columns default-sort-column default-sort-order filterable?]}]
   (let [all-columns [{:key :id
                       :title (text :t.actions/id)
                       :sortable? true
@@ -208,18 +169,18 @@
        :application/last-activity "2017-01-01T01:01:01:001Z"}]))
 
   [:div
-   (component-info component2)
+   (component-info component)
    (example "empty list"
-            [component2 {:id ::example1
-                         :applications ::no-applications
-                         :visible-columns #{:id :description :resource :applicant :state :created :last-activity :view}}])
+            [component {:id ::example1
+                        :applications ::no-applications
+                        :visible-columns #{:id :description :resource :applicant :state :created :last-activity :view}}])
    (example "applications, default order"
-            [component2 {:id ::example2
-                         :applications ::example-applications
-                         :visible-columns #{:id :description :resource :applicant :state :created :last-activity :view}}])
+            [component {:id ::example2
+                        :applications ::example-applications
+                        :visible-columns #{:id :description :resource :applicant :state :created :last-activity :view}}])
    (example "applications, descending date, all columns"
-            [component2 {:id ::example3
-                         :applications ::example-applications
-                         :visible-columns (constantly true)
-                         :default-sort-column :created
-                         :default-sort-order :desc}])])
+            [component {:id ::example3
+                        :applications ::example-applications
+                        :visible-columns (constantly true)
+                        :default-sort-column :created
+                        :default-sort-order :desc}])])

--- a/src/cljs/rems/application_list.cljs
+++ b/src/cljs/rems/application_list.cljs
@@ -3,6 +3,7 @@
             [rems.application-util :as application-util]
             [rems.guide-functions]
             [rems.table :as table]
+            [rems.table2 :as table2]
             [rems.text :refer [localize-state localize-time localized text]])
   (:require-macros [rems.guide-macros :refer [component-info example]]))
 
@@ -58,6 +59,55 @@
            :id-function #(str "application-" (:application/id %))
            :class "applications"}
           opts)])
+
+(defn component2 [{:keys [id applications visible-columns default-sort-column default-sort-order]}]
+  (let [all-columns [{:key :external-id
+                      :title (text :t.actions/id)
+                      :sortable? true
+                      :filterable? true}
+                     {:key :id
+                      :title (text :t.actions/id)
+                      :sortable? true
+                      :filterable? true}
+                     {:key :description
+                      :title (text :t.actions/description)
+                      :sortable? true
+                      :filterable? true}
+                     {:key :resource
+                      :title (text :t.actions/resource)
+                      :sortable? true
+                      :filterable? true}
+                     {:key :applicant
+                      :title (text :t.actions/applicant)
+                      :sortable? true
+                      :filterable? true}
+                     {:key :state
+                      :title (text :t.actions/state)
+                      :sortable? true
+                      :filterable? true}
+                     {:key :created
+                      :title (text :t.actions/created)
+                      :sortable? true
+                      :filterable? true}
+                     {:key :submitted
+                      :title (text :t.actions/submitted)
+                      :sortable? true
+                      :filterable? true}
+                     {:key :last-activity
+                      :title (text :t.actions/last-activity)
+                      :sortable? true
+                      :filterable? true}
+                     {:key :view
+                      :title ""
+                      :sortable? false
+                      :filterable? false}]
+        visible-columns (or visible-columns (constantly true))
+        application-table {:id id
+                           :columns (filter #(visible-columns (:key %)) all-columns)
+                           :rows applications ; TODO: preprocess subscription
+                           :default-sort-column default-sort-column
+                           :default-sort-order default-sort-order}]
+    [table2/table application-table]))
 
 (def ^:private +example-applications+
   [{:application/id 1

--- a/src/cljs/rems/application_list.cljs
+++ b/src/cljs/rems/application_list.cljs
@@ -69,38 +69,38 @@
  (fn [[apps] _]
    (map (fn [app]
           {:key (:application/id app)
-           :external-id (let [value (:application/external-id app)]
-                          {:td [:td.external-id value]
-                           :sort-value value
-                           :filter-value (str/lower-case value)})
            :id (let [value (:application/id app)]
                  {:td [:td.id value]
                   :sort-value value
                   :filter-value (str/lower-case (str value))})
+           :external-id (let [value (:application/external-id app)]
+                          {:td [:td.external-id value]
+                           :sort-value value
+                           :filter-value (str/lower-case (str value))})
            :description (let [value (:application/description app)]
                           {:td [:td.description (format-description app)]
                            :sort-value value
-                           :filter-value (str/lower-case value)})
+                           :filter-value (str/lower-case (str value))})
            :resource (let [value (format-catalogue-items app)]
                        {:td [:td.resource value]
                         :sort-value value
-                        :filter-value (str/lower-case value)})
+                        :filter-value (str/lower-case (str value))})
            :applicant (let [value (:application/applicant app)]
                         {:td [:td.applicant value]
                          :sort-value value
-                         :filter-value (str/lower-case value)})
+                         :filter-value (str/lower-case (str value))})
            :state (let [value (localize-state (:application/state app))]
                     {:td [:td.state
                           {:class (when (application-util/form-fields-editable? app)
                                     "text-highlight")}
                           value]
                      :sort-value value
-                     :filter-value (str/lower-case value)})
+                     :filter-value (str/lower-case (str value))})
            :created (let [value (:application/created app)
                           display-value (localize-time value)]
                       {:td [:td.created display-value]
                        :sort-value value
-                       :filter-value (str/lower-case display-value)})
+                       :filter-value (str/lower-case (str display-value))})
            :submitted (let [value (:application/first-submitted app)
                             display-value (localize-time value)]
                         {:td [:td.submitted display-value]
@@ -110,16 +110,16 @@
                                 display-value (localize-time value)]
                             {:td [:td.last-activity display-value]
                              :sort-value value
-                             :filter-value (str/lower-case display-value)})
+                             :filter-value (str/lower-case (str display-value))})
            :view {:td [:td.view [view-button app]]}})
         apps)))
 
 (defn component2 [{:keys [id applications visible-columns default-sort-column default-sort-order]}]
-  (let [all-columns [{:key :external-id
+  (let [all-columns [{:key :id
                       :title (text :t.actions/id)
                       :sortable? true
                       :filterable? true}
-                     {:key :id
+                     {:key :external-id
                       :title (text :t.actions/id)
                       :sortable? true
                       :filterable? true}
@@ -165,57 +165,60 @@
      [table2/search application-table]
      [table2/table application-table]]))
 
-(def ^:private +example-applications+
-  [{:application/id 1
-    :application/resources [{:catalogue-item/title {:en "Item 5"}}]
-    :application/state :application.state/draft
-    :application/applicant "alice"
-    :application/created "1980-01-02T13:45:00.000Z"
-    :application/last-activity "2017-01-01T01:01:01:001Z"}
-   {:application/id 2
-    :application/resources [{:catalogue-item/title {:en "Item 3"}}]
-    :application/state :application.state/submitted
-    :application/applicant "bob"
-    :application/created "1971-02-03T23:59:00.000Z"
-    :application/last-activity "2017-01-01T01:01:01:001Z"}
-   {:application/id 3
-    :application/resources [{:catalogue-item/title {:en "Item 2"}}
-                            {:catalogue-item/title {:en "Item 5"}}]
-    :application/state :application.state/approved
-    :application/applicant "charlie"
-    :application/created "1980-01-01T01:01:00.000Z"
-    :application/last-activity "2017-01-01T01:01:01:001Z"}
-   {:application/id 4
-    :application/resources [{:catalogue-item/title {:en "Item 2"}}]
-    :application/state :application.state/rejected
-    :application/applicant "david"
-    :application/created "1972-12-12T12:12:00.000Z"
-    :application/last-activity "2017-01-01T01:01:01:001Z"}
-   {:application/id 5
-    :application/resources [{:catalogue-item/title {:en "Item 2"}}]
-    :application/state :application.state/closed
-    :application/applicant "ernie"
-    :application/created "1972-12-12T12:12:00.000Z"
-    :application/last-activity "2017-01-01T01:01:01:001Z"}])
+(defn guide []
+  (rf/reg-sub
+   ::no-applications
+   (fn [_ _]
+     []))
 
-(defn guide
-  []
+  (rf/reg-sub
+   ::example-applications
+   (fn [_ _]
+     [{:application/id 1
+       :application/resources [{:catalogue-item/title {:en "Item 5"}}]
+       :application/state :application.state/draft
+       :application/applicant "alice"
+       :application/created "1980-01-02T13:45:00.000Z"
+       :application/last-activity "2017-01-01T01:01:01:001Z"}
+      {:application/id 2
+       :application/resources [{:catalogue-item/title {:en "Item 3"}}]
+       :application/state :application.state/submitted
+       :application/applicant "bob"
+       :application/created "1971-02-03T23:59:00.000Z"
+       :application/last-activity "2017-01-01T01:01:01:001Z"}
+      {:application/id 3
+       :application/resources [{:catalogue-item/title {:en "Item 2"}}
+                               {:catalogue-item/title {:en "Item 5"}}]
+       :application/state :application.state/approved
+       :application/applicant "charlie"
+       :application/created "1980-01-01T01:01:00.000Z"
+       :application/last-activity "2017-01-01T01:01:01:001Z"}
+      {:application/id 4
+       :application/resources [{:catalogue-item/title {:en "Item 2"}}]
+       :application/state :application.state/rejected
+       :application/applicant "david"
+       :application/created "1972-12-12T12:12:00.000Z"
+       :application/last-activity "2017-01-01T01:01:01:001Z"}
+      {:application/id 5
+       :application/resources [{:catalogue-item/title {:en "Item 2"}}]
+       :application/state :application.state/closed
+       :application/applicant "ernie"
+       :application/created "1972-12-12T12:12:00.000Z"
+       :application/last-activity "2017-01-01T01:01:01:001Z"}]))
+
   [:div
    (component-info component)
    (example "empty list"
-            [component {:visible-columns [:id :description :resource :applicant :state :created :last-activity :view]
-                        :sorting {:sort-column :id :sort-order :asc}
-                        :items []}])
+            [component2 {:id ::example1
+                         :applications ::no-applications
+                         :visible-columns #{:id :description :resource :applicant :state :created :last-activity :view}}])
    (example "applications, default order"
-            [component {:visible-columns [:id :description :resource :applicant :state :created :last-activity :view]
-                        :sorting {:sort-column :id :sort-order :asc}
-                        :items +example-applications+}])
+            [component2 {:id ::example2
+                         :applications ::example-applications
+                         :visible-columns #{:id :description :resource :applicant :state :created :last-activity :view}}])
    (example "applications, descending date, all columns"
-            [component {:visible-columns [:id :description :resource :applicant :state :created :last-activity :view]
-                        :sorting {:sort-column :created :sort-order :desc}
-                        :items +example-applications+}])
-   (example "applications, initially sorted by id descending, then resource descending"
-            [component {:visible-columns [:id :description :resource :applicant :state :created :last-activity :view]
-                        :sorting {:initial-sort [{:sort-column :id :sort-order :desc}
-                                                 {:sort-column :resource :sort-order :desc}]}
-                        :items +example-applications+}])])
+            [component2 {:id ::example3
+                         :applications ::example-applications
+                         :visible-columns (constantly true)
+                         :default-sort-column :created
+                         :default-sort-order :desc}])])

--- a/src/cljs/rems/application_list.cljs
+++ b/src/cljs/rems/application_list.cljs
@@ -75,7 +75,8 @@
            :view {:td [:td.view [view-button app]]}})
         apps)))
 
-(defn component [{:keys [id applications visible-columns default-sort-column default-sort-order filterable?]}]
+(defn component [{:keys [id applications visible-columns default-sort-column default-sort-order filterable?]
+                  :or {visible-columns (constantly true) filterable? true}}]
   (let [all-columns [{:key :id
                       :title (text :t.actions/id)}
                      {:key :external-id
@@ -97,14 +98,13 @@
                      {:key :view
                       :sortable? false
                       :filterable? false}]
-        visible-columns (or visible-columns (constantly true))
         application-table {:id id
                            :columns (filter #(visible-columns (:key %)) all-columns)
                            :rows [::table-rows applications]
                            :default-sort-column default-sort-column
                            :default-sort-order default-sort-order}]
     [:div
-     (when-not (false? filterable?)
+     (when filterable?
        [table2/search application-table])
      [table2/table application-table]]))
 

--- a/src/cljs/rems/application_list.cljs
+++ b/src/cljs/rems/application_list.cljs
@@ -66,18 +66,30 @@
  (fn [[_ apps-sub] _]
    [(rf/subscribe [apps-sub])])
  (fn [[apps] _]
-   ;; TODO
+   ;; TODO: sorting and filtering
    (map (fn [app]
-          {:external-id {:td [:td.external-id "x"]}
-           :id {:td [:td.id "x"]}
-           :description {:td [:td.description "x"]}
-           :resource {:td [:td.resource "x"]}
-           :applicant {:td [:td.applicant "x"]}
-           :state {:td [:td.state "x"]}
-           :created {:td [:td.created "x"]}
-           :submitted {:td [:td.submitted "x"]}
-           :last-activity {:td [:td.last-activity "x"]}
-           :view {:td [:td.view "x"]}})
+          {:external-id {:td [:td.external-id
+                              (:application/external-id app)]}
+           :id {:td [:td.id
+                     (:application/id app)]}
+           :description {:td [:td.description
+                              (format-description app)]}
+           :resource {:td [:td.resource
+                           (format-catalogue-items app)]}
+           :applicant {:td [:td.applicant
+                            (:application/applicant app)]}
+           :state {:td [:td.state
+                        {:class (when (application-util/form-fields-editable? app)
+                                  "text-highlight")}
+                        (localize-state (:application/state app))]}
+           :created {:td [:td.created
+                          (localize-time (:application/created app))]}
+           :submitted {:td [:td.submitted
+                            (localize-time (:application/first-submitted app))]}
+           :last-activity {:td [:td.last-activity
+                                (localize-time (:application/last-activity app))]}
+           :view {:td [:td.view
+                       [view-button app]]}})
         apps)))
 
 (defn component2 [{:keys [id applications visible-columns default-sort-column default-sort-order]}]

--- a/src/cljs/rems/applications.cljs
+++ b/src/cljs/rems/applications.cljs
@@ -13,7 +13,8 @@
    {:db (dissoc db ::my-applications ::all-applications)
     :dispatch-n [[::fetch-my-applications]
                  (when (roles/show-all-applications? (:roles (:identity db)))
-                   [::fetch-all-applications])]}))
+                   [::fetch-all-applications])
+                 [:rems.table2/reset]]}))
 
 ;;;; my applications
 

--- a/src/cljs/rems/applications.cljs
+++ b/src/cljs/rems/applications.cljs
@@ -92,12 +92,12 @@
      [document-title (text :t.applications/applications)]
      (when (roles/show-all-applications? (:roles identity))
        [:h2 (text :t.applications/my-applications)])
-     [application-list {:id :my-applications
+     [application-list {:id ::my-applications
                         :applications ::my-applications
                         ::loading? @(rf/subscribe [::loading-my-applications?])}]
      (when (roles/show-all-applications? (:roles identity))
        [:div
         [:h2 (text :t.applications/all-applications)]
-        [application-list {:id :all-applications
+        [application-list {:id ::all-applications
                            :applications ::all-applications
                            ::loading? @(rf/subscribe [::loading-all-applications?])}]])]))

--- a/src/cljs/rems/applications.cljs
+++ b/src/cljs/rems/applications.cljs
@@ -67,64 +67,37 @@
  (fn [db _]
    (::loading-all-applications? db)))
 
-;;;; table sorting
-
-(rf/reg-sub
- ::sorting
- (fn [db _]
-   (or (::sorting db)
-       {:sort-column :created
-        :sort-order :desc})))
-
-(rf/reg-event-db ::set-sorting (fn [db [_ sorting]] (assoc db ::sorting sorting)))
-
-(rf/reg-sub ::filtering (fn [db _] (::filtering db)))
-
-(rf/reg-event-db ::set-filtering (fn [db [_ filtering]] (assoc db ::filtering filtering)))
-
 ;;;; UI
 
-;; XXX: the application lists share sorting and filtering state
-(defn- application-list [apps loading? opts]
-  (cond loading?
-        [spinner/big]
+(defn- application-list [opts]
+  (let [apps @(rf/subscribe [(:applications opts)])]
+    (cond (::loading? opts)
+          [spinner/big]
 
-        (empty? apps)
-        [:div.applications.alert.alert-success (text :t.applications/empty)]
+          (empty? apps)
+          [:div.applications.alert.alert-success (text :t.applications/empty)]
 
-        :else
-        [:div
-         (let [config @(rf/subscribe [:rems.config/config])
-               id-column (get config :application-id-column :id)]
-           [application-list/component2
-            (merge {:visible-columns #{id-column :description :resource :state :created :submitted :last-activity :view}
-                    :default-sort-column :created
-                    :default-sort-order :desc}
-                   opts)])
-         ;; TODO: remove me
-         [application-list/component
-          {:visible-columns (into [(get @(rf/subscribe [:rems.config/config]) :application-id-column :id)]
-                                  [:description :resource :state :created :submitted :last-activity :view])
-           :sorting (assoc @(rf/subscribe [::sorting])
-                           :set-sorting #(rf/dispatch [::set-sorting %]))
-           :filtering (assoc @(rf/subscribe [::filtering])
-                             :set-filtering #(rf/dispatch [::set-filtering %]))
-           :items apps}]]))
+          :else
+          (let [config @(rf/subscribe [:rems.config/config])
+                id-column (get config :application-id-column :id)]
+            [application-list/component2
+             (merge {:visible-columns #{id-column :description :resource :state :created :submitted :last-activity :view}
+                     :default-sort-column :created
+                     :default-sort-order :desc}
+                    opts)]))))
 
 (defn applications-page []
-  (let [apps @(rf/subscribe [::my-applications])
-        identity @(rf/subscribe [:identity])
-        loading? @(rf/subscribe [::loading-my-applications?])]
+  (let [identity @(rf/subscribe [:identity])]
     [:div
      [document-title (text :t.applications/applications)]
      (when (roles/show-all-applications? (:roles identity))
        [:h2 (text :t.applications/my-applications)])
-     [application-list apps loading? {:id :my-applications
-                                      :applications ::my-applications}]
-     (let [apps @(rf/subscribe [::all-applications])
-           loading? @(rf/subscribe [::loading-all-applications?])]
-       (when (roles/show-all-applications? (:roles identity))
-         [:div
-          [:h2 (text :t.applications/all-applications)]
-          [application-list apps loading? {:id :all-applications
-                                           :applications ::all-applications}]]))]))
+     [application-list {:id :my-applications
+                        :applications ::my-applications
+                        ::loading? @(rf/subscribe [::loading-my-applications?])}]
+     (when (roles/show-all-applications? (:roles identity))
+       [:div
+        [:h2 (text :t.applications/all-applications)]
+        [application-list {:id :all-applications
+                           :applications ::all-applications
+                           ::loading? @(rf/subscribe [::loading-all-applications?])}]])]))

--- a/src/cljs/rems/applications.cljs
+++ b/src/cljs/rems/applications.cljs
@@ -105,9 +105,19 @@
 (defn applications-page []
   (let [apps @(rf/subscribe [::my-applications])
         identity @(rf/subscribe [:identity])
-        loading? @(rf/subscribe [::loading-my-applications?])]
+        loading? @(rf/subscribe [::loading-my-applications?])
+        config @(rf/subscribe [:rems.config/config])]
     [:div
      [document-title (text :t.applications/applications)]
+
+     ;; TODO: remove spike code
+     [application-list/component2 {:id :my-applications
+                                   :applications ::my-applications
+                                   :visible-columns #{(get config :application-id-column :id)
+                                                      :description :resource :state :created :submitted :last-activity :view}
+                                   :default-sort-column :created
+                                   :default-sort-order :desc}]
+
      (when (roles/show-all-applications? (:roles identity))
        [:h2 (text :t.applications/my-applications)])
      [application-list apps loading?]

--- a/src/cljs/rems/applications.cljs
+++ b/src/cljs/rems/applications.cljs
@@ -80,7 +80,7 @@
           :else
           (let [config @(rf/subscribe [:rems.config/config])
                 id-column (get config :application-id-column :id)]
-            [application-list/component2
+            [application-list/component
              (merge {:visible-columns #{id-column :description :resource :state :created :submitted :last-activity :view}
                      :default-sort-column :created
                      :default-sort-order :desc}

--- a/src/cljs/rems/cart.cljs
+++ b/src/cljs/rems/cart.cljs
@@ -83,8 +83,9 @@
                       (for [group (vals (into (sorted-map) (group-by key-fn items)))]
                         (group-view (sort-by get-catalogue-item-title group) language)))))]]]))
 
-(defn cart-list-container [language]
-  (let [cart @(rf/subscribe [::cart])]
+(defn cart-list-container []
+  (let [language @(rf/subscribe [:language])
+        cart @(rf/subscribe [::cart])]
     [cart-list cart language]))
 
 (defn guide []

--- a/src/cljs/rems/catalogue.cljs
+++ b/src/cljs/rems/catalogue.cljs
@@ -103,7 +103,7 @@
     (when (seq @(rf/subscribe [applications]))
       [:div
        [:h2 (text :t.catalogue/continue-existing-application)]
-       [application-list/component2
+       [application-list/component
         {:id applications
          :applications applications
          :visible-columns #{:resource :last-activity :view}

--- a/src/cljs/rems/catalogue.cljs
+++ b/src/cljs/rems/catalogue.cljs
@@ -115,10 +115,10 @@
 (defn- catalogue-table []
   (let [catalogue {:id ::catalogue
                    :columns [{:key :name
-                              :title (text :t.catalogue/header)
-                              :sortable? true
-                              :filterable? true}
-                             {:key :commands}]
+                              :title (text :t.catalogue/header)}
+                             {:key :commands
+                              :sortable? false
+                              :filterable? false}]
                    :rows [::catalogue-table-rows]
                    :default-sort-column :name}]
     [:div

--- a/src/cljs/rems/catalogue.cljs
+++ b/src/cljs/rems/catalogue.cljs
@@ -117,7 +117,7 @@
                                     :sortable? true
                                     :filterable? true}
                                    {:key :commands}]
-                         :rows ::catalogue-table-rows
+                         :rows [::catalogue-table-rows]
                          :default-sort-column :name}]
     [:div
      [document-title (text :t.catalogue/catalogue)]

--- a/src/cljs/rems/catalogue.cljs
+++ b/src/cljs/rems/catalogue.cljs
@@ -101,7 +101,7 @@
 (defn draft-application-list []
   (let [applications ::draft-applications]
     (when (seq @(rf/subscribe [applications]))
-      [:div.drafts
+      [:div
        [:h2 (text :t.catalogue/continue-existing-application)]
        [application-list/component2
         {:id applications
@@ -111,18 +111,22 @@
          :default-sort-order :desc
          :filterable? false}]])))
 
+(defn- catalogue-table []
+  (let [catalogue {:id ::catalogue
+                   :columns [{:key :name
+                              :title (text :t.catalogue/header)
+                              :sortable? true
+                              :filterable? true}
+                             {:key :commands}]
+                   :rows [::catalogue-table-rows]
+                   :default-sort-column :name}]
+    [:div
+     [table2/search catalogue]
+     [table2/table catalogue]]))
+
 (defn catalogue-page []
-  (let [language @(rf/subscribe [:language])
-        loading-catalogue? @(rf/subscribe [::loading-catalogue?])
-        loading-drafts? @(rf/subscribe [::loading-drafts?])
-        catalogue-table {:id ::catalogue
-                         :columns [{:key :name
-                                    :title (text :t.catalogue/header)
-                                    :sortable? true
-                                    :filterable? true}
-                                   {:key :commands}]
-                         :rows [::catalogue-table-rows]
-                         :default-sort-column :name}]
+  (let [loading-catalogue? @(rf/subscribe [::loading-catalogue?])
+        loading-drafts? @(rf/subscribe [::loading-drafts?])]
     [:div
      [document-title (text :t.catalogue/catalogue)]
      (if (or loading-catalogue? loading-drafts?)
@@ -130,6 +134,5 @@
        [:div
         [draft-application-list]
         [:h2 (text :t.catalogue/apply-resources)]
-        [cart/cart-list-container language]
-        [table2/search catalogue-table]
-        [table2/table catalogue-table]])]))
+        [cart/cart-list-container]
+        [catalogue-table]])]))

--- a/src/cljs/rems/catalogue.cljs
+++ b/src/cljs/rems/catalogue.cljs
@@ -111,7 +111,7 @@
         loading-catalogue? @(rf/subscribe [::loading-catalogue?])
         drafts @(rf/subscribe [::draft-applications])
         loading-drafts? @(rf/subscribe [::loading-drafts?])
-        catalogue-table {:id :catalogue
+        catalogue-table {:id ::catalogue
                          :columns [{:key :name
                                     :title (text :t.catalogue/header)
                                     :sortable? true

--- a/src/cljs/rems/catalogue.cljs
+++ b/src/cljs/rems/catalogue.cljs
@@ -98,18 +98,22 @@
                              [cart/add-to-cart-button item]]}}))
         catalogue)))
 
-(defn draft-application-list [drafts]
-  (when (seq drafts)
-    [:div.drafts
-     [:h2 (text :t.catalogue/continue-existing-application)]
-     [application-list/component
-      {:visible-columns [:resource :last-activity :view]
-       :items drafts}]]))
+(defn draft-application-list []
+  (let [applications ::draft-applications]
+    (when (seq @(rf/subscribe [applications]))
+      [:div.drafts
+       [:h2 (text :t.catalogue/continue-existing-application)]
+       [application-list/component2
+        {:id applications
+         :applications applications
+         :visible-columns #{:resource :last-activity :view}
+         :default-sort-column :last-activity
+         :default-sort-order :desc
+         :filterable? false}]])))
 
 (defn catalogue-page []
   (let [language @(rf/subscribe [:language])
         loading-catalogue? @(rf/subscribe [::loading-catalogue?])
-        drafts @(rf/subscribe [::draft-applications])
         loading-drafts? @(rf/subscribe [::loading-drafts?])
         catalogue-table {:id ::catalogue
                          :columns [{:key :name
@@ -124,27 +128,8 @@
      (if (or loading-catalogue? loading-drafts?)
        [spinner/big]
        [:div
-        [draft-application-list drafts]
+        [draft-application-list]
         [:h2 (text :t.catalogue/apply-resources)]
         [cart/cart-list-container language]
         [table2/search catalogue-table]
         [table2/table catalogue-table]])]))
-
-(defn guide []
-  [:div
-   (component-info draft-application-list)
-   (example "draft-list empty"
-            [draft-application-list []])
-   (example "draft-list with two drafts"
-            [draft-application-list [{:application/id 1
-                                      :application/resources [{:catalogue-item/title {:en "Item 5"}}]
-                                      :application/state :application.state/draft
-                                      :application/applicant "alice"
-                                      :application/created "1980-01-02T13:45:00.000Z"
-                                      :application/last-activity "2017-01-01T01:01:01:001Z"}
-                                     {:application/id 2
-                                      :application/resources [{:catalogue-item/title {:en "Item 3"}}]
-                                      :application/state :application.state/draft
-                                      :application/applicant "bob"
-                                      :application/created "1971-02-03T23:59:00.000Z"
-                                      :application/last-activity "2017-01-01T01:01:01:001Z"}]])])

--- a/src/cljs/rems/catalogue.cljs
+++ b/src/cljs/rems/catalogue.cljs
@@ -20,7 +20,8 @@
    (if (roles/is-logged-in? (get-in db [:identity :roles]))
      {:db (dissoc db ::catalogue ::draft-applications)
       :dispatch-n [[::fetch-catalogue]
-                   [::fetch-drafts]]}
+                   [::fetch-drafts]
+                   [:rems.table2/reset]]}
      (do
        (unauthorized!)
        {}))))

--- a/src/cljs/rems/guide_page.cljs
+++ b/src/cljs/rems/guide_page.cljs
@@ -101,9 +101,6 @@
     [:h2 "Login"]
     [auth/guide]
 
-    [:h2 "Catalogue components"]
-    [catalogue/guide]
-
     [:h2 "Cart components"]
     [cart/guide]
 

--- a/src/cljs/rems/guide_page.cljs
+++ b/src/cljs/rems/guide_page.cljs
@@ -7,7 +7,6 @@
             [rems.auth.auth :as auth]
             [rems.autocomplete :as autocomplete]
             [rems.cart :as cart]
-            [rems.catalogue :as catalogue]
             [rems.collapsible :as collapsible]
             [rems.fields :as fields]
             [rems.language-switcher :as language-switcher]

--- a/src/cljs/rems/table.cljs
+++ b/src/cljs/rems/table.cljs
@@ -176,16 +176,15 @@
   (let [{:keys [sort-column sort-order set-sorting]} sorting
         sortable? (get-in column-definitions [column :sortable?] true)]
     [:th
-     [:div.column-header
-      (when (and sortable? set-sorting)
-        {:on-click (fn []
-                     (set-sorting (-> sorting
-                                      (assoc :sort-column column)
-                                      (assoc :sort-order (change-sort-order sort-column sort-order column)))))})
-      (column-header column-definitions column)
-      " "
-      (when (= column sort-column)
-        [sort-symbol sort-order])]]))
+     (when (and sortable? set-sorting)
+       {:on-click (fn []
+                    (set-sorting (-> sorting
+                                     (assoc :sort-column column)
+                                     (assoc :sort-order (change-sort-order sort-column sort-order column)))))})
+     (column-header column-definitions column)
+     " "
+     (when (= column sort-column)
+       [sort-symbol sort-order])]))
 
 (defn- head [{:keys [column-definitions visible-columns sorting filtering id-function items class] :as params}]
   [:thead

--- a/src/cljs/rems/table2.cljs
+++ b/src/cljs/rems/table2.cljs
@@ -5,6 +5,11 @@
             [rems.text :refer [text]])
   (:require-macros [rems.guide-macros :refer [component-info example]]))
 
+(rf/reg-event-db
+ ::reset
+ (fn [db _]
+   (dissoc db ::sorting ::filtering)))
+
 (defn- flip [order]
   (case order
     :desc :asc

--- a/src/cljs/rems/table2.cljs
+++ b/src/cljs/rems/table2.cljs
@@ -118,8 +118,9 @@
                  [sort-symbol (:sort-order sorting)]))]))))
 
 (defn- table-row [row table]
-  ;; performance optimization: hide DOM nodes instead of destroying them
-  (into [:tr {:style {:display (if (::display-row? row)
+  (into [:tr {:data-row (:key row)
+              ;; performance optimization: hide DOM nodes instead of destroying them
+              :style {:display (if (::display-row? row)
                                  "table-row"
                                  "none")}}]
         (for [column (:columns table)]

--- a/src/cljs/rems/table2.cljs
+++ b/src/cljs/rems/table2.cljs
@@ -30,8 +30,10 @@
  ::sorting
  (fn [db [_ table]]
    (or (get-in db [::sorting (:id table)])
-       {:sort-order (get table :default-sort-order :asc)
-        :sort-column (get table :default-sort-column (-> table :columns first :key))})))
+       {:sort-order (or (:default-sort-order table)
+                        :asc)
+        :sort-column (or (:default-sort-column table)
+                         (-> table :columns first :key))})))
 
 (rf/reg-event-db
  ::set-filtering
@@ -175,7 +177,7 @@
   [:div
    (component-info table)
    (example "static table"
-            (let [example1 {:id :example1
+            (let [example1 {:id ::example1
                             :columns [{:key :first-name
                                        :title "First name"}
                                       {:key :last-name
@@ -185,7 +187,7 @@
                             :default-sort-column :first-name}]
               [table example1]))
    (example "sortable and filterable table"
-            (let [example2 {:id :example2
+            (let [example2 {:id ::example2
                             :columns [{:key :first-name
                                        :title "First name"
                                        :sortable? true

--- a/src/cljs/rems/table2.cljs
+++ b/src/cljs/rems/table2.cljs
@@ -30,8 +30,8 @@
  ::sorting
  (fn [db [_ table]]
    (or (get-in db [::sorting (:id table)])
-       {:sort-order :asc
-        :sort-column (:default-sort-column table)})))
+       {:sort-order (get table :default-sort-order :asc)
+        :sort-column (get table :default-sort-column (-> table :columns first :key))})))
 
 (rf/reg-event-db
  ::set-filtering

--- a/src/cljs/rems/table2.cljs
+++ b/src/cljs/rems/table2.cljs
@@ -46,7 +46,7 @@
 (rf/reg-sub
  ::sorted-rows
  (fn [[_ table] _]
-   [(rf/subscribe [(:rows table)])
+   [(rf/subscribe (:rows table))
     (rf/subscribe [::sorting table])])
  (fn [[rows sorting] _]
    (->> rows
@@ -180,7 +180,7 @@
                                       {:key :last-name
                                        :title "Last name"}
                                       {:key :commands}]
-                            :rows ::example-table-rows
+                            :rows [::example-table-rows]
                             :default-sort-column :first-name}]
               [table example1]))
    (example "sortable and filterable table"
@@ -194,7 +194,7 @@
                                        :sortable? true
                                        :filterable? true}
                                       {:key :commands}]
-                            :rows ::example-table-rows
+                            :rows [::example-table-rows]
                             :default-sort-column :first-name}]
               [:div
                [search example2]

--- a/src/cljs/rems/table2.cljs
+++ b/src/cljs/rems/table2.cljs
@@ -62,6 +62,12 @@
                    :desc #(compare %2 %1)
                    #(compare %1 %2))))))
 
+(defn- sortable? [column]
+  (:sortable? column true))
+
+(defn- filterable? [column]
+  (:filterable? column true))
+
 (defn- display-row? [row filtered-columns filters]
   (if (empty? filtered-columns)
     true ; table has no filtering enabled
@@ -78,7 +84,7 @@
  (fn [[rows filtering] [_ table]]
    (let [filters (str/lower-case (str (:filters filtering)))
          columns (->> (:columns table)
-                      (filter :filterable?))]
+                      (filter filterable?))]
      (->> rows
           (map (fn [row]
                  ;; performance optimization: hide DOM nodes instead of destroying them
@@ -116,11 +122,11 @@
     (into [:tr]
           (for [column (:columns table)]
             [:th
-             (when (:sortable? column)
+             (when (sortable? column)
                {:on-click #(rf/dispatch [::toggle-sorting table (:key column)])})
              (:title column)
              " "
-             (when (:sortable? column)
+             (when (sortable? column)
                (when (= (:key column) (:sort-column sorting))
                  [sort-symbol (:sort-order sorting)]))]))))
 
@@ -184,9 +190,13 @@
    (example "static table"
             (let [example1 {:id ::example1
                             :columns [{:key :first-name
-                                       :title "First name"}
+                                       :title "First name"
+                                       :sortable? false
+                                       :filterable? false}
                                       {:key :last-name
-                                       :title "Last name"}
+                                       :title "Last name"
+                                       :sortable? false
+                                       :filterable? false}
                                       {:key :commands}]
                             :rows [::example-table-rows]
                             :default-sort-column :first-name}]
@@ -194,13 +204,9 @@
    (example "sortable and filterable table"
             (let [example2 {:id ::example2
                             :columns [{:key :first-name
-                                       :title "First name"
-                                       :sortable? true
-                                       :filterable? true}
+                                       :title "First name"}
                                       {:key :last-name
-                                       :title "Last name"
-                                       :sortable? true
-                                       :filterable? true}
+                                       :title "Last name"}
                                       {:key :commands}]
                             :rows [::example-table-rows]
                             :default-sort-column :first-name}]

--- a/src/cljs/rems/table2.cljs
+++ b/src/cljs/rems/table2.cljs
@@ -59,7 +59,7 @@
   (if (empty? filtered-columns)
     true ; table has no filtering enabled
     (some (fn [column]
-            (str/includes? (get-in row [(:key column) :filter-value])
+            (str/includes? (str (get-in row [(:key column) :filter-value]))
                            filters))
           filtered-columns)))
 

--- a/test/clj/rems/test_browser.clj
+++ b/test/clj/rems/test_browser.clj
@@ -40,7 +40,6 @@
   (mount/start)
   (migrations/migrate ["reset"] (select-keys rems.config/env [:database-url]))
   (test-data/create-test-data!)
-  (test-data/create-performance-test-data!)
   (f)
   (mount/stop))
 
@@ -62,13 +61,13 @@
 ;;; basic navigation
 
 (defn scroll-and-click
- "Wait a button to become visible, scroll it to middle
- (to make sure it's not hidden under navigation) and click."
- [driver q & [opt]]
- (doto driver
-   (wait-visible q opt)
-   (scroll-query q {"block" "center"})
-   (click q)))
+  "Wait a button to become visible, scroll it to middle
+  (to make sure it's not hidden under navigation) and click."
+  [driver q & [opt]]
+  (doto driver
+    (wait-visible q opt)
+    (scroll-query q {"block" "center"})
+    (click q)))
 
 (defn login-as [username]
   (doto *driver*

--- a/test/clj/rems/test_browser.clj
+++ b/test/clj/rems/test_browser.clj
@@ -184,8 +184,8 @@
 ;; applications page
 
 (defn get-application-summary [application-id]
-  (let [row (query *driver* [{:css "table.applications"}
-                             {:tag :tr, :id (str "application-" application-id)}])]
+  (let [row (query *driver* [{:css "table.my-applications"}
+                             {:tag :tr, :data-row application-id}])]
     {:id application-id
      :description (get-element-text-el *driver* (child *driver* row {:css ".description"}))
      :resource (get-element-text-el *driver* (child *driver* row {:css ".resource"}))


### PR DESCRIPTION
After this PR the administration pages still use the old rems.table, so they will be updated next.

Now there is probably enough duplication to see how to refactor the column and row definitions to simplify the default cases.