### PR TITLE
rems.application.model: use json form templates

### DIFF
--- a/resources/migrations/20190527064110-form-templates-for-old-forms.edn
+++ b/resources/migrations/20190527064110-form-templates-for-old-forms.edn
@@ -1,0 +1,3 @@
+{:ns rems.migrations.form-templates-for-old-forms
+ :up-fn migrate-up
+ :down-fn nil}

--- a/src/clj/rems/api/forms.clj
+++ b/src/clj/rems/api/forms.clj
@@ -29,9 +29,13 @@
                                :label {s/Keyword s/Str}}]
    (s/optional-key :input-prompt) {s/Keyword s/Str}})
 
+(s/defschema FormFieldWithId
+  (merge FormField
+         {:id s/Int}))
+
 (s/defschema FullForm
   (merge Form
-         {:fields [FormField]}))
+         {:fields [FormFieldWithId]}))
 
 (s/defschema Forms
   [Form])

--- a/src/clj/rems/application/model.clj
+++ b/src/clj/rems/application/model.clj
@@ -401,16 +401,16 @@
 (defn- enrich-form [app-form get-form]
   (let [form (get-form (:form/id app-form))
         app-fields (:form/fields app-form)
-        rich-fields (map (fn [item]
-                           {:field/id (:id item)
+        rich-fields (map (fn [field]
+                           {:field/id (:id field)
                             :field/value "" ; default for new forms
-                            :field/type (keyword (:type item))
-                            :field/title (localization-for :title item)
-                            :field/placeholder (localization-for :inputprompt item)
-                            :field/optional (:optional item)
-                            :field/options (:options item)
-                            :field/max-length (:maxlength item)})
-                         (:items form))
+                            :field/type (keyword (:type field))
+                            :field/title (:title field)
+                            :field/placeholder (get field :input-prompt {})
+                            :field/optional (:optional field)
+                            :field/options (:options field)
+                            :field/max-length (:maxlength field)})
+                         (:fields form))
         fields (merge-lists-by :field/id rich-fields app-fields)]
     (assoc app-form
            :form/title (:title form)

--- a/src/clj/rems/application/model.clj
+++ b/src/clj/rems/application/model.clj
@@ -496,7 +496,7 @@
   (-> application
       (permissions/give-role-to-users :reporter (get-users-with-role :reporter))))
 
-(defn enrich-with-injections [application {:keys [get-form get-catalogue-item get-license
+(defn enrich-with-injections [application {:keys [get-form-template get-catalogue-item get-license
                                                   get-user get-users-with-role get-workflow
                                                   get-attachments-for-application]}]
   (let [answer-versions (remove nil? [(::draft-answers application)
@@ -515,7 +515,7 @@
                                                                           {:field/id field-id
                                                                            :field/value value})
                                                                         current-answers)))
-        (update :application/form enrich-form get-form)
+        (update :application/form enrich-form get-form-template)
         set-application-description
         (update :application/resources enrich-resources get-catalogue-item)
         (update :application/licenses enrich-licenses get-license)

--- a/src/clj/rems/db/applications.clj
+++ b/src/clj/rems/db/applications.clj
@@ -150,7 +150,7 @@
 
 (def ^:private injections
   {:get-attachments-for-application attachments/get-attachments-for-application
-   :get-form form/get-form
+   :get-form form/get-form-template ;; TODO rename injection key
    :get-catalogue-item catalogue/get-localized-catalogue-item
    :get-license licenses/get-license
    :get-user users/get-user-attributes

--- a/src/clj/rems/db/applications.clj
+++ b/src/clj/rems/db/applications.clj
@@ -150,7 +150,7 @@
 
 (def ^:private injections
   {:get-attachments-for-application attachments/get-attachments-for-application
-   :get-form form/get-form-template ;; TODO rename injection key
+   :get-form-template form/get-form-template
    :get-catalogue-item catalogue/get-localized-catalogue-item
    :get-license licenses/get-license
    :get-user users/get-user-attributes

--- a/src/clj/rems/db/form.clj
+++ b/src/clj/rems/db/form.clj
@@ -126,4 +126,6 @@
                          (mapv process-field)))))
 
 (comment
-  (get-form 1))
+  (clojure.pprint/pprint
+   [(get-form 1)
+    (get-form-template 1)]))

--- a/src/clj/rems/migrations/form_templates_for_old_forms.clj
+++ b/src/clj/rems/migrations/form_templates_for_old_forms.clj
@@ -1,0 +1,102 @@
+(ns rems.migrations.form-templates-for-old-forms
+  (:require [clojure.test :refer :all]
+            [hugsql.core :as hugsql]
+            [rems.json :as json]))
+
+;; SQL queries repeated here so that this migration is standalone
+
+(hugsql/def-db-fns-from-string
+  "
+-- :name get-forms :? :*
+SELECT id FROM application_form;
+
+-- :name get-form-template-impl :? :1
+SELECT
+  id,
+  organization,
+  title,
+  start,
+  endt as \"end\",
+  fields::TEXT,
+  enabled,
+  archived
+FROM form_template
+WHERE id = :id;
+
+-- :name set-template-fields! :!
+UPDATE form_template
+SET fields = :fields::jsonb
+WHERE id = :id;
+
+-- :name get-form-items :? :*
+SELECT
+  item.id,
+  formitemoptional,
+  type,
+  value,
+  itemorder,
+  item.visibility,
+  itemmap.maxlength
+FROM application_form form
+LEFT OUTER JOIN application_form_item_map itemmap ON form.id = itemmap.formId
+LEFT OUTER JOIN application_form_item item ON item.id = itemmap.formItemId
+WHERE form.id = :id AND item.id IS NOT NULL
+ORDER BY itemorder;")
+
+(defn get-template-fields [db params]
+  (-> (get-form-template-impl db params)
+      :fields
+      json/parse-string))
+
+(defn should-update? [fields]
+  (not (every? #(contains? % :id) fields)))
+
+(defn update-fields [template-fields items]
+  (assert (= (count template-fields)
+             (count items)))
+  (let [result (mapv #(assoc %2 :id (:id %1)) items template-fields)]
+    (assert (not (should-update? result)))
+    result))
+
+(deftest test-update-template
+  (is (= [{:type "description"
+           :title {:fi "Projektin nimi" :en "Project name"}
+           :input-prompt {:fi "Projekti" :en "Project"}
+           :id 1
+           :optional false}
+          {:type "texta"
+           :title {:fi "Projektin tarkoitus" :en "Purpose of the project"}
+           :input-prompt
+           {:fi "Projektin tarkoitus on..."
+            :en "The purpose of the project is to..."}
+           :id 7
+           :optional false}
+          {:type "date"
+           :title
+           {:fi "Projektin aloituspäivä" :en "Start date of the project"}
+           :id 3
+           :optional true}]
+         (update-fields
+          [{:type "description"
+            :title {:fi "Projektin nimi" :en "Project name"}
+            :input-prompt {:fi "Projekti" :en "Project"}
+            :optional false}
+           {:type "texta"
+            :title {:fi "Projektin tarkoitus" :en "Purpose of the project"}
+            :input-prompt
+            {:fi "Projektin tarkoitus on..."
+             :en "The purpose of the project is to..."}
+            :optional false}
+           {:type "date"
+            :title
+            {:fi "Projektin aloituspäivä" :en "Start date of the project"}
+            :optional true}]
+          [{:id 1} {:id 7} {:id 3}]))))
+
+(defn migrate-up [{:keys [conn]}]
+  (doseq [{:keys [id]} (get-forms conn)]
+    (let [fields (get-template-fields conn {:id id})]
+      (when (should-update? fields)
+        (let [items (get-form-items conn {:id id})
+              updated (update-fields fields items)]
+          (set-template-fields! conn {:id id :fields (json/generate-string updated)}))))))

--- a/test/clj/rems/api/test_forms.clj
+++ b/test/clj/rems/api/test_forms.clj
@@ -69,7 +69,7 @@
                   (is (= (select-keys command [:title :organization])
                          (select-keys form-template [:title :organization])))
                   (is (= (:fields command)
-                         (:fields form-template))))))))))))
+                         (mapv #(dissoc % :id) (:fields form-template)))))))))))))
 
 (deftest forms-api-all-field-types-test
   (let [api-key "42"
@@ -123,7 +123,10 @@
                          (authenticate api-key user-id)
                          handler
                          read-ok-body)]
-            (is (= form-spec (select-keys form [:organization :title :fields])))))))))
+            (is (= (select-keys form-spec [:organization :title])
+                   (select-keys form [:organization :title])))
+            (is (= (:fields form-spec)
+                   (mapv #(dissoc % :id) (:fields form))))))))))
 
 (deftest form-update-test
   (let [api-key "42"
@@ -196,7 +199,7 @@
                          handler
                          read-ok-body)]
             (is (= (:fields command)
-                   (:fields form)))))))))
+                   (mapv #(dissoc % :id) (:fields form))))))))))
 
 (deftest forms-api-filtering-test
   (let [unfiltered (-> (request :get "/api/forms" {:expired true})

--- a/test/clj/rems/application/test_commands.clj
+++ b/test/clj/rems/application/test_commands.clj
@@ -33,7 +33,7 @@
 
 (def ^:private injections
   {:get-workflow dummy-workflows
-   :get-form dummy-forms
+   :get-form-template dummy-forms
    :get-catalogue-item (constantly nil)
    :get-license (constantly nil)
    :get-user (constantly nil)

--- a/test/clj/rems/application/test_model.clj
+++ b/test/clj/rems/application/test_model.clj
@@ -11,24 +11,20 @@
   {40 {:id 40
        :organization "org"
        :title "form title"
-       :items [{:id 41
-                :localizations {:en {:title "en title"
-                                     :inputprompt "en placeholder"}
-                                :fi {:title "fi title"
-                                     :inputprompt "fi placeholder"}}
-                :optional false
-                :options []
-                :maxlength 100
-                :type "description"}
-               {:id 42
-                :localizations {:en {:title "en title"
-                                     :inputprompt "en placeholder"}
-                                :fi {:title "fi title"
-                                     :inputprompt "fi placeholder"}}
-                :optional false
-                :options []
-                :maxlength 100
-                :type "text"}]
+       :fields [{:id 41
+                 :title {:en "en title" :fi "fi title"}
+                 :input-prompt {:en "en placeholder" :fi "fi placeholder"}
+                 :optional false
+                 :options []
+                 :maxlength 100
+                 :type "description"}
+                {:id 42
+                 :title {:en "en title" :fi "fi title"}
+                 :input-prompt {:en "en placeholder" :fi "fi placeholder"}
+                 :optional false
+                 :options []
+                 :maxlength 100
+                 :type "text"}]
        :start (DateTime. 100)
        :end nil}})
 

--- a/test/clj/rems/application/test_model.clj
+++ b/test/clj/rems/application/test_model.clj
@@ -7,7 +7,7 @@
   (:import [java.util UUID]
            [org.joda.time DateTime]))
 
-(def ^:private get-form
+(def ^:private get-form-template
   {40 {:id 40
        :organization "org"
        :title "form title"
@@ -175,7 +175,7 @@
   [])
 
 (deftest test-application-view
-  (let [injections {:get-form get-form
+  (let [injections {:get-form-template get-form-template
                     :get-catalogue-item get-catalogue-item
                     :get-license get-license
                     :get-user get-user

--- a/test/clj/rems/poller/test_email.clj
+++ b/test/clj/rems/poller/test_email.clj
@@ -38,7 +38,7 @@
   (let [application (-> (reduce model/application-view nil events)
                         (model/enrich-with-injections {:get-workflow get-workflow
                                                        :get-catalogue-item get-catalogue-item
-                                                       :get-form get-nothing
+                                                       :get-form-template get-nothing
                                                        :get-license get-nothing
                                                        :get-user get-nothing
                                                        :get-users-with-role get-nothing


### PR DESCRIPTION
instead of forms stored as relations

required allocating ids for the fields stored in the templates

for #913