### PR TITLE
Refactor edit buttons

### DIFF
--- a/src/cljs/rems/administration/catalogue_item.cljs
+++ b/src/cljs/rems/administration/catalogue_item.cljs
@@ -37,8 +37,8 @@
    "/#/administration/catalogue-items"
    (text :t.administration/back)])
 
-(defn- edit-button [id]
-  [atoms/link {:class "btn btn-secondary"}
+(defn edit-button [id]
+  [atoms/link {:class "btn btn-primary"}
    (str "/#/administration/edit-catalogue-item/" id)
    (text :t.administration/edit)])
 

--- a/src/cljs/rems/administration/catalogue_items.cljs
+++ b/src/cljs/rems/administration/catalogue_items.cljs
@@ -1,6 +1,7 @@
 (ns rems.administration.catalogue-items
   (:require [re-frame.core :as rf]
             [rems.administration.administration :refer [administration-navigator-container]]
+            [rems.administration.catalogue-item :as catalogue-item]
             [rems.administration.status-flags :as status-flags]
             [rems.atoms :as atoms :refer [readonly-checkbox document-title]]
             [rems.spinner :as spinner]
@@ -64,11 +65,6 @@
    (str "/#/administration/catalogue-items/" catalogue-item-id)
    (text :t.administration/view)])
 
-(defn- to-edit-catalogue-item [catalogue-item-id]
-  [atoms/link {:class "btn btn-primary"}
-   (str "/#/administration/edit-catalogue-item/" catalogue-item-id)
-   (text :t.administration/edit)])
-
 (rf/reg-sub
  ::catalogue-table-rows
  (fn [_ _]
@@ -108,7 +104,7 @@
                       :sort-value (if checked? 1 2)})
            :commands {:td [:td.commands
                            [to-catalogue-item (:id item)]
-                           [to-edit-catalogue-item (:id item)]
+                           [catalogue-item/edit-button (:id item)]
                            [status-flags/enabled-toggle item #(rf/dispatch [::update-catalogue-item %1 %2 [::fetch-catalogue]])]
                            [status-flags/archived-toggle item #(rf/dispatch [::update-catalogue-item %1 %2 [::fetch-catalogue]])]]}})
         catalogue)))

--- a/src/cljs/rems/administration/form.cljs
+++ b/src/cljs/rems/administration/form.cljs
@@ -50,7 +50,7 @@
    "/#/administration/forms"
    (text :t.administration/back)])
 
-(defn- edit-button [id]
+(defn edit-button [id]
   [:button.btn.btn-primary
    {:type :button
     :on-click (fn []

--- a/src/cljs/rems/administration/forms.cljs
+++ b/src/cljs/rems/administration/forms.cljs
@@ -1,6 +1,7 @@
 (ns rems.administration.forms
   (:require [re-frame.core :as rf]
             [rems.administration.administration :refer [administration-navigator-container]]
+            [rems.administration.form :as form]
             [rems.administration.status-flags :as status-flags]
             [rems.atoms :as atoms :refer [readonly-checkbox document-title]]
             [rems.spinner :as spinner]
@@ -65,14 +66,6 @@
    (str "/#/administration/forms/" (:form/id form))
    (text :t.administration/view)])
 
-(defn- to-edit-form [form]
-  [:button.btn.btn-primary
-   {:type :button
-    :on-click (fn []
-                (rf/dispatch [:rems.spa/user-triggered-navigation])
-                (rf/dispatch [:rems.administration.form/edit-form (:form/id form)]))}
-   (text :t.administration/edit)])
-
 (defn- copy-as-new-form [form]
   [atoms/link {:class "btn btn-primary"}
    (str "/#/administration/create-form/" (:form/id form))
@@ -99,7 +92,7 @@
                       :sort-value (if checked? 1 2)})
            :commands {:td [:td.commands
                            [to-view-form form]
-                           [to-edit-form form]
+                           [form/edit-button (:form/id form)]
                            [copy-as-new-form form]
                            [status-flags/enabled-toggle form #(rf/dispatch [::update-form %1 %2 [::fetch-forms]])]
                            [status-flags/archived-toggle form #(rf/dispatch [::update-form %1 %2 [::fetch-forms]])]]}})

--- a/src/cljs/rems/administration/workflow.cljs
+++ b/src/cljs/rems/administration/workflow.cljs
@@ -39,8 +39,8 @@
    "/#/administration/workflows"
    (text :t.administration/back)])
 
-(defn- edit-button [id]
-  [atoms/link {:class "btn btn-secondary"}
+(defn edit-button [id]
+  [atoms/link {:class "btn btn-primary"}
    (str "/#/administration/edit-workflow/" id)
    (text :t.administration/edit)])
 

--- a/src/cljs/rems/administration/workflows.cljs
+++ b/src/cljs/rems/administration/workflows.cljs
@@ -1,6 +1,7 @@
 (ns rems.administration.workflows
   (:require [re-frame.core :as rf]
             [rems.administration.administration :refer [administration-navigator-container]]
+            [rems.administration.workflow :as workflow]
             [rems.administration.status-flags :as status-flags]
             [rems.atoms :as atoms :refer [readonly-checkbox document-title]]
             [rems.spinner :as spinner]
@@ -62,11 +63,6 @@
    (str "/#/administration/workflows/" workflow-id)
    (text :t.administration/view)])
 
-(defn- to-edit-workflow [workflow-id]
-  [atoms/link {:class "btn btn-primary"}
-   (str "/#/administration/edit-workflow/" workflow-id)
-   (text :t.administration/edit)])
-
 (rf/reg-sub
  ::workflows-table-rows
  (fn [_ _]
@@ -88,7 +84,7 @@
                       :sort-value (if checked? 1 2)})
            :commands {:td [:td.commands
                            [to-view-workflow (:id workflow)]
-                           [to-edit-workflow (:id workflow)]
+                           [workflow/edit-button (:id workflow)]
                            [status-flags/enabled-toggle workflow #(rf/dispatch [::update-workflow %1 %2 [::fetch-workflows]])]
                            [status-flags/archived-toggle workflow #(rf/dispatch [::update-workflow %1 %2 [::fetch-workflows]])]]}})
         workflows)))


### PR DESCRIPTION
- Also change btn.secondary to btn.primary in edit buttons, the
  former had ended up there accidentally in a previous refactoring patch

Related to change requested for #1507 but not done then.

# Definition of Done / Review checklist

## Reviewability
- [ ] link to issue
- [ ] note if PR is on top of other PR
- [ ] note if related change in rems-deploy repo
- [ ] consider adding screenshots for ease of review

## API
- [ ] API is documented and shows up in Swagger UI
- [ ] API is backwards compatible or completely new
- [ ] Events are backwards compatible

## Documentation
- [ ] update changelog if necessary
- [ ] add or update docstrings for namespaces and functions
- [ ] components are added to guide page
- [ ] documentation _at least_ for config options (i.e. docs folder)
- [ ] ADR for major architectural decisions or experiments

## Different installations
- [ ] new configuration options added to rems-deploy repository
- [ ] instance specific translations (i.e. LBR kielivara)

## Testing
- [ ] complex logic is unit tested
- [ ] valuable features are integration / browser / acceptance tested automatically

## Accessibility
- [ ] all icons have the aria-label attribute
- [ ] all fields have a label
- [ ] errors are linked to fields with aria-describedby
- [ ] contrast is checked
- [ ] conscious decision about where to move focus after an action

## Follow-up
- [ ] new tasks are created for pending or remaining tasks
- [ ] no critical TODOs left to implement
