### PR TITLE
Flash message location

### DIFF
--- a/resources/translations/en.edn
+++ b/resources/translations/en.edn
@@ -23,8 +23,6 @@
             :licenses-not-accepted-error "Terms of use not accepted."
             :load-application-states "Load application states"
             :member "Member"
-            :member-invited "Member invited."
-            :member-added "Member added."
             :member-name "Name"
             :member-email "Email"
             :name-and-email-required "Name and email are required."

--- a/resources/translations/fi.edn
+++ b/resources/translations/fi.edn
@@ -23,8 +23,6 @@
             :licenses-not-accepted-error "Käyttöehtoja ei ole hyväksytty."
             :load-application-states "Lataa hakemusten tilat"
             :member "Jäsen"
-            :member-added "Jäsen lisätty."
-            :member-invited "Jäsen kutsuttu."
             :member-name "Nimi"
             :member-email "Sähköposti"
             :name-and-email-required "Nimi ja sähköposti ovat pakollisia."

--- a/src/cljs/rems/actions/accept_licenses.cljs
+++ b/src/cljs/rems/actions/accept_licenses.cljs
@@ -1,18 +1,20 @@
 (ns rems.actions.accept-licenses
   (:require [re-frame.core :as rf]
             [rems.actions.action :refer [action-button action-form-view action-comment button-wrapper]]
-            [rems.status-modal :as status-modal]
+            [rems.flash-message :as flash-message]
             [rems.text :refer [text]]
             [rems.util :refer [post!]]))
 
 (rf/reg-event-fx
  ::send-accept-licenses
  (fn [_ [_ {:keys [application-id licenses on-finished]}]]
-   (post! "/api/applications/accept-licenses"
-          {:params {:application-id application-id
-                    :accepted-licenses licenses}
-           :handler (fn [_] (on-finished))
-           :error-handler status-modal/common-error-handler!})
+   (let [description (text :t.actions/accept-licenses)]
+     (post! "/api/applications/accept-licenses"
+            {:params {:application-id application-id
+                      :accepted-licenses licenses}
+             :handler (flash-message/default-success-handler
+                       :accept-licenses description (fn [_] (on-finished)))
+             :error-handler (flash-message/default-error-handler :accept-licenses description)}))
    {}))
 
 (defn accept-licenses-action-button [application-id licenses on-finished]

--- a/src/cljs/rems/actions/add_licenses.cljs
+++ b/src/cljs/rems/actions/add_licenses.cljs
@@ -54,11 +54,12 @@
                       :comment comment
                       :licenses (map :id licenses)}
              :handler (flash-message/default-success-handler
+                       :top
                        description
                        (fn [_]
                          (collapse-action-form action-form-id)
                          (on-finished)))
-             :error-handler (flash-message/default-error-handler description)}))
+             :error-handler (flash-message/default-error-handler :top description)}))
    {}))
 
 (defn add-licenses-action-button []

--- a/src/cljs/rems/actions/add_member.cljs
+++ b/src/cljs/rems/actions/add_member.cljs
@@ -18,7 +18,6 @@
  ::open-form
  (fn [{:keys [db]} _]
    {:db (assoc db
-               ::done? false
                ::potential-members #{}
                ::selected-member nil)
     ::fetch-potential-members #(rf/dispatch [::set-potential-members %])}))
@@ -34,9 +33,6 @@
 (rf/reg-event-db ::set-selected-member (fn [db [_ member]] (assoc db ::selected-member member)))
 (rf/reg-sub ::selected-member (fn [db _] (::selected-member db)))
 
-(rf/reg-event-db ::set-done? (fn [db [_ done]] (assoc db ::done? done)))
-(rf/reg-sub ::done? (fn [db _] (::done? db)))
-
 (def ^:private action-form-id "add-member")
 (def ^:private dropdown-id "add-member-dropdown")
 
@@ -47,21 +43,16 @@
           {:params {:application-id application-id
                     :member (select-keys member [:userid])}
            :handler (fn [_]
+                      (flash-message/show-success! :change-members (text :t.actions/member-added))
                       (collapse-action-form action-form-id)
-                      (rf/dispatch [::set-done? true])
                       (on-finished))
-           :error-handler (flash-message/default-error-handler :top (text :t.actions/add-member))})
+           :error-handler (flash-message/default-error-handler :change-members (text :t.actions/add-member))})
    {}))
 
 (defn add-member-action-button []
   [action-button {:id action-form-id
                   :text (text :t.actions/add-member)
                   :on-click #(rf/dispatch [::open-form])}])
-
-(defn add-member-status []
-  (when @(rf/subscribe [::done?])
-    [atoms/flash-message {:status :success
-                          :contents (text :t.actions/member-added)}]))
 
 (defn add-member-view
   [{:keys [selected-member potential-members on-set-member on-send]}]

--- a/src/cljs/rems/actions/add_member.cljs
+++ b/src/cljs/rems/actions/add_member.cljs
@@ -50,7 +50,7 @@
                       (collapse-action-form action-form-id)
                       (rf/dispatch [::set-done? true])
                       (on-finished))
-           :error-handler (flash-message/default-error-handler (text :t.actions/add-member))})
+           :error-handler (flash-message/default-error-handler :top (text :t.actions/add-member))})
    {}))
 
 (defn add-member-action-button []

--- a/src/cljs/rems/actions/add_member.cljs
+++ b/src/cljs/rems/actions/add_member.cljs
@@ -39,14 +39,17 @@
 (rf/reg-event-fx
  ::send-add-member
  (fn [_ [_ {:keys [member application-id on-finished]}]]
-   (post! "/api/applications/add-member"
-          {:params {:application-id application-id
-                    :member (select-keys member [:userid])}
-           :handler (fn [_]
-                      (flash-message/show-success! :change-members (text :t.actions/member-added))
-                      (collapse-action-form action-form-id)
-                      (on-finished))
-           :error-handler (flash-message/default-error-handler :change-members (text :t.actions/add-member))})
+   (let [description (text :t.actions/add-member)]
+     (post! "/api/applications/add-member"
+            {:params {:application-id application-id
+                      :member (select-keys member [:userid])}
+             :handler (flash-message/default-success-handler
+                       :change-members
+                       description
+                       (fn [_]
+                         (collapse-action-form action-form-id)
+                         (on-finished)))
+             :error-handler (flash-message/default-error-handler :change-members description)}))
    {}))
 
 (defn add-member-action-button []

--- a/src/cljs/rems/actions/approve_reject.cljs
+++ b/src/cljs/rems/actions/approve_reject.cljs
@@ -23,11 +23,12 @@
             {:params {:application-id application-id
                       :comment comment}
              :handler (flash-message/default-success-handler
+                       :top
                        description
                        (fn [_]
                          (collapse-action-form action-form-id)
                          (on-finished)))
-             :error-handler (flash-message/default-error-handler description)}))
+             :error-handler (flash-message/default-error-handler :top description)}))
    {}))
 
 (rf/reg-event-fx
@@ -38,11 +39,12 @@
             {:params {:application-id application-id
                       :comment comment}
              :handler (flash-message/default-success-handler
+                       :top
                        description
                        (fn [_]
                          (collapse-action-form action-form-id)
                          (on-finished)))
-             :error-handler (flash-message/default-error-handler description)}))
+             :error-handler (flash-message/default-error-handler :top description)}))
    {}))
 
 (defn approve-reject-action-button []

--- a/src/cljs/rems/actions/close.cljs
+++ b/src/cljs/rems/actions/close.cljs
@@ -23,11 +23,12 @@
             {:params {:application-id application-id
                       :comment comment}
              :handler (flash-message/default-success-handler
+                       :top
                        description
                        (fn [_]
                          (collapse-action-form action-form-id)
                          (on-finished)))
-             :error-handler (flash-message/default-error-handler description)}))
+             :error-handler (flash-message/default-error-handler :top description)}))
    {}))
 
 (defn close-action-button []

--- a/src/cljs/rems/actions/decide.cljs
+++ b/src/cljs/rems/actions/decide.cljs
@@ -24,11 +24,12 @@
                       :decision decision
                       :comment comment}
              :handler (flash-message/default-success-handler
+                       :top
                        description
                        (fn [_]
                          (collapse-action-form action-form-id)
                          (on-finished)))
-             :error-handler (flash-message/default-error-handler description)}))
+             :error-handler (flash-message/default-error-handler :top description)}))
    {}))
 
 (defn decide-action-button []

--- a/src/cljs/rems/actions/invite_member.cljs
+++ b/src/cljs/rems/actions/invite_member.cljs
@@ -35,7 +35,7 @@
             {:params {:application-id application-id
                       :member member}
              :handler (fn [_]
-                        (flash-message/show-success! :invite-member (text :t.actions/member-invited))
+                        (flash-message/show-success! :change-members (text :t.actions/member-invited))
                         (collapse-action-form action-form-id)
                         (on-finished))
              :error-handler (flash-message/default-error-handler :invite-member-errors (text :t.actions/invite-member))}))

--- a/src/cljs/rems/actions/invite_member.cljs
+++ b/src/cljs/rems/actions/invite_member.cljs
@@ -29,16 +29,19 @@
 (rf/reg-event-fx
  ::send-invite-member
  (fn [_ [_ {:keys [member application-id on-finished]}]]
-   (if-let [errors (validate-member member)]
-     (flash-message/show-error! :invite-member-errors (status-modal/format-errors errors))
-     (post! "/api/applications/invite-member"
-            {:params {:application-id application-id
-                      :member member}
-             :handler (fn [_]
-                        (flash-message/show-success! :change-members (text :t.actions/member-invited))
-                        (collapse-action-form action-form-id)
-                        (on-finished))
-             :error-handler (flash-message/default-error-handler :invite-member-errors (text :t.actions/invite-member))}))
+   (let [description (text :t.actions/invite-member)]
+     (if-let [errors (validate-member member)]
+       (flash-message/show-error! :invite-member-errors (status-modal/format-errors errors))
+       (post! "/api/applications/invite-member"
+              {:params {:application-id application-id
+                        :member member}
+               :handler (flash-message/default-success-handler
+                         :change-members
+                         description
+                         (fn [_]
+                           (collapse-action-form action-form-id)
+                           (on-finished)))
+               :error-handler (flash-message/default-error-handler :invite-member-errors description)})))
    {}))
 
 (defn invite-member-action-button []

--- a/src/cljs/rems/actions/invite_member.cljs
+++ b/src/cljs/rems/actions/invite_member.cljs
@@ -1,7 +1,7 @@
 (ns rems.actions.invite-member
   (:require [re-frame.core :as rf]
             [rems.actions.action :refer [action-button action-form-view button-wrapper collapse-action-form]]
-            [rems.atoms :as atoms]
+            [rems.flash-message :as flash-message]
             [rems.status-modal :as status-modal]
             [rems.text :refer [text]]
             [rems.util :refer [post!]]))
@@ -10,7 +10,6 @@
  ::open-form
  (fn [db _]
    (assoc db
-          ::done? false
           ::name ""
           ::email "")))
 
@@ -19,9 +18,6 @@
 
 (rf/reg-event-db ::set-email (fn [db [_ email]] (assoc db ::email email)))
 (rf/reg-sub ::email (fn [db _] (::email db)))
-
-(rf/reg-event-db ::set-done? (fn [db [_ done]] (assoc db ::done? done)))
-(rf/reg-sub ::done? (fn [db _] (::done? db)))
 
 (def ^:private action-form-id "invite-member")
 
@@ -34,15 +30,15 @@
  ::send-invite-member
  (fn [_ [_ {:keys [member application-id on-finished]}]]
    (if-let [errors (validate-member member)]
-     (status-modal/set-error! {:result {:errors errors}})
+     (flash-message/show-error! :invite-member-errors (status-modal/format-errors errors))
      (post! "/api/applications/invite-member"
             {:params {:application-id application-id
                       :member member}
              :handler (fn [_]
+                        (flash-message/show-success! :invite-member (text :t.actions/member-invited))
                         (collapse-action-form action-form-id)
-                        (rf/dispatch [::set-done? true])
                         (on-finished))
-             :error-handler status-modal/common-error-handler!}))
+             :error-handler (flash-message/default-error-handler :invite-member-errors (text :t.actions/invite-member))}))
    {}))
 
 (defn invite-member-action-button []
@@ -51,25 +47,25 @@
                   :on-click #(rf/dispatch [::open-form])}])
 
 ;; TODO refactor to common input-field ?
-(defn input-field [{:keys [id label placeholder value type on-change normalizer]}]
-  (let [normalizer (or normalizer identity)]
-    [:div.form-group.field
-     [:label {:for id} label]
-     [:input.form-control {:type type
-                           :id id
-                           :placeholder placeholder
-                           :value value
-                           :on-change on-change}]]))
+(defn input-field [{:keys [id label placeholder value type on-change]}]
+  [:div.form-group.field
+   [:label {:for id} label]
+   [:input.form-control {:type type
+                         :id id
+                         :placeholder placeholder
+                         :value value
+                         :on-change on-change}]])
 
 (defn invite-member-view
-  [{:keys [name email done? on-send]}]
+  [{:keys [name email on-send]}]
   [action-form-view action-form-id
    (text :t.actions/invite-member)
    [[button-wrapper {:id "invite-member"
                      :text (text :t.actions/invite-member)
-                      :class "btn-primary"
+                     :class "btn-primary"
                      :on-click on-send}]]
    [:div
+    [flash-message/component :invite-member-errors]
     [input-field {:id "member-name"
                   :label (text :t.actions/member-name)
                   :value name
@@ -82,15 +78,9 @@
                   :on-change #(rf/dispatch [::set-email (.. % -target -value)])}]]
    {:collapse-id "member-action-forms"}])
 
-(defn invite-member-status []
-  (when @(rf/subscribe [::done?])
-    [atoms/flash-message {:status :success
-                          :contents (text :t.actions/member-invited)}]))
-
 (defn invite-member-form [application-id on-finished]
   (let [name @(rf/subscribe [::name])
-        email @(rf/subscribe [::email])
-        done? @(rf/subscribe [::done?])]
+        email @(rf/subscribe [::email])]
     [invite-member-view {:name name
                          :email email
                          :on-send #(rf/dispatch [::send-invite-member {:application-id application-id

--- a/src/cljs/rems/actions/remark.cljs
+++ b/src/cljs/rems/actions/remark.cljs
@@ -29,11 +29,12 @@
                       :comment (::comment db)
                       :public (::public db)}
              :handler (flash-message/default-success-handler
+                       :top
                        description
                        (fn [_]
                          (collapse-action-form action-form-id)
                          (on-finished)))
-             :error-handler (flash-message/default-error-handler description)}))
+             :error-handler (flash-message/default-error-handler :top description)}))
    {}))
 
 (defn remark-action-button []

--- a/src/cljs/rems/actions/remove_member.cljs
+++ b/src/cljs/rems/actions/remove_member.cljs
@@ -33,11 +33,12 @@
                                 (select-keys member [:name :email]))
                       :comment comment}
              :handler (flash-message/default-success-handler
+                       :top
                        description
                        (fn [_]
                          (collapse-action-form collapse-id)
                          (on-finished)))
-             :error-handler (flash-message/default-error-handler description)}))
+             :error-handler (flash-message/default-error-handler :top description)}))
    {}))
 
 (defn remove-member-action-button [element-id]

--- a/src/cljs/rems/actions/remove_member.cljs
+++ b/src/cljs/rems/actions/remove_member.cljs
@@ -33,12 +33,12 @@
                                 (select-keys member [:name :email]))
                       :comment comment}
              :handler (flash-message/default-success-handler
-                       :top
+                       :change-members
                        description
                        (fn [_]
                          (collapse-action-form collapse-id)
                          (on-finished)))
-             :error-handler (flash-message/default-error-handler :top description)}))
+             :error-handler (flash-message/default-error-handler :change-members description)}))
    {}))
 
 (defn remove-member-action-button [element-id]

--- a/src/cljs/rems/actions/request_decision.cljs
+++ b/src/cljs/rems/actions/request_decision.cljs
@@ -47,11 +47,12 @@
                       :comment comment
                       :deciders (map :userid deciders)}
              :handler (flash-message/default-success-handler
+                       :top
                        description
                        (fn [_]
                          (collapse-action-form action-form-id)
                          (on-finished)))
-             :error-handler (flash-message/default-error-handler description)}))
+             :error-handler (flash-message/default-error-handler :top description)}))
    {}))
 
 (defn request-decision-action-button []

--- a/src/cljs/rems/actions/request_review.cljs
+++ b/src/cljs/rems/actions/request_review.cljs
@@ -49,11 +49,12 @@
                       :comment comment
                       :commenters (map :userid reviewers)}
              :handler (flash-message/default-success-handler
+                       :top
                        description
                        (fn [_]
                          (collapse-action-form action-form-id)
                          (on-finished)))
-             :error-handler (flash-message/default-error-handler description)}))
+             :error-handler (flash-message/default-error-handler :top description)}))
    {}))
 
 (defn request-review-action-button []

--- a/src/cljs/rems/actions/return_action.cljs
+++ b/src/cljs/rems/actions/return_action.cljs
@@ -23,11 +23,12 @@
             {:params {:application-id application-id
                       :comment comment}
              :handler (flash-message/default-success-handler
+                       :top
                        description
                        (fn [_]
                          (collapse-action-form action-form-id)
                          (on-finished)))
-             :error-handler (flash-message/default-error-handler description)}))
+             :error-handler (flash-message/default-error-handler :top description)}))
    {}))
 
 (defn return-action-button []

--- a/src/cljs/rems/actions/review.cljs
+++ b/src/cljs/rems/actions/review.cljs
@@ -23,11 +23,12 @@
             {:params {:application-id application-id
                       :comment comment}
              :handler (flash-message/default-success-handler
+                       :top
                        description
                        (fn [_]
                          (collapse-action-form action-form-id)
                          (on-finished)))
-             :error-handler (flash-message/default-error-handler description)}))
+             :error-handler (flash-message/default-error-handler :top description)}))
    {}))
 
 (defn review-action-button []

--- a/src/cljs/rems/administration/catalogue_item.cljs
+++ b/src/cljs/rems/administration/catalogue_item.cljs
@@ -90,7 +90,7 @@
       [:div
        [administration-navigator-container]
        [document-title (text :t.administration/catalogue-item)]
-       [flash-message/component]
+       [flash-message/component :top]
        (if @loading?
          [spinner/big]
          [catalogue-item-view @catalogue-item @language])])))

--- a/src/cljs/rems/administration/catalogue_items.cljs
+++ b/src/cljs/rems/administration/catalogue_items.cljs
@@ -44,8 +44,9 @@
  (fn [_ [_ item description dispatch-on-finished]]
    (put! "/api/catalogue-items/archived"
          {:params (select-keys item [:id :archived])
-          :handler (flash-message/status-update-handler description #(rf/dispatch dispatch-on-finished))
-          :error-handler (flash-message/default-error-handler description)})
+          :handler (flash-message/status-update-handler
+                    :top description #(rf/dispatch dispatch-on-finished))
+          :error-handler (flash-message/default-error-handler :top description)})
    {}))
 
 (rf/reg-event-fx
@@ -53,8 +54,9 @@
  (fn [_ [_ item description dispatch-on-finished]]
    (put! "/api/catalogue-items/enabled"
          {:params (select-keys item [:id :enabled])
-          :handler (flash-message/status-update-handler description #(rf/dispatch dispatch-on-finished))
-          :error-handler (flash-message/default-error-handler description)})
+          :handler (flash-message/status-update-handler
+                    :top description #(rf/dispatch dispatch-on-finished))
+          :error-handler (flash-message/default-error-handler :top description)})
    {}))
 
 (rf/reg-event-fx
@@ -143,7 +145,7 @@
   (into [:div
          [administration-navigator-container]
          [document-title (text :t.administration/catalogue-items)]
-         [flash-message/component]]
+         [flash-message/component :top]]
         (if @(rf/subscribe [::loading?])
           [[spinner/big]]
           [[to-create-catalogue-item]

--- a/src/cljs/rems/administration/create_catalogue_item.cljs
+++ b/src/cljs/rems/administration/create_catalogue_item.cljs
@@ -87,11 +87,12 @@
                         ;; create disabled catalogue items by default
                         (assoc :enabled false))
             :handler (flash-message/default-success-handler
+                      :top
                       description
                       (fn [response]
                         (dispatch! (str "#/administration/catalogue-items/"
                                         (:id response)))))
-            :error-handler (flash-message/default-error-handler description)}))
+            :error-handler (flash-message/default-error-handler :top description)}))
   {})
 
 (defn- edit-catalogue-item! [{:keys [db]} [_ request]]
@@ -101,10 +102,11 @@
           {:params {:id id
                     :localizations (:localizations request)}
            :handler (flash-message/default-success-handler
+                     :top
                      description
                      (fn [_]
                        (dispatch! (str "#/administration/catalogue-items/" id))))
-           :error-handler (flash-message/default-error-handler description)}))
+           :error-handler (flash-message/default-error-handler :top description)}))
   {})
 
 (rf/reg-event-fx ::create-catalogue-item create-catalogue-item!)
@@ -276,7 +278,7 @@
     [:div
      [administration-navigator-container]
      [document-title (page-title editing?)]
-     [flash-message/component]
+     [flash-message/component :top]
      [collapsible/component
       {:id "create-catalogue-item"
        :title (page-title editing?)

--- a/src/cljs/rems/administration/create_form.cljs
+++ b/src/cljs/rems/administration/create_form.cljs
@@ -183,13 +183,14 @@
        (send-verb send-url
                   {:params request
                    :handler (flash-message/default-success-handler
+                             :top
                              description
                              (fn [response]
                                (dispatch! (str "#/administration/forms/"
                                                (if edit?
                                                  (::form-id db)
                                                  (response :id))))))
-                   :error-handler (flash-message/default-error-handler description)}))
+                   :error-handler (flash-message/default-error-handler :top description)}))
      {:db (assoc db ::form-errors form-errors)})))
 
 ;;;; preview auto-scrolling
@@ -444,7 +445,7 @@
     [:div
      [administration-navigator-container]
      [document-title (page-title edit-form?)]
-     [flash-message/component]
+     [flash-message/component :top]
      (if loading-form?
        [:div [spinner/big]]
        [:div.container-fluid.editor-content

--- a/src/cljs/rems/administration/create_license.cljs
+++ b/src/cljs/rems/administration/create_license.cljs
@@ -63,8 +63,9 @@
    (let [description (text :t.administration/create-license)]
      (post! "/api/licenses/create"
             {:params request
-             :handler (flash-message/default-success-handler description #(dispatch! (str "#/administration/licenses/" (:id %))))
-             :error-handler (flash-message/default-error-handler description)}))
+             :handler (flash-message/default-success-handler
+                       :top description #(dispatch! (str "#/administration/licenses/" (:id %))))
+             :error-handler (flash-message/default-error-handler :top description)}))
    {}))
 
 (defn- save-attachment [language form-data]
@@ -200,7 +201,7 @@
     [:div
      [administration-navigator-container]
      [document-title (text :t.administration/create-license)]
-     [flash-message/component]
+     [flash-message/component :top]
      [collapsible/component
       {:id "create-license"
        :title (text :t.administration/create-license)

--- a/src/cljs/rems/administration/create_resource.cljs
+++ b/src/cljs/rems/administration/create_resource.cljs
@@ -49,8 +49,9 @@
      (post! "/api/resources/create"
             {:params request
              ;; TODO: render the catalogue items that use this resource in the error handler
-             :handler (flash-message/default-success-handler description #(dispatch! (str "#/administration/resources/" (:id %))))
-             :error-handler (flash-message/default-error-handler description)}))
+             :handler (flash-message/default-success-handler
+                       :top description #(dispatch! (str "#/administration/resources/" (:id %))))
+             :error-handler (flash-message/default-error-handler :top description)}))
    {}))
 
 ;; available licenses
@@ -126,7 +127,7 @@
     [:div
      [administration-navigator-container]
      [document-title (text :t.administration/create-resource)]
-     [flash-message/component]
+     [flash-message/component :top]
      [collapsible/component
       {:id "create-resource"
        :title (text :t.administration/create-resource)

--- a/src/cljs/rems/administration/create_workflow.cljs
+++ b/src/cljs/rems/administration/create_workflow.cljs
@@ -89,8 +89,9 @@
    (let [description (text :t.administration/create-workflow)]
      (post! "/api/workflows/create"
             {:params request
-             :handler (flash-message/default-success-handler description #(dispatch! (str "#/administration/workflows/" (:id %))))
-             :error-handler (flash-message/default-error-handler description)}))
+             :handler (flash-message/default-success-handler
+                       :top description #(dispatch! (str "#/administration/workflows/" (:id %))))
+             :error-handler (flash-message/default-error-handler :top description)}))
    {}))
 
 (rf/reg-event-fx
@@ -99,8 +100,9 @@
    (let [description (text :t.administration/edit-workflow)]
      (put! "/api/workflows/edit"
            {:params request
-            :handler (flash-message/default-success-handler description #(dispatch! (str "#/administration/workflows/" (:id request))))
-            :error-handler (flash-message/default-error-handler description)}))
+            :handler (flash-message/default-success-handler
+                      :top description #(dispatch! (str "#/administration/workflows/" (:id request))))
+            :error-handler (flash-message/default-error-handler :top description)}))
    {}))
 
 (rf/reg-event-db ::set-handlers (fn [db [_ handlers]] (assoc-in db [::form :handlers] (sort-by :userid handlers))))
@@ -208,7 +210,7 @@
     [:div
      [administration-navigator-container]
      [document-title title]
-     [flash-message/component]
+     [flash-message/component :top]
      [collapsible/component
       {:id "create-workflow"
        :title title

--- a/src/cljs/rems/administration/form.cljs
+++ b/src/cljs/rems/administration/form.cljs
@@ -42,8 +42,9 @@
             {:handler (fn [response]
                         (if (:success response)
                           (dispatch! (str "/#/administration/edit-form/" id))
-                          (flash-message/show-default-error! description (status-flags/format-update-failure response))))
-             :error-handler (flash-message/default-error-handler description)}))
+                          (flash-message/show-default-error!
+                           :top description (status-flags/format-update-failure response))))
+             :error-handler (flash-message/default-error-handler :top description)}))
    {}))
 
 (defn- back-button []
@@ -92,7 +93,7 @@
       [:div
        [administration-navigator-container]
        [document-title (text :t.administration/form)]
-       [flash-message/component]
+       [flash-message/component :top]
        (if @loading?
          [spinner/big]
          [form-view @form])])))

--- a/src/cljs/rems/administration/forms.cljs
+++ b/src/cljs/rems/administration/forms.cljs
@@ -42,8 +42,9 @@
    (put! "/api/forms/archived"
          {:params {:id (:form/id form)
                    :archived (:archived form)}
-          :handler (flash-message/status-update-handler description #(rf/dispatch dispatch-on-finished))
-          :error-handler (flash-message/default-error-handler description)})
+          :handler (flash-message/status-update-handler
+                    :top description #(rf/dispatch dispatch-on-finished))
+          :error-handler (flash-message/default-error-handler :top description)})
    {}))
 
 (rf/reg-event-fx
@@ -52,8 +53,9 @@
    (put! "/api/forms/enabled"
          {:params {:id (:form/id form)
                    :enabled (:enabled form)}
-          :handler (flash-message/status-update-handler description #(rf/dispatch dispatch-on-finished))
-          :error-handler (flash-message/default-error-handler description)})
+          :handler (flash-message/status-update-handler
+                    :top description #(rf/dispatch dispatch-on-finished))
+          :error-handler (flash-message/default-error-handler :top description)})
    {}))
 
 (rf/reg-event-fx
@@ -127,7 +129,7 @@
   (into [:div
          [administration-navigator-container]
          [document-title (text :t.administration/forms)]
-         [flash-message/component]]
+         [flash-message/component :top]]
         (if @(rf/subscribe [::loading?])
           [[spinner/big]]
           [[to-create-form]

--- a/src/cljs/rems/administration/license.cljs
+++ b/src/cljs/rems/administration/license.cljs
@@ -130,7 +130,7 @@
       [:div
        [administration-navigator-container]
        [document-title (text :t.administration/license)]
-       [flash-message/component]
+       [flash-message/component :top]
        (if @loading?
          [spinner/big]
          [license-view @license @language])])))

--- a/src/cljs/rems/administration/licenses.cljs
+++ b/src/cljs/rems/administration/licenses.cljs
@@ -40,8 +40,9 @@
  (fn [_ [_ item description dispatch-on-finished]]
    (put! "/api/licenses/archived"
          {:params (select-keys item [:id :archived])
-          :handler (flash-message/status-update-handler description #(rf/dispatch dispatch-on-finished))
-          :error-handler (flash-message/default-error-handler description)})
+          :handler (flash-message/status-update-handler
+                    :top description #(rf/dispatch dispatch-on-finished))
+          :error-handler (flash-message/default-error-handler :top description)})
    {}))
 
 (rf/reg-event-fx
@@ -49,8 +50,9 @@
  (fn [_ [_ item description dispatch-on-finished]]
    (put! "/api/licenses/enabled"
          {:params (select-keys item [:id :enabled])
-          :handler (flash-message/status-update-handler description #(rf/dispatch dispatch-on-finished))
-          :error-handler (flash-message/default-error-handler description)})
+          :handler (flash-message/status-update-handler
+                    :top description #(rf/dispatch dispatch-on-finished))
+          :error-handler (flash-message/default-error-handler :top description)})
    {}))
 
 (rf/reg-event-fx
@@ -113,7 +115,7 @@
   (into [:div
          [administration-navigator-container]
          [document-title (text :t.administration/licenses)]
-         [flash-message/component]]
+         [flash-message/component :top]]
         (if @(rf/subscribe [::loading?])
           [[spinner/big]]
           [[to-create-license]

--- a/src/cljs/rems/administration/resource.cljs
+++ b/src/cljs/rems/administration/resource.cljs
@@ -65,7 +65,7 @@
       [:div
        [administration-navigator-container]
        [document-title (text :t.administration/resource)]
-       [flash-message/component]
+       [flash-message/component :top]
        (if @loading?
          [spinner/big]
          [resource-view @resource @language])])))

--- a/src/cljs/rems/administration/resources.cljs
+++ b/src/cljs/rems/administration/resources.cljs
@@ -42,8 +42,9 @@
  (fn [_ [_ item description dispatch-on-finished]]
    (put! "/api/resources/archived"
          {:params (select-keys item [:id :archived])
-          :handler (flash-message/status-update-handler description #(rf/dispatch dispatch-on-finished))
-          :error-handler (flash-message/default-error-handler description)})
+          :handler (flash-message/status-update-handler
+                    :top description #(rf/dispatch dispatch-on-finished))
+          :error-handler (flash-message/default-error-handler :top description)})
    {}))
 
 (rf/reg-event-fx
@@ -51,8 +52,9 @@
  (fn [_ [_ item description dispatch-on-finished]]
    (put! "/api/resources/enabled"
          {:params (select-keys item [:id :enabled])
-          :handler (flash-message/status-update-handler description #(rf/dispatch dispatch-on-finished))
-          :error-handler (flash-message/default-error-handler description)})
+          :handler (flash-message/status-update-handler
+                    :top description #(rf/dispatch dispatch-on-finished))
+          :error-handler (flash-message/default-error-handler :top description)})
    {}))
 
 (rf/reg-event-fx
@@ -118,7 +120,7 @@
   (into [:div
          [administration-navigator-container]
          [document-title (text :t.administration/resources)]
-         [flash-message/component]]
+         [flash-message/component :top]]
         (if @(rf/subscribe [::loading?])
           [[spinner/big]]
           [[to-create-resource]

--- a/src/cljs/rems/administration/workflow.cljs
+++ b/src/cljs/rems/administration/workflow.cljs
@@ -81,7 +81,7 @@
       [:div
        [administration-navigator-container]
        [document-title (text :t.administration/workflow)]
-       [flash-message/component]
+       [flash-message/component :top]
        (if @loading?
          [spinner/big]
          [workflow-view @workflow @language])])))

--- a/src/cljs/rems/administration/workflows.cljs
+++ b/src/cljs/rems/administration/workflows.cljs
@@ -41,8 +41,9 @@
  (fn [_ [_ item description dispatch-on-finished]]
    (put! "/api/workflows/archived"
          {:params (select-keys item [:id :archived])
-          :handler (flash-message/status-update-handler description #(rf/dispatch dispatch-on-finished))
-          :error-handler (flash-message/default-error-handler description)})
+          :handler (flash-message/status-update-handler
+                    :top description #(rf/dispatch dispatch-on-finished))
+          :error-handler (flash-message/default-error-handler :top description)})
    {}))
 
 (rf/reg-event-fx
@@ -50,8 +51,9 @@
  (fn [_ [_ item description dispatch-on-finished]]
    (put! "/api/workflows/enabled"
          {:params (select-keys item [:id :enabled])
-          :handler (flash-message/status-update-handler description #(rf/dispatch dispatch-on-finished))
-          :error-handler (flash-message/default-error-handler description)})
+          :handler (flash-message/status-update-handler
+                    :top description #(rf/dispatch dispatch-on-finished))
+          :error-handler (flash-message/default-error-handler :top description)})
    {}))
 
 (rf/reg-event-fx
@@ -119,7 +121,7 @@
   (into [:div
          [administration-navigator-container]
          [document-title (text :t.administration/workflows)]
-         [flash-message/component]]
+         [flash-message/component :top]]
         (if @(rf/subscribe [::loading?])
           [[spinner/big]]
           [[to-create-workflow]

--- a/src/cljs/rems/application.cljs
+++ b/src/cljs/rems/application.cljs
@@ -142,10 +142,11 @@
          {:params {:application-id application-id
                    :field-values (field-values-to-api field-values)}
           :handler (flash-message/default-success-handler
+                    :top
                     description
                     (fn [_]
                       (rf/dispatch [::fetch-application application-id])))
-          :error-handler (flash-message/default-error-handler description)}))
+          :error-handler (flash-message/default-error-handler :top description)}))
 
 (rf/reg-event-fx
  ::save-application
@@ -166,10 +167,10 @@
           :handler (fn [response]
                      (cond
                        (not (:success response))
-                       (flash-message/show-default-error! description)
+                       (flash-message/show-default-error! :top description)
 
                        (not (accepted-licenses? application userid))
-                       (flash-message/show-error! (text :t.actions/licenses-not-accepted-error))
+                       (flash-message/show-error! :top (text :t.actions/licenses-not-accepted-error))
 
                        :else
                        (post! "/api/applications/submit"
@@ -178,12 +179,12 @@
                                           (if (:success response)
                                             (do
                                               (rf/dispatch [::fetch-application application-id])
-                                              (flash-message/show-default-success! description))
+                                              (flash-message/show-default-success! :top description))
                                             (do
                                               (rf/dispatch [::set-validation-errors (:errors response)])
-                                              (flash-message/show-error! [format-validation-errors application (:errors response)]))))
-                               :error-handler (flash-message/default-error-handler description)})))
-          :error-handler (flash-message/default-error-handler description)}))
+                                              (flash-message/show-error! :top [format-validation-errors application (:errors response)]))))
+                               :error-handler (flash-message/default-error-handler :top description)})))
+          :error-handler (flash-message/default-error-handler :top description)}))
 
 (rf/reg-event-fx
  ::submit-application
@@ -205,11 +206,12 @@
      (post! "/api/applications/copy-as-new"
             {:params {:application-id application-id}
              :handler (flash-message/default-success-handler
+                       :top
                        description
                        (fn [response]
                          (rf/dispatch [:rems.spa/user-triggered-navigation])
                          (dispatch! (str "/#/application/" (:application-id response)))))
-             :error-handler (flash-message/default-error-handler description)}))
+             :error-handler (flash-message/default-error-handler :top description)}))
    {}))
 
 (defn- save-attachment [{:keys [db]} [_ field-id file description]]
@@ -222,13 +224,14 @@
             ;; this ensures that the attachment is not left
             ;; dangling (with no references to it)
             :handler (flash-message/default-success-handler
+                      :top
                       description
                       (fn [response]
                         ;; no race condition here: events are handled in a FIFO manner
                         (rf/dispatch [::set-field-value field-id (str (:id response))])
                         (rf/dispatch [::set-attachment-success field-id])
                         (rf/dispatch [::save-application description])))
-            :error-handler (flash-message/default-error-handler description)})
+            :error-handler (flash-message/default-error-handler :top description)})
     {}))
 
 (rf/reg-event-fx ::save-attachment save-attachment)
@@ -691,7 +694,7 @@
    [:div.row
     [:div.col-lg-4.order-lg-last
      [:div#float-actions.mb-3
-      [flash-message/component]
+      [flash-message/component :top]
       [disabled-items-warning application]
       [actions-form application]]]
     [:div.col-lg-8

--- a/src/cljs/rems/application.cljs
+++ b/src/cljs/rems/application.cljs
@@ -678,6 +678,7 @@
      {:id "resources"
       :title (text :t.form/resources)
       :always [:div.form-items.form-group
+               [flash-message/component :change-resources]
                (into [:div.application-resources]
                      (for [resource (:application/resources application)]
                        [render-resource resource]))]

--- a/src/cljs/rems/application.cljs
+++ b/src/cljs/rems/application.cljs
@@ -7,7 +7,7 @@
             [rems.actions.accept-licenses :refer [accept-licenses-action-button]]
             [rems.actions.action :refer [action-button action-form-view action-comment action-collapse-id button-wrapper]]
             [rems.actions.add-licenses :refer [add-licenses-action-button add-licenses-form]]
-            [rems.actions.add-member :refer [add-member-action-button add-member-form add-member-status]]
+            [rems.actions.add-member :refer [add-member-action-button add-member-form]]
             [rems.actions.approve-reject :refer [approve-reject-action-button approve-reject-form]]
             [rems.actions.change-resources :refer [change-resources-action-button change-resources-form]]
             [rems.actions.close :refer [close-action-button close-form]]
@@ -577,6 +577,7 @@
       :title (text :t.applicant-info/applicants)
       :always
       (into [:div
+             [flash-message/component :change-members]
              [member-info {:element-id "applicant"
                            :attributes applicant
                            :application application
@@ -600,8 +601,6 @@
                              :group? true
                              :can-remove? can-uninvite?}])))
       :footer [:div
-               [flash-message/component :invite-member]
-               [add-member-status]
                [:div.commands
                 (when can-invite? [invite-member-action-button])
                 (when can-add? [add-member-action-button])]

--- a/src/cljs/rems/application.cljs
+++ b/src/cljs/rems/application.cljs
@@ -366,6 +366,7 @@
         :title (text :t.form/licenses)
         :always
         [:div
+         [flash-message/component :accept-licenses]
          [:p (text :t.form/must-accept-licenses)]
          (into [:div#licenses]
                (for [license licenses]

--- a/src/cljs/rems/application.cljs
+++ b/src/cljs/rems/application.cljs
@@ -12,7 +12,7 @@
             [rems.actions.change-resources :refer [change-resources-action-button change-resources-form]]
             [rems.actions.close :refer [close-action-button close-form]]
             [rems.actions.decide :refer [decide-action-button decide-form]]
-            [rems.actions.invite-member :refer [invite-member-action-button invite-member-form invite-member-status]]
+            [rems.actions.invite-member :refer [invite-member-action-button invite-member-form]]
             [rems.actions.remark :refer [remark-action-button remark-form]]
             [rems.actions.remove-member :refer [remove-member-action-button remove-member-form]]
             [rems.actions.request-decision :refer [request-decision-action-button request-decision-form]]
@@ -600,7 +600,7 @@
                              :group? true
                              :can-remove? can-uninvite?}])))
       :footer [:div
-               [invite-member-status]
+               [flash-message/component :invite-member]
                [add-member-status]
                [:div.commands
                 (when can-invite? [invite-member-action-button])

--- a/src/cljs/rems/atoms.cljs
+++ b/src/cljs/rems/atoms.cljs
@@ -51,11 +51,14 @@
 (defn flash-message
   "Displays a notification (aka flash) message.
 
+   :id - HTML element ID
    :status   - one of the alert types from Bootstrap i.e. :success, :info, :warning or :danger
    :contents - content to show inside the notification"
-  [{status :status contents :contents}]
+  [{:keys [id status contents]}]
   (when status
-    [:div#flash-message.alert {:class (str "alert-" (name status))} contents]))
+    [:div.alert {:class (str "alert-" (name status))
+                 :id id}
+     contents]))
 
 (defn readonly-checkbox
   "Displays a checkbox."

--- a/src/cljs/rems/flash_message.cljs
+++ b/src/cljs/rems/flash_message.cljs
@@ -29,11 +29,13 @@
 
 (defn show-success! [location contents]
   (rf/dispatch [::show-flash-message {:status :success
+                                      :location location
                                       :contents contents
                                       :page @(rf/subscribe [:page])}]))
 
 (defn show-error! [location contents]
   (rf/dispatch [::show-flash-message {:status :danger
+                                      :location location
                                       :contents contents
                                       :page @(rf/subscribe [:page])}]))
 
@@ -50,7 +52,8 @@
     :reagent-render
     (fn []
       (let [message @(rf/subscribe [::message])]
-        [atoms/flash-message message]))}))
+        (when (= location (:location message))
+          [atoms/flash-message message])))}))
 
 ;;; Helpers for typical messages
 

--- a/src/cljs/rems/flash_message.cljs
+++ b/src/cljs/rems/flash_message.cljs
@@ -27,17 +27,17 @@
    ;; TODO: flash the message with CSS
    {:db (assoc db ::message (assoc message :expires (+ 500 (current-time-millis))))}))
 
-(defn show-success! [contents]
+(defn show-success! [location contents]
   (rf/dispatch [::show-flash-message {:status :success
                                       :contents contents
                                       :page @(rf/subscribe [:page])}]))
 
-(defn show-error! [contents]
+(defn show-error! [location contents]
   (rf/dispatch [::show-flash-message {:status :danger
                                       :contents contents
                                       :page @(rf/subscribe [:page])}]))
 
-(defn component []
+(defn component [location]
   (reagent/create-class
    {:display-name "rems.flash-message/component"
 
@@ -54,33 +54,33 @@
 
 ;;; Helpers for typical messages
 
-(defn show-default-success! [description]
-  (show-success! [:div#status-success.flash-message-title
-                  (str description ": " (text :t.form/success))]))
+(defn show-default-success! [location description]
+  (show-success! location [:div#status-success.flash-message-title
+                           (str description ": " (text :t.form/success))]))
 
-(defn show-default-error! [description & more]
-  (show-error! (into [:<> [:div#status-failed.flash-message-title
-                           (str description ": " (text :t.form/failed))]]
-                     more)))
+(defn show-default-error! [location description & more]
+  (show-error! location (into [:<> [:div#status-failed.flash-message-title
+                                    (str description ": " (text :t.form/failed))]]
+                              more)))
 
-(defn default-success-handler [description on-success]
+(defn default-success-handler [location description on-success]
   (fn [response]
     (if (:success response)
       (do
-        (show-default-success! description)
+        (show-default-success! location description)
         (when on-success
           (on-success response)))
-      (show-default-error! description))))
+      (show-default-error! location description))))
 
-(defn status-update-handler [description on-success]
+(defn status-update-handler [location description on-success]
   (fn [response]
     (if (:success response)
       (do
-        (show-default-success! description)
+        (show-default-success! location description)
         (when on-success
           (on-success response)))
-      (show-default-error! description (status-flags/format-update-failure response)))))
+      (show-default-error! location description (status-flags/format-update-failure response)))))
 
-(defn default-error-handler [description]
+(defn default-error-handler [location description]
   (fn [response]
-    (show-default-error! description (:status-text response))))
+    (show-default-error! location description (:status-text response))))

--- a/src/cljs/rems/focus.cljs
+++ b/src/cljs/rems/focus.cljs
@@ -12,17 +12,17 @@
         (.scrollBy js/window 0 (- element-top navbar-height))))))
 
 (defn focus-element-async
-  "Focus an element when it appears. Options can include:
-    :tries -- number of times to poll, defaults to 100"
-  [selector & [options]]
-  (let [tries (get options :tries 100)]
-    (when (pos? tries)
-      (if-let [element (.querySelector js/document selector)]
-        (do
-          (.setAttribute element "tabindex" "-1")
-          ;; Focusing the element scrolls it into the viewport, but
-          ;; it can still be hidden behind the navigation menu.
-          (.focus element)
-          (scroll-below-navigation-menu element))
-        (js/setTimeout #(focus-element-async selector (assoc options :tries (dec tries)))
-                       10)))))
+  "Focus an element when it appears."
+  ([selector]
+   (focus-element-async selector 100))
+  ([selector tries]
+   (when (pos? tries)
+     (if-let [element (.querySelector js/document selector)]
+       (do
+         (.setAttribute element "tabindex" "-1")
+         ;; Focusing the element scrolls it into the viewport, but
+         ;; it can still be hidden behind the navigation menu.
+         (.focus element)
+         (scroll-below-navigation-menu element))
+       (js/setTimeout #(focus-element-async selector (dec tries))
+                      10)))))

--- a/src/cljs/rems/focus.cljs
+++ b/src/cljs/rems/focus.cljs
@@ -2,6 +2,15 @@
   "Focuses an HTML element as soon as it exists."
   (:require [rems.util :refer [visibility-ratio]]))
 
+(defn- scroll-below-navigation-menu
+  "Scrolls an element into view if it's behind the navigation menu."
+  [element]
+  (when-let [navbar (.querySelector js/document ".fixed-top")]
+    (let [navbar-height (.-height (.getBoundingClientRect navbar))
+          element-top (.-top (.getBoundingClientRect element))]
+      (when (< element-top navbar-height)
+        (.scrollBy js/window 0 (- element-top navbar-height))))))
+
 (defn focus-element-async
   "Focus an element when it appears. Options can include:
     :tries -- number of times to poll, defaults to 100"
@@ -12,10 +21,8 @@
         (do
           (.setAttribute element "tabindex" "-1")
           ;; Focusing the element scrolls it into the viewport, but
-          ;; it's hidden behind the navigation menu,
-          ;; so explicit scrolling is needed. There used to be code
-          ;; for this, but most pages perform a scroll to top
-          ;; anyway (e.g. via ::rems.spa/user-triggered-navigation).
-          (.focus element))
+          ;; it can still be hidden behind the navigation menu.
+          (.focus element)
+          (scroll-below-navigation-menu element))
         (js/setTimeout #(focus-element-async selector (assoc options :tries (dec tries)))
                        10)))))

--- a/test/cljs/rems/cljs_tests.cljs
+++ b/test/cljs/rems/cljs_tests.cljs
@@ -6,6 +6,7 @@
             rems.administration.test-create-resource
             rems.administration.test-create-workflow
             rems.administration.test-items
+            rems.flash-message
             rems.test-fields
             rems.test-table
             rems.test-util))
@@ -16,6 +17,7 @@
            'rems.administration.test-create-resource
            'rems.administration.test-create-workflow
            'rems.administration.test-items
+           'rems.flash-message
            'rems.test-fields
            'rems.test-table
            'rems.test-util)


### PR DESCRIPTION
#1580

Adds support for having flash messages at different places on the page.

# Definition of Done / Review checklist

## Reviewability
- [x] link to issue

## Documentation
- [x] update changelog if necessary
   - flash messages are still in the unreleased section, so no need to add more details
- [x] add or update docstrings for namespaces and functions

## Accessibility
- [x] conscious decision about where to move focus after an action
