### PR TITLE
Change 'active' to mean enabled, not archived, and not expired

### DIFF
--- a/src/cljs/rems/administration/catalogue_item.cljs
+++ b/src/cljs/rems/administration/catalogue_item.cljs
@@ -3,6 +3,7 @@
             [re-frame.core :as rf]
             [rems.administration.administration :refer [administration-navigator-container]]
             [rems.administration.components :refer [inline-info-field]]
+            [rems.administration.status-flags :as status-flags]
             [rems.atoms :as atoms :refer [info-field readonly-checkbox document-title]]
             [rems.collapsible :as collapsible]
             [rems.spinner :as spinner]
@@ -67,7 +68,7 @@
                        (:form-name catalogue-item)]]
                      [inline-info-field (text :t.administration/start) (localize-time (:start catalogue-item))]
                      [inline-info-field (text :t.administration/end) (localize-time (:end catalogue-item))]
-                     [inline-info-field (text :t.administration/active) [readonly-checkbox (not (:expired catalogue-item))]]]))}]
+                     [inline-info-field (text :t.administration/active) [readonly-checkbox (status-flags/active? catalogue-item)]]]))}]
    [:div.col.commands [back-button] [edit-button (:id catalogue-item)]]])
 
 (defn catalogue-item-page []

--- a/src/cljs/rems/administration/catalogue_items.cljs
+++ b/src/cljs/rems/administration/catalogue_items.cljs
@@ -102,8 +102,7 @@
            :end (let [value (:end item)]
                   {:value value
                    :display-value (localize-time value)})
-           ;; TODO: active means not-expired currently. it should maybe mean (and not-expired enabled not-archived)
-           :active (let [checked? (not (:expired item))]
+           :active (let [checked? (status-flags/active? item)]
                      {:td [:td.active
                            [readonly-checkbox checked?]]
                       :sort-value (if checked? 1 2)})

--- a/src/cljs/rems/administration/form.cljs
+++ b/src/cljs/rems/administration/form.cljs
@@ -73,7 +73,7 @@
               [inline-info-field (text :t.administration/title) (:form/title form)]
               [inline-info-field (text :t.administration/start) (localize-time (:start form))]
               [inline-info-field (text :t.administration/end) (localize-time (:end form))]
-              [inline-info-field (text :t.administration/active) [readonly-checkbox (not (:expired form))]]]}]
+              [inline-info-field (text :t.administration/active) [readonly-checkbox (status-flags/active? form)]]]}]
    [:div.col.commands
     [back-button]
     [edit-button (:form/id form)]

--- a/src/cljs/rems/administration/forms.cljs
+++ b/src/cljs/rems/administration/forms.cljs
@@ -93,7 +93,7 @@
            :end (let [value (:end form)]
                   {:value value
                    :display-value (localize-time value)})
-           :active (let [checked? (not (:expired form))]
+           :active (let [checked? (status-flags/active? form)]
                      {:td [:td.active
                            [readonly-checkbox checked?]]
                       :sort-value (if checked? 1 2)})

--- a/src/cljs/rems/administration/license.cljs
+++ b/src/cljs/rems/administration/license.cljs
@@ -3,6 +3,7 @@
             [re-frame.core :as rf]
             [rems.administration.administration :refer [administration-navigator-container]]
             [rems.administration.components :refer [inline-info-field]]
+            [rems.administration.status-flags :as status-flags]
             [rems.atoms :as atoms :refer [attachment-link external-link readonly-checkbox document-title]]
             [rems.collapsible :as collapsible]
             [rems.spinner :as spinner]
@@ -71,7 +72,7 @@
                            {:box? false}])))
                     [[inline-info-field (text :t.administration/start) (localize-time (:start license))]
                      [inline-info-field (text :t.administration/end) (localize-time (:end license))]
-                     [inline-info-field (text :t.administration/active) [readonly-checkbox (not (:expired license))]]]))}]
+                     [inline-info-field (text :t.administration/active) [readonly-checkbox (status-flags/active? license)]]]))}]
    [:div.col.commands [back-button]]])
 
 ;; XXX: Duplicates much of license-view. One notable difference is that

--- a/src/cljs/rems/administration/licenses.cljs
+++ b/src/cljs/rems/administration/licenses.cljs
@@ -79,7 +79,7 @@
            :end (let [value (:end license)]
                   {:value value
                    :display-value (localize-time value)})
-           :active (let [checked? (not (:expired license))]
+           :active (let [checked? (status-flags/active? license)]
                      {:td [:td.active
                            [readonly-checkbox checked?]]
                       :sort-value (if checked? 1 2)})

--- a/src/cljs/rems/administration/resource.cljs
+++ b/src/cljs/rems/administration/resource.cljs
@@ -4,6 +4,7 @@
             [rems.administration.administration :refer [administration-navigator-container]]
             [rems.administration.components :refer [inline-info-field]]
             [rems.administration.license :refer [licenses-view]]
+            [rems.administration.status-flags :as status-flags]
             [rems.atoms :as atoms :refer [attachment-link external-link readonly-checkbox document-title]]
             [rems.collapsible :as collapsible]
             [rems.common-util :refer [andstr]]
@@ -48,7 +49,7 @@
               [inline-info-field (text :t.administration/resource) (:resid resource)]
               [inline-info-field (text :t.administration/start) (localize-time (:start resource))]
               [inline-info-field (text :t.administration/end) (localize-time (:end resource))]
-              [inline-info-field (text :t.administration/active) [readonly-checkbox (not (:expired resource))]]]}]
+              [inline-info-field (text :t.administration/active) [readonly-checkbox (status-flags/active? resource)]]]}]
    [licenses-view (:licenses resource) language]
    [:div.col.commands [back-button]]])
 

--- a/src/cljs/rems/administration/resources.cljs
+++ b/src/cljs/rems/administration/resources.cljs
@@ -78,7 +78,7 @@
            :end (let [value (:end resource)]
                   {:value value
                    :display-value (localize-time value)})
-           :active (let [checked? (not (:expired resource))]
+           :active (let [checked? (status-flags/active? resource)]
                      {:td [:td.active
                            [readonly-checkbox checked?]]
                       :sort-value (if checked? 1 2)})

--- a/src/cljs/rems/administration/status_flags.cljs
+++ b/src/cljs/rems/administration/status_flags.cljs
@@ -38,7 +38,6 @@
     [unarchive-button item on-change]
     [archive-button item on-change]))
 
-
 (defn display-old-toggle [display-old? on-change]
   [:div.form-check.form-check-inline {:style {:float "right"}}
    [:input.form-check-input {:type "checkbox"
@@ -47,6 +46,9 @@
                              :on-change #(on-change (not display-old?))}]
    [:label.form-check-label {:for "display-old"}
     (text :t.administration/display-old)]])
+
+(defn active? [item]
+  (and (not (:expired item)) (:enabled item) (not (:archived item))))
 
 (defn- format-update-error [{:keys [type catalogue-items forms licenses resources workflows]}]
   (let [language @(rf/subscribe [:language])]

--- a/src/cljs/rems/administration/workflow.cljs
+++ b/src/cljs/rems/administration/workflow.cljs
@@ -4,6 +4,7 @@
             [rems.administration.administration :refer [administration-navigator-container]]
             [rems.administration.components :refer [inline-info-field]]
             [rems.administration.license :refer [licenses-view]]
+            [rems.administration.status-flags :as status-flags]
             [rems.atoms :as atoms :refer [attachment-link external-link info-field readonly-checkbox enrich-user document-title]]
             [rems.collapsible :as collapsible]
             [rems.common-util :refer [andstr]]
@@ -62,7 +63,7 @@
                                                                          (str/join ", "))]
               [inline-info-field (text :t.administration/start) (localize-time (:start workflow))]
               [inline-info-field (text :t.administration/end) (localize-time (:end workflow))]
-              [inline-info-field (text :t.administration/active) [readonly-checkbox (not (:expired workflow))]]]}]
+              [inline-info-field (text :t.administration/active) [readonly-checkbox (status-flags/active? workflow)]]]}]
    [licenses-view (:licenses workflow) language]
    [:div.col.commands [back-button] [edit-button (:id workflow)]]])
 

--- a/src/cljs/rems/administration/workflows.cljs
+++ b/src/cljs/rems/administration/workflows.cljs
@@ -82,7 +82,7 @@
            :end (let [value (:end workflow)]
                   {:value value
                    :display-value (localize-time value)})
-           :active (let [checked? (not (:expired workflow))]
+           :active (let [checked? (status-flags/active? workflow)]
                      {:td [:td.active
                            [readonly-checkbox checked?]]
                       :sort-value (if checked? 1 2)})


### PR DESCRIPTION
Tables have 'Active' column, which can be used, e.g., for sorting,
therefore have a more meaningful definition for active than just
expired.

Part of #1438

# Definition of Done / Review checklist

## Reviewability
- [x] link to issue
- [x] note if PR is on top of other PR
- [x] note if related change in rems-deploy repo
- [x] consider adding screenshots for ease of review

## API
- [x] API is documented and shows up in Swagger UI
- [x] API is backwards compatible or completely new
- [x] Events are backwards compatible

## Documentation
- [x] update changelog if necessary
- [x] add or update docstrings for namespaces and functions
- [x] components are added to guide page
- [x] documentation _at least_ for config options (i.e. docs folder)
- [x] ADR for major architectural decisions or experiments

## Different installations
- [x] new configuration options added to rems-deploy repository
- [x] instance specific translations (i.e. LBR kielivara)

## Testing
- [x] complex logic is unit tested
- [x] valuable features are integration / browser / acceptance tested automatically

## Accessibility
- [x] all icons have the aria-label attribute
- [x] all fields have a label
- [x] errors are linked to fields with aria-describedby
- [x] contrast is checked
- [x] conscious decision about where to move focus after an action

## Follow-up
- [x] new tasks are created for pending or remaining tasks
- [x] no critical TODOs left to implement
