### PR TITLE
Remove unused query param from API calls in create catalogue item

### DIFF
--- a/src/cljs/rems/administration/create_catalogue_item.cljs
+++ b/src/cljs/rems/administration/create_catalogue_item.cljs
@@ -66,8 +66,7 @@
 
 
 (defn- fetch-workflows []
-  (fetch "/api/workflows" {:url-params {:active true}
-                           :handler #(rf/dispatch [::fetch-workflows-result %])}))
+  (fetch "/api/workflows" {:handler #(rf/dispatch [::fetch-workflows-result %])}))
 
 (rf/reg-fx ::fetch-workflows fetch-workflows)
 
@@ -80,8 +79,7 @@
 (rf/reg-sub ::workflows (fn [db _] (::workflows db)))
 
 (defn- fetch-resources []
-  (fetch "/api/resources" {:url-params {:active true}
-                           :handler #(rf/dispatch [::fetch-resources-result %])}))
+  (fetch "/api/resources" {:handler #(rf/dispatch [::fetch-resources-result %])}))
 
 (rf/reg-fx ::fetch-resources fetch-resources)
 
@@ -95,8 +93,7 @@
 
 
 (defn- fetch-forms []
-  (fetch "/api/forms" {:url-params {:active true}
-                       :handler #(rf/dispatch [::fetch-forms-result %])}))
+  (fetch "/api/forms" {:handler #(rf/dispatch [::fetch-forms-result %])}))
 
 (rf/reg-fx ::fetch-forms fetch-forms)
 


### PR DESCRIPTION
The query parameters used for controlling what is returned by API
are called disabled, expired, and archived. Also, they default to
returning only non-disabled, non-expired, and non-archived items,
which is what was intended here, so no query parameter is needed.