### PR TITLE
Change edit form API endpoint from /[form-id]/edit to /edit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ Changes since v2.4
 - API for creating catalogue item and its localizations has been changed.
   There is now a single API call that is used to create both a catalogue
   item and the localizations, namely, /api/catalogue-items/create.
+- API endpoint for editing forms has been changed from
+  /api/forms/[form-id]/edit to /api/forms/edit.
 
 ### Additions
 - New field types: description, option, multiselect

--- a/src/clj/rems/api/forms.clj
+++ b/src/clj/rems/api/forms.clj
@@ -17,6 +17,9 @@
    :form/title s/Str
    :form/fields [NewFieldTemplate]})
 
+(s/defschema EditFormCommand
+  (assoc CreateFormCommand :form/id s/Int))
+
 (s/defschema CreateFormResponse
   {:success s/Bool
    :id s/Int})
@@ -61,21 +64,13 @@
       (ok (form/form-editable form-id)))
 
     ;; TODO: PATCH would be more appropriate, but we use PUT elsewhere in the API
-    (PUT "/:form-id/edit" []
+    (PUT "/edit" []
       :summary "Edit form"
       :roles #{:owner}
-      :path-params [form-id :- (describe s/Int "form-id")]
-      :body [command CreateFormCommand]
+      :body [command EditFormCommand]
       :return SuccessResponse
-      (ok (form/edit-form! (getx-user-id) form-id command)))
+      (ok (form/edit-form! (getx-user-id) command)))
 
-    ;; TODO: Change endpoint for updating form to be consistent with
-    ;;   the endpoint for editing form (/:form-id/edit). Also change
-    ;;   terminology to be less easily confused with form editing, e.g.,
-    ;;   from /update to /:form-id/update-state.
-    ;;
-    ;;   For consistency, do similar change for catalogue items, licenses,
-    ;;   and resources.
     (PUT "/update" []
       :summary "Update form"
       :roles #{:owner}

--- a/src/clj/rems/db/form.clj
+++ b/src/clj/rems/db/form.clj
@@ -77,14 +77,15 @@
     {:success (not (nil? form-id))
      :id form-id}))
 
-(defn edit-form! [user-id form-id form]
-  (or (form-in-use-error form-id)
-      (do (db/edit-form-template! {:id form-id
-                                   :organization (:form/organization form)
-                                   :title (:form/title form)
-                                   :user user-id
-                                   :fields (serialize-fields form)})
-          {:success true})))
+(defn edit-form! [user-id form]
+  (let [form-id (:form/id form)]
+    (or (form-in-use-error form-id)
+        (do (db/edit-form-template! {:id form-id
+                                     :organization (:form/organization form)
+                                     :title (:form/title form)
+                                     :user user-id
+                                     :fields (serialize-fields form)})
+            {:success true}))))
 
 (defn update-form! [command]
   (let [catalogue-items (catalogue-items-for-form (:id command))]

--- a/src/cljs/rems/administration/create_form.cljs
+++ b/src/cljs/rems/administration/create_form.cljs
@@ -174,11 +174,12 @@
          send-verb (if edit? put! post!)]
      (when-not form-errors
        (status-modal/common-pending-handler! (page-title edit?))
-       (send-verb (str "/api/forms/"
-                       (if edit?
-                         (str (db ::form-id) "/edit")
-                         "create"))
-                  {:params (build-request (db ::form) (db :languages))
+       (send-verb (str "/api/forms/" (if edit?
+                                       "edit"
+                                       "create"))
+                  {:params (merge (build-request (db ::form) (db :languages))
+                                  (when edit?
+                                    {:form/id (db ::form-id)}))
                    :handler (partial status-modal/common-success-handler! #(dispatch! (str "#/administration/forms/" (or (db ::form-id) (:id %)))))
                    :error-handler status-modal/common-error-handler!}))
      {:db (assoc db ::form-errors form-errors)})))

--- a/test/clj/rems/api/test_forms.clj
+++ b/test/clj/rems/api/test_forms.clj
@@ -185,9 +185,10 @@
                      handler
                      read-ok-body)]
         (is (= (:form/organization form) "abc")))
-      (let [response (-> (request :put (str "/api/forms/" form-id "/edit"))
+      (let [response (-> (request :put "/api/forms/edit")
                          (authenticate api-key user-id)
-                         (json-body {:form/organization "def"
+                         (json-body {:form/id form-id
+                                     :form/organization "def"
                                      :form/title "form edit test"
                                      :form/fields []})
                          handler


### PR DESCRIPTION
Related to #1548 (cleaning up the API)

# Definition of Done / Review checklist

## Reviewability
- [ ] link to issue
- [ ] note if PR is on top of other PR
- [ ] note if related change in rems-deploy repo
- [ ] consider adding screenshots for ease of review

## API
- [ ] API is documented and shows up in Swagger UI
- [ ] API is backwards compatible or completely new
- [ ] Events are backwards compatible

## Documentation
- [ ] update changelog if necessary
- [ ] add or update docstrings for namespaces and functions
- [ ] components are added to guide page
- [ ] documentation _at least_ for config options (i.e. docs folder)
- [ ] ADR for major architectural decisions or experiments

## Different installations
- [ ] new configuration options added to rems-deploy repository
- [ ] instance specific translations (i.e. LBR kielivara)

## Testing
- [ ] complex logic is unit tested
- [ ] valuable features are integration / browser / acceptance tested automatically

## Accessibility
- [ ] all icons have the aria-label attribute
- [ ] all fields have a label
- [ ] errors are linked to fields with aria-describedby
- [ ] contrast is checked
- [ ] conscious decision about where to move focus after an action

## Follow-up
- [ ] new tasks are created for pending or remaining tasks
- [ ] no critical TODOs left to implement
