### PR TITLE
Close modal when enter is pressed

### DIFF
--- a/src/cljs/rems/modal.cljs
+++ b/src/cljs/rems/modal.cljs
@@ -58,6 +58,11 @@
                                  commands)]
                   :open? true}]]
     [:div.modal--container
+     {:on-key-press
+      (fn [e]
+        (if (= (.-key e) "Enter")
+          (on-close)))
+      :tabIndex "-1"}
      (if (false? shade?)
        content
        [shade-wrapper content on-close])]))


### PR DESCRIPTION
- tabIndex -1 needs to be set for div.modal--container, otherwise
  key-press is not triggered everywhere within the modal when using
  a screen reader to navigate