### PR TITLE
Fix duplicate key error in dropdown menus

### DIFF
--- a/src/cljs/rems/actions/add_licenses.cljs
+++ b/src/cljs/rems/actions/add_licenses.cljs
@@ -86,6 +86,7 @@
      [dropdown/dropdown
       {:id dropdown-id
        :items potential-licenses
+       :item-key :id
        :item-label #(title-of-license % language)
        :item-selected? #(contains? (set selected-licenses) %)
        :multi? true

--- a/src/cljs/rems/actions/add_member.cljs
+++ b/src/cljs/rems/actions/add_member.cljs
@@ -68,6 +68,7 @@
      [dropdown/dropdown
       {:id dropdown-id
        :items potential-members
+       :item-key :userid
        :item-label :display
        :item-selected? #(= selected-member %)
        :on-change on-set-member}]]]

--- a/src/cljs/rems/actions/change_resources.cljs
+++ b/src/cljs/rems/actions/change_resources.cljs
@@ -95,6 +95,7 @@
           {:id dropdown-id
            :items sorted-selected-catalogue
            :item-disabled? #(not (compatible-item? % original-workflow-id original-form-id))
+           :item-key :id
            :item-label #(get-localized-title % language)
            :item-selected? #(contains? (set selected-resources) (% :id))
            :multi? true

--- a/src/cljs/rems/actions/request_decision.cljs
+++ b/src/cljs/rems/actions/request_decision.cljs
@@ -76,6 +76,7 @@
      [dropdown/dropdown
       {:id dropdown-id
        :items potential-deciders
+       :item-key :userid
        :item-label :display
        :item-selected? #(contains? (set selected-deciders) %)
        :multi? true

--- a/src/cljs/rems/actions/request_review.cljs
+++ b/src/cljs/rems/actions/request_review.cljs
@@ -78,6 +78,7 @@
      [dropdown/dropdown
       {:id dropdown-id
        :items potential-reviewers
+       :item-key :userid
        :item-label :display
        :item-selected? #(contains? (set selected-reviewers) %)
        :multi? true

--- a/src/cljs/rems/administration/create_catalogue_item.cljs
+++ b/src/cljs/rems/administration/create_catalogue_item.cljs
@@ -145,6 +145,7 @@
      [dropdown/dropdown
       {:id workflow-dropdown-id
        :items workflows
+       :item-key :id
        :item-label :title
        :item-selected? #(= (:id %) (:id selected-workflow))
        :on-change #(rf/dispatch [::set-selected-workflow %])}]]))
@@ -157,6 +158,7 @@
      [dropdown/dropdown
       {:id resource-dropdown-id
        :items resources
+       :item-key :id
        :item-label :resid
        :item-selected? #(= (:id %) (:id selected-resource))
        :on-change #(rf/dispatch [::set-selected-resource %])}]]))
@@ -169,6 +171,7 @@
      [dropdown/dropdown
       {:id form-dropdown-id
        :items forms
+       :item-key :id
        :item-label :form/title
        :item-selected? #(= (:form/id %) (:id selected-form))
        :on-change #(rf/dispatch [::set-selected-form %])}]]))

--- a/src/cljs/rems/administration/create_resource.cljs
+++ b/src/cljs/rems/administration/create_resource.cljs
@@ -98,6 +98,7 @@
      [dropdown/dropdown
       {:id licenses-dropdown-id
        :items (map localize-item available-licenses)
+       :item-key :id
        :item-label :title
        :item-selected? #(contains? (set selected-licenses) %)
        :multi? true

--- a/src/cljs/rems/administration/create_workflow.cljs
+++ b/src/cljs/rems/administration/create_workflow.cljs
@@ -180,6 +180,7 @@
      [dropdown/dropdown
       {:id handlers-dropdown-id
        :items all-handlers
+       :item-key :userid
        :item-label :display
        :item-selected? #(contains? selected-handlers (% :userid))
        :multi? true

--- a/src/cljs/rems/dropdown.cljs
+++ b/src/cljs/rems/dropdown.cljs
@@ -6,7 +6,7 @@
 
 (defn dropdown
   "Single- or multi-choice, searchable dropdown menu."
-  [{:keys [id items item-label item-selected? item-disabled? multi? on-change]
+  [{:keys [id items item-key item-label item-selected? item-disabled? multi? on-change]
     :or {item-selected? (constantly false)
          item-disabled? (constantly false)}}]
   (let [options (map (fn [item] {:value item
@@ -16,6 +16,8 @@
         grouped (group-by #(item-selected? (% :value)) options)]
     [:> js/Select {:className "dropdown-container"
                    :classNamePrefix "dropdown-select"
+                   :getOptionValue #(let [item (:value (js->clj % :keywordize-keys true))]
+                                      (item-key item))
                    :inputId id
                    :isMulti multi?
                    :maxMenuHeight 200
@@ -42,10 +44,12 @@
      (component-info dropdown)
      (example "dropdown menu, single-choice, empty"
               [dropdown {:items items
+                         :item-key :userid
                          :item-label :userid
                          :on-change on-change}])
      (example "dropdown menu, multi-choice, several values selected"
               [dropdown {:items items
+                         :item-key :userid
                          :item-label :userid
                          :item-selected? #(contains? #{1 3 5} (% :id))
                          :multi? true


### PR DESCRIPTION
- As a default, the value of an option is used as the key for the
  element in react-select, but the library does not work well with
  non-primitive keys -- instead it gives an error about a duplicate
  key.

- As a fix, use getOptionValue parameter to set a custom mapping
  from an option to the key.