### PR TITLE
Refactor fetching licenses for workflow

### DIFF
--- a/resources/sql/queries.sql
+++ b/resources/sql/queries.sql
@@ -331,17 +331,15 @@ UPDATE workflow_licenses wl
 SET start = :start, endt = :end
 WHERE wl.licid = :licid;
 
+-- :name get-workflow-licenses :? :*
+SELECT licid, start, endt as "end"
+FROM workflow_licenses
+WHERE wfid = :wfid
+
 -- :name get-workflow :? :1
 SELECT
   wf.id, wf.organization, wf.owneruserid, wf.modifieruserid, wf.title, wf.start, wf.endt AS "end",
-  wf.workflowBody::TEXT as workflow, wf.enabled, wf.archived,
-  (SELECT json_agg(joined)
-   FROM (SELECT *, (SELECT json_agg(licloc)
-                    FROM license_localization licloc
-                    WHERE licloc.licid = lic.id) AS localizations
-         FROM workflow_licenses wflic
-         JOIN license lic ON (wflic.licid = lic.id)
-         WHERE wf.id = wflic.wfid) joined)::TEXT AS licenses
+  wf.workflowBody::TEXT as workflow, wf.enabled, wf.archived
 FROM workflow wf
 /*~ (when (:catid params) */
 JOIN catalogue_item ci ON (wf.id = ci.wfid)

--- a/src/clj/rems/api/schema.clj
+++ b/src/clj/rems/api/schema.clj
@@ -95,13 +95,6 @@
 
 (def UserId s/Str)
 
-(s/defschema WorkflowLicense
-  {:type s/Str
-   :start DateTime
-   :textcontent s/Str
-   :localizations [s/Any]
-   :end (s/maybe DateTime)})
-
 (s/defschema Workflow
   {:id s/Int
    :organization s/Str
@@ -109,7 +102,7 @@
    :modifieruserid UserId
    :title s/Str
    :workflow s/Any
-   :licenses [WorkflowLicense]
+   :licenses [License]
    :start DateTime
    :end (s/maybe DateTime)
    :expired s/Bool

--- a/src/clj/rems/db/workflow.clj
+++ b/src/clj/rems/db/workflow.clj
@@ -1,67 +1,40 @@
 (ns rems.db.workflow
-  (:require [clj-time.core :as time-core]
-            [clojure.test :refer [deftest is]]
-            [rems.db.catalogue :as catalogue]
-            [rems.db.core :as db]
+  (:require [rems.db.core :as db]
+            [rems.db.licenses :as licenses]
             [rems.db.users :as users]
             [rems.json :as json]
-            [rems.util :refer [update-present]])
-  (:import [org.joda.time DateTime DateTimeZone]))
+            [rems.util :refer [update-present]]))
 
-(defn- parse-db-time [s]
-  (when s
-    (-> (DateTime/parse s)
-        (.withZone DateTimeZone/UTC))))
+;; XXX: Overwriting :start and :end from license table with :start and :end
+;;      from workflow_license table seems error-prone - they could at least
+;;      be named differently to avoid confusion.
+;;
+;;      See a related comment in rems.db.licenses regarding the use of
+;;      various start and end times.
+(defn- join-workflow-license-with-license [workflow-license]
+  (-> (:licid workflow-license)
+      licenses/get-license
+      (assoc :start (:start workflow-license)
+             :end (:end workflow-license))))
 
-(deftest test-parse-db-time
-  (is (= nil (parse-db-time nil)))
-  (is (= (time-core/date-time 2019 1 30 7 56 38 627) (parse-db-time "2019-01-30T09:56:38.627616+02:00")))
-  (is (= (time-core/date-time 2015 2 13 12 47 26) (parse-db-time "2015-02-13T14:47:26+02:00"))))
-
-;; TODO: This should probably be in rems.db.licenses.
-(defn- format-license [license]
-  (-> license
-      (select-keys [:type :textcontent :localizations])
-      (assoc :start (parse-db-time (:start license)))
-      (assoc :end (parse-db-time (:end license)))))
-
-(defn- format-workflow
-  [{:keys [id organization owneruserid modifieruserid title workflow start end expired enabled archived licenses]}]
-  {:id id
-   :organization organization
-   :owneruserid owneruserid
-   :modifieruserid modifieruserid
-   :title title
-   :workflow workflow
-   :start start
-   :end end
-   :expired expired
-   :enabled enabled
-   :archived archived
-   :licenses (mapv format-license licenses)})
+(defn- get-workflow-licenses [id]
+  (->> {:wfid id}
+       db/get-workflow-licenses
+       (mapv join-workflow-license-with-license)))
 
 (defn- enrich-and-format-workflow [wf]
   (-> wf
-      (update-present :workflow update :handlers #(mapv users/get-user %))
-      format-workflow))
-
-(defn- parse-workflow-body [json]
-  (json/parse-string json))
-
-(defn- parse-licenses [json]
-  (json/parse-string json))
+      (update :workflow #(json/parse-string %))
+      (assoc :licenses (get-workflow-licenses (:id wf)))
+      db/assoc-expired
+      (update-present :workflow update :handlers #(mapv users/get-user %))))
 
 (defn get-workflow [id]
   (-> {:wfid id}
       db/get-workflow
-      (update :workflow parse-workflow-body)
-      (update :licenses parse-licenses)
-      db/assoc-expired
       enrich-and-format-workflow))
 
 (defn get-workflows [filters]
   (->> (db/get-workflows)
-       (map #(update % :workflow parse-workflow-body))
-       (map db/assoc-expired)
-       (db/apply-filters filters)
-       (mapv enrich-and-format-workflow)))
+       (map enrich-and-format-workflow)
+       (db/apply-filters filters)))

--- a/src/clj/rems/db/workflow.clj
+++ b/src/clj/rems/db/workflow.clj
@@ -2,8 +2,7 @@
   (:require [rems.db.core :as db]
             [rems.db.licenses :as licenses]
             [rems.db.users :as users]
-            [rems.json :as json]
-            [rems.util :refer [update-present]]))
+            [rems.json :as json]))
 
 ;; XXX: Overwriting :start and :end from license table with :start and :end
 ;;      from workflow_license table seems error-prone - they could at least
@@ -24,10 +23,10 @@
 
 (defn- enrich-and-format-workflow [wf]
   (-> wf
-      (update :workflow #(json/parse-string %))
+      (update :workflow json/parse-string)
       (assoc :licenses (get-workflow-licenses (:id wf)))
       db/assoc-expired
-      (update-present :workflow update :handlers #(mapv users/get-user %))))
+      (update-in [:workflow :handlers] #(mapv users/get-user %))))
 
 (defn get-workflow [id]
   (-> {:wfid id}


### PR DESCRIPTION
- Previously, /api/workflows/ did not work correctly when fetching
  all workflows. It returned an empty vector of licenses for a
  workflow regardless of if it had licenses or not. (Do not add
  test for that because having workflows contain licenses is a
  legacy feature, so it is would be more difficult to test.)

- Simplify SQL queries and move parts of the logic to clojure side,
  namely, joining workflow-licenses and the actual license data,
  which has the benefit of doing fewer JSON round-trips.

- Previously, workflow had license localizations that were formatted
  differently compared to fetching only the license using API, which
  will cause potential trouble when using the license.

  To fix that, use rems.db.licenses for joining license data to workflow,
  ensuring that the license is always formatted in the same way.

- Consequently, remove license-related parts from rems.db.workflow.

- Unify License and WorkflowLicense schemas: use License schema for
  workflows, as well.

- Be more explicit about using workflow_license table's start and end times
  when joining a license to a workflow, previously it was slightly hidden
  in the SQL query returning start, start_2, end, and end_2, from which
  the correct keys were selected.