### PR TITLE
Change focus to modal content when opened

### DIFF
--- a/src/cljs/rems/modal.cljs
+++ b/src/cljs/rems/modal.cljs
@@ -48,7 +48,12 @@
                   :title-class title-class
                   :always [:div.full
                            ;; max-height in order to keep header and controls visible
-                           [:div.modal--content {:style {:max-height "70vh" :overflow :auto}} content]
+                           [:div.modal--content
+                            {:style {:max-height "70vh" :overflow :auto}
+                             :ref (fn [elem] (when elem
+                                               (.focus elem)))
+                             :tabIndex "-1"}
+                            content]
                            (into [:div.modal--commands.commands {:style {:padding 0}}]
                                  commands)]
                   :open? true}]]


### PR DESCRIPTION
I'm making here a new pull request out of this same patch as previously. Meanwhile, I looked into using rems.focus for this, but as I understand, rems.focus shouldn't be needed because there is no need to asynchronously create the element and set focus to it.

However, I had a problem using screen reader with this patch, described below:

Switching the focus to content seemed to work correctly, but the screen reader I'm using (ChromeVox) did not always start reading the content. Not sure if it is a problem with the screen reader or the code. It probably needs to be tested with another screen reader eventually. But at least switching the focus is a step to the right direction.