### PR TITLE
rems.application-list: avoid warning about overwriting cljs.core/list

### DIFF
--- a/src/cljs/rems/application_list.cljs
+++ b/src/cljs/rems/application_list.cljs
@@ -1,4 +1,5 @@
 (ns rems.application-list
+  (:refer-clojure :exclude [list])
   (:require [clojure.set :as set]
             [clojure.string :as str]
             [re-frame.core :as rf]


### PR DESCRIPTION
figwheel doesn't load code with warnings