### PR TITLE
fix error modal header styling

### DIFF
--- a/src/clj/rems/css/styles.clj
+++ b/src/clj/rems/css/styles.clj
@@ -599,9 +599,9 @@
    [:.license-panel {:display :inline-block
                      :width "inherit"}]
    [:.card-header.clickable {:cursor "pointer"}]
+   [:.rems-card-margin-fix {:margin (u/px -1)}]  ; make sure header overlaps container border
    [:.rems-card-header {:color (util/get-theme-attribute :table-heading-color "#fff")
-                        :background-color (util/get-theme-attribute :table-heading-bgcolor :color3)
-                        :margin (u/px -1)}] ; make sure header overlaps container border
+                        :background-color (util/get-theme-attribute :table-heading-bgcolor :color3)}]
    [(s/descendant :.card-header :a) {:color :inherit}]
    [:.application-resources
     [:.application-resource {:margin-bottom (u/rem 1)

--- a/src/cljs/rems/collapsible.cljs
+++ b/src/cljs/rems/collapsible.cljs
@@ -5,7 +5,7 @@
 
 (defn- header
   [title title-class]
-  [:h2.card-header {:class (or title-class "rems-card-header")} title])
+  [:h2.card-header {:class ["rems-card-margin-fix" (or title-class "rems-card-header")]} title])
 
 (defn- show-more-button
   [id expanded callback]


### PR DESCRIPTION
when setting the title-class for a modal, the margin fix got thrown
away which resulted in white space above the header