### PR TITLE
Write custom exceptions in Java to avoid compilation issues

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -69,6 +69,7 @@
   :min-lein-version "2.0.0"
 
   :source-paths ["src/clj" "src/cljc"]
+  :java-source-paths ["src/java"]
   :test-paths ["src/clj" "src/cljc" "test/clj" "test/cljc"] ;; also run tests from src files
   :resource-paths ["resources" "target/cljsbuild"]
   :target-path "target/%s/"
@@ -114,6 +115,7 @@
              :prep-tasks [["shell" "sh" "-c" "mkdir -p target/uberjar/resources"]
                           ["shell" "sh" "-c" "git describe --tags --long --always --dirty=-custom > target/uberjar/resources/git-describe.txt"]
                           ["shell" "sh" "-c" "git rev-parse HEAD > target/uberjar/resources/git-revision.txt"]
+                          "javac"
                           "compile"
                           ["cljsbuild" "once" "min"]]
              :cljsbuild {:builds {:min {:source-paths ["src/cljc" "src/cljs"]
@@ -151,7 +153,6 @@
                  :plugins [[lein-ancient "0.6.15"]
                            [lein-doo "0.1.11"]
                            [lein-figwheel "0.5.18"]]
-                 :aot [rems.InvalidRequestException rems.auth.NotAuthorizedException rems.auth.ForbiddenException]
 
                  :jvm-opts ["-Drems.config=dev-config.edn"
                             "-Djdk.attach.allowAttachSelf"] ; needed by clj-memory-meter on Java 9+

--- a/src/clj/rems/InvalidRequestException.clj
+++ b/src/clj/rems/InvalidRequestException.clj
@@ -1,3 +1,0 @@
-(ns ^{:doc "REMS custom exception thrown when a request is invalid"}
-    rems.InvalidRequestException
-  (:gen-class :extends java.lang.Exception))

--- a/src/clj/rems/api.clj
+++ b/src/clj/rems/api.clj
@@ -15,8 +15,6 @@
             [rems.api.resources :refer [resources-api]]
             [rems.api.users :refer [users-api]]
             [rems.api.workflows :refer [workflows-api]]
-            [rems.auth.ForbiddenException]
-            [rems.auth.NotAuthorizedException]
             [rems.json :refer [muuntaja]]
             [ring.middleware.cors :refer [wrap-cors]]
             [ring.util.http-response :refer :all]

--- a/src/clj/rems/auth/ForbiddenException.clj
+++ b/src/clj/rems/auth/ForbiddenException.clj
@@ -1,3 +1,0 @@
-(ns ^{:doc "REMS custom exception thrown when user is not authenticated."}
-    rems.auth.ForbiddenException
-  (:gen-class :extends java.lang.Exception))

--- a/src/clj/rems/auth/NotAuthorizedException.clj
+++ b/src/clj/rems/auth/NotAuthorizedException.clj
@@ -1,3 +1,0 @@
-(ns ^{:doc "REMS custom exception thrown when an operation is not authorized."}
-    rems.auth.NotAuthorizedException
-  (:gen-class :extends java.lang.Exception))

--- a/src/clj/rems/auth/util.clj
+++ b/src/clj/rems/auth/util.clj
@@ -1,13 +1,12 @@
 (ns rems.auth.util
-  (:require [rems.auth.ForbiddenException]
-            [rems.auth.NotAuthorizedException]))
+  (:import [rems.auth NotAuthorizedException ForbiddenException]))
 
 (defn throw-unauthorized
   "Helper for throwing `NotAuthorizedException`."
   []
-  (throw (rems.auth.NotAuthorizedException.)))
+  (throw (NotAuthorizedException.)))
 
 (defn throw-forbidden
   "Helper for throwing `ForbiddenException`."
   []
-  (throw (rems.auth.ForbiddenException.)))
+  (throw (ForbiddenException.)))

--- a/src/clj/rems/db/applications/legacy.clj
+++ b/src/clj/rems/db/applications/legacy.clj
@@ -1,23 +1,23 @@
 (ns rems.db.applications.legacy
   "Functions for dealing with old round-based applications."
-  (:require [clojure.test :refer :all]
-            [clj-time.core :as time]
+  (:require [clj-time.core :as time]
+            [clojure.test :refer :all]
             [cprop.tools :refer [merge-maps]]
+            [rems.application-util :refer [form-fields-editable?]]
             [rems.application.commands :as commands]
             [rems.application.model :as model]
-            [rems.application-util :refer [form-fields-editable?]]
             [rems.auth.util :refer [throw-forbidden]]
             [rems.db.applications :as applications]
-            [rems.db.core :as db]
             [rems.db.catalogue :as catalogue]
+            [rems.db.core :as db]
             [rems.db.entitlements :as entitlements]
             [rems.db.events :as events]
-            [rems.db.form :as form]
             [rems.db.licenses :as licenses]
             [rems.db.users :as users]
             [rems.db.workflow-actors :as actors]
             [rems.json :as json]
-            [rems.permissions :as permissions]))
+            [rems.permissions :as permissions])
+  (:import [rems InvalidRequestException]))
 
 (declare get-application-state)
 
@@ -202,7 +202,7 @@
 
 (defn- get-dynamic-application-state [application-id]
   (let [application (or (first (db/get-applications {:id application-id}))
-                        (throw (rems.InvalidRequestException.
+                        (throw (InvalidRequestException.
                                 (str "Application " application-id " not found"))))
         events (events/get-application-events application-id)
         application (assoc application

--- a/src/clj/rems/db/attachments.clj
+++ b/src/clj/rems/db/attachments.clj
@@ -1,10 +1,9 @@
 (ns rems.db.attachments
   (:require [rems.application-util :refer [form-fields-editable?]]
-            [rems.InvalidRequestException]
             [rems.auth.util :refer [throw-forbidden]]
             [rems.db.core :as db])
-  (:import [java.io ByteArrayOutputStream FileInputStream File ByteArrayInputStream]
-           rems.InvalidRequestException))
+  (:import [java.io ByteArrayOutputStream FileInputStream File]
+           [rems InvalidRequestException]))
 
 (defn check-attachment-content-type
   "Checks that content-type matches the allowed ones listed on the UI side:

--- a/src/clj/rems/db/form.clj
+++ b/src/clj/rems/db/form.clj
@@ -1,6 +1,5 @@
 (ns rems.db.form
   (:require [clojure.test :refer :all]
-            [rems.InvalidRequestException]
             [rems.db.catalogue :as catalogue]
             [rems.db.core :as db]
             [rems.json :as json]))
@@ -56,8 +55,8 @@
        :errors [{:type :t.administration.errors/form-in-use :catalogue-items catalogue-items}]})))
 
 (defn form-editable [form-id]
-    (or (form-in-use-error form-id)
-        {:success true}))
+  (or (form-in-use-error form-id)
+      {:success true}))
 
 (defn- generate-fields-with-ids! [user-id form-id fields]
   ;; Mirror field ids to form template so that form templates

--- a/src/clj/rems/middleware.clj
+++ b/src/clj/rems/middleware.clj
@@ -24,9 +24,9 @@
             [ring.middleware.format :refer [wrap-restful-format]]
             [ring.middleware.webjars :refer [wrap-webjars]]
             [ring.util.http-response :refer [unauthorized]]
-            [ring.util.response :refer [redirect header]]
-            [taoensso.tempura :as tempura])
-  (:import (javax.servlet ServletContext)))
+            [ring.util.response :refer [redirect header]])
+  (:import [javax.servlet ServletContext]
+           [rems.auth ForbiddenException NotAuthorizedException]))
 
 (defn calculate-root-path [request]
   (if-let [context (:servlet-context request)]
@@ -159,9 +159,9 @@
   (fn [req]
     (try
       (handler req)
-      (catch rems.auth.NotAuthorizedException e
+      (catch NotAuthorizedException e
         (on-unauthorized-error req))
-      (catch rems.auth.ForbiddenException e
+      (catch ForbiddenException e
         (on-forbidden-error req)))))
 
 (defn wrap-logging

--- a/src/java/rems/InvalidRequestException.java
+++ b/src/java/rems/InvalidRequestException.java
@@ -19,8 +19,4 @@ public class InvalidRequestException extends Exception {
     public InvalidRequestException(Throwable cause) {
         super(cause);
     }
-
-    public InvalidRequestException(String message, Throwable cause, boolean enableSuppression, boolean writableStackTrace) {
-        super(message, cause, enableSuppression, writableStackTrace);
-    }
 }

--- a/src/java/rems/InvalidRequestException.java
+++ b/src/java/rems/InvalidRequestException.java
@@ -1,0 +1,26 @@
+package rems;
+
+/**
+ * Thrown when a request is invalid.
+ */
+public class InvalidRequestException extends Exception {
+
+    public InvalidRequestException() {
+    }
+
+    public InvalidRequestException(String message) {
+        super(message);
+    }
+
+    public InvalidRequestException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public InvalidRequestException(Throwable cause) {
+        super(cause);
+    }
+
+    public InvalidRequestException(String message, Throwable cause, boolean enableSuppression, boolean writableStackTrace) {
+        super(message, cause, enableSuppression, writableStackTrace);
+    }
+}

--- a/src/java/rems/auth/ForbiddenException.java
+++ b/src/java/rems/auth/ForbiddenException.java
@@ -1,0 +1,26 @@
+package rems.auth;
+
+/**
+ * Thrown when user is not authenticated.
+ */
+public class ForbiddenException extends Exception {
+
+    public ForbiddenException() {
+    }
+
+    public ForbiddenException(String message) {
+        super(message);
+    }
+
+    public ForbiddenException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public ForbiddenException(Throwable cause) {
+        super(cause);
+    }
+
+    public ForbiddenException(String message, Throwable cause, boolean enableSuppression, boolean writableStackTrace) {
+        super(message, cause, enableSuppression, writableStackTrace);
+    }
+}

--- a/src/java/rems/auth/ForbiddenException.java
+++ b/src/java/rems/auth/ForbiddenException.java
@@ -19,8 +19,4 @@ public class ForbiddenException extends Exception {
     public ForbiddenException(Throwable cause) {
         super(cause);
     }
-
-    public ForbiddenException(String message, Throwable cause, boolean enableSuppression, boolean writableStackTrace) {
-        super(message, cause, enableSuppression, writableStackTrace);
-    }
 }

--- a/src/java/rems/auth/NotAuthorizedException.java
+++ b/src/java/rems/auth/NotAuthorizedException.java
@@ -1,0 +1,26 @@
+package rems.auth;
+
+/**
+ * Thrown when an operation is not authorized.
+ */
+public class NotAuthorizedException extends Exception {
+
+    public NotAuthorizedException() {
+    }
+
+    public NotAuthorizedException(String message) {
+        super(message);
+    }
+
+    public NotAuthorizedException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public NotAuthorizedException(Throwable cause) {
+        super(cause);
+    }
+
+    public NotAuthorizedException(String message, Throwable cause, boolean enableSuppression, boolean writableStackTrace) {
+        super(message, cause, enableSuppression, writableStackTrace);
+    }
+}

--- a/src/java/rems/auth/NotAuthorizedException.java
+++ b/src/java/rems/auth/NotAuthorizedException.java
@@ -19,8 +19,4 @@ public class NotAuthorizedException extends Exception {
     public NotAuthorizedException(Throwable cause) {
         super(cause);
     }
-
-    public NotAuthorizedException(String message, Throwable cause, boolean enableSuppression, boolean writableStackTrace) {
-        super(message, cause, enableSuppression, writableStackTrace);
-    }
 }

--- a/test/clj/rems/api/test_util.clj
+++ b/test/clj/rems/api/test_util.clj
@@ -2,8 +2,6 @@
   (:require [clojure.test :refer :all]
             [compojure.api.sweet :refer :all]
             [rems.api.util :refer :all]
-            [rems.auth.ForbiddenException]
-            [rems.auth.NotAuthorizedException]
             [rems.context :as context]
             [ring.util.http-response :refer :all])
   (:import (rems.auth ForbiddenException NotAuthorizedException)))

--- a/test/clj/rems/test_db.clj
+++ b/test/clj/rems/test_db.clj
@@ -4,7 +4,6 @@
             [clj-time.core :as time]
             [clojure.string :refer [split-lines]]
             [clojure.test :refer :all]
-            [rems.auth.ForbiddenException]
             [rems.config]
             [rems.context :as context]
             [rems.db.applications :as applications]


### PR DESCRIPTION
Clojure's support for custom exception classes is fragile, so let's write the them in Java. Earlier for example Kaocha used to occasionally fail in watch mode when it couldn't find the exception namespace. This fixes that.