### PR TITLE
rems.fields: fix texta-field autosize

### DIFF
--- a/src/cljs/rems/fields.cljs
+++ b/src/cljs/rems/fields.cljs
@@ -156,7 +156,7 @@
                                     (str (id-to-name id) "-error"))
                 :max-length max-length
                 :class (when validation "is-invalid")
-                :defaultValue value
+                :value value
                 :on-change (comp on-change event-value)}]]))
 
 (defn date-field


### PR DESCRIPTION
Komponentit uses the value and not the defaultValue to compute the
size. The defaultValue hack was introduced in PR #1070 commit
bff0d4d728f74149d1286a541f71f1bf9a9f9965 but seems unnecessary now.

fixes #1626 

# Definition of Done / Review checklist
## Reviewability
- [x] link to issue