### PR TITLE
Remove custom spacing from headings

### DIFF
--- a/src/clj/rems/css/styles.clj
+++ b/src/clj/rems/css/styles.clj
@@ -282,8 +282,6 @@
            :flex-direction :column
            :padding-top (u/px 56)}]
    [:h1 :h2 {:font-weight 400}]
-   [:h1 :h2 :h3 {:letter-spacing (u/rem 0.17)}]
-   [:h4 :h5 :h6 {:letter-spacing (u/rem 0.12)}]
    [:h1 {:margin-bottom (u/rem 2)}]
    [:#app {:min-height (u/percent 100)
            :flex 1


### PR DESCRIPTION
- I could not find the reason for using these in the first place,
  and LBR preferred default spacing in large headings (h1, h2, h3).
  The smaller headings are only used in one place (h4 in create form)
  or nowhere (h5, h6), so remove custom spacing from them, as well.