### PR TITLE
Force creation of localizations before resetting cache

### DIFF
--- a/src/clj/rems/api/services/catalogue.clj
+++ b/src/clj/rems/api/services/catalogue.clj
@@ -18,10 +18,11 @@
 (defn create-catalogue-item! [{:keys [localizations] :as command}]
   (let [id (:id (db/create-catalogue-item! (select-keys command [:form :resid :wfid :enabled :archived])))
         loc-ids
-        (for [[langcode localization] localizations]
-          (:id (db/create-catalogue-item-localization! {:id id
-                                                        :langcode (name langcode)
-                                                        :title (:title localization)})))]
+        (doall
+         (for [[langcode localization] localizations]
+           (:id (db/create-catalogue-item-localization! {:id id
+                                                         :langcode (name langcode)
+                                                         :title (:title localization)}))))]
     ;; Reset cache so that next call to get localizations will get these ones.
     (catalogue/reset-cache!)
     {:success (not (some nil? (cons id loc-ids)))


### PR DESCRIPTION
I noticed that sometimes just created catalogue item did not have
localizations until after a while, this is a likely cause for that.

Caused by previous changes done for #1507.

# Definition of Done / Review checklist

## Reviewability
- [ ] link to issue
- [ ] note if PR is on top of other PR
- [ ] note if related change in rems-deploy repo
- [ ] consider adding screenshots for ease of review

## API
- [ ] API is documented and shows up in Swagger UI
- [ ] API is backwards compatible or completely new
- [ ] Events are backwards compatible

## Documentation
- [ ] update changelog if necessary
- [ ] add or update docstrings for namespaces and functions
- [ ] components are added to guide page
- [ ] documentation _at least_ for config options (i.e. docs folder)
- [ ] ADR for major architectural decisions or experiments

## Different installations
- [ ] new configuration options added to rems-deploy repository
- [ ] instance specific translations (i.e. LBR kielivara)

## Testing
- [ ] complex logic is unit tested
- [ ] valuable features are integration / browser / acceptance tested automatically

## Accessibility
- [ ] all icons have the aria-label attribute
- [ ] all fields have a label
- [ ] errors are linked to fields with aria-describedby
- [ ] contrast is checked
- [ ] conscious decision about where to move focus after an action

## Follow-up
- [ ] new tasks are created for pending or remaining tasks
- [ ] no critical TODOs left to implement
