### PR TITLE
rems.api.applications: set filename of pdf to <application-id>.pdf

### DIFF
--- a/src/clj/rems/api/applications.clj
+++ b/src/clj/rems/api/applications.clj
@@ -287,5 +287,7 @@
                (pdf/application-to-pdf-bytes)
                (ByteArrayInputStream.)
                (ok)
+               ;; could also set "attachment" here to force download:
+               (header "Content-Disposition" (str "filename=\"" application-id ".pdf\""))
                (content-type "application/pdf")))
         (api-util/not-found-json-response)))))

--- a/test/clj/rems/api/test_applications.clj
+++ b/test/clj/rems/api/test_applications.clj
@@ -127,6 +127,7 @@
                        handler
                        assert-response-is-ok)]
       (is (= "application/pdf" (get-in response [:headers "Content-Type"])))
+      (is (= "filename=\"13.pdf\"" (get-in response [:headers "Content-Disposition"])))
       (is (.startsWith (slurp (:body response)) "%PDF-1.")))))
 
 (deftest test-application-commands


### PR DESCRIPTION
closes #1470