### PR TITLE
feat: handle email address not existing by skipping

### DIFF
--- a/src/clj/rems/poller/email.clj
+++ b/src/clj/rems/poller/email.clj
@@ -191,7 +191,10 @@
                                    (:to-user email-spec)))))]
         ;; TODO check that :to is set
         (log/info "sending email:" (pr-str email))
-        (postal/send-message {:host host :port port} email)))))
+        (try
+          (postal/send-message {:host host :port port} email)
+          (catch com.sun.mail.smtp.SMTPAddressFailedException e ; email address does not exist
+            (log/warn e "failed sending email, skipping:" (pr-str email))))))))
 
 (defn run []
   (common/run-event-poller ::poller (fn [event]


### PR DESCRIPTION
In testing it's often the case that the email address does not exist, and
this should not block sending emails overall. There is the issue #1026 about
improving the poller architecture more later.