### PR TITLE
Error messages when data fetching fails

### DIFF
--- a/src/clj/rems/css/styles.clj
+++ b/src/clj/rems/css/styles.clj
@@ -714,6 +714,10 @@
    [:#main-content.page-application {:max-width (u/px (int (* 1.5 (:magnitude content-width))))}]
    [:#float-actions {:position :sticky
                      :top "100px"}]
+   [:.reload-indicator {:position :fixed
+                        :bottom "15px"
+                        :right "15px"
+                        :z-index 1000}] ; over re-frisk devtool
 
    ;; application list
    [:.rems-table

--- a/src/cljs/rems/actions/add_licenses.cljs
+++ b/src/cljs/rems/actions/add_licenses.cljs
@@ -10,7 +10,9 @@
 (rf/reg-fx
  ::fetch-licenses
  (fn [on-success]
-   (fetch "/api/licenses" {:handler on-success})))
+   (fetch "/api/licenses"
+          {:handler on-success
+           :error-handler (flash-message/default-error-handler :top "Fetch licenses")})))
 
 (rf/reg-event-fx
  ::open-form

--- a/src/cljs/rems/actions/add_member.cljs
+++ b/src/cljs/rems/actions/add_member.cljs
@@ -12,7 +12,9 @@
 (rf/reg-fx
  ::fetch-potential-members
  (fn [on-success]
-   (fetch "/api/applications/members" {:handler on-success})))
+   (fetch "/api/applications/members"
+          {:handler on-success
+           :error-handler (flash-message/default-error-handler :top "Fetch potential members")})))
 
 (rf/reg-event-fx
  ::open-form

--- a/src/cljs/rems/actions/change_resources.cljs
+++ b/src/cljs/rems/actions/change_resources.cljs
@@ -5,7 +5,7 @@
             [rems.flash-message :as flash-message]
             [rems.spinner :as spinner]
             [rems.text :refer [text get-localized-title]]
-            [rems.util :refer [fetch post!]]))
+            [rems.util :refer [post!]]))
 
 (rf/reg-event-fx
  ::open-form

--- a/src/cljs/rems/actions/request_decision.cljs
+++ b/src/cljs/rems/actions/request_decision.cljs
@@ -10,7 +10,9 @@
 (rf/reg-fx
  ::fetch-potential-deciders
  (fn [on-success]
-   (fetch "/api/applications/deciders" {:handler on-success})))
+   (fetch "/api/applications/deciders"
+          {:handler on-success
+           :error-handler (flash-message/default-error-handler :top "Fetch potential deciders")})))
 
 (rf/reg-event-fx
  ::open-form

--- a/src/cljs/rems/actions/request_review.cljs
+++ b/src/cljs/rems/actions/request_review.cljs
@@ -11,7 +11,9 @@
 (rf/reg-fx
  ::fetch-potential-reviewers
  (fn [on-success]
-   (fetch "/api/applications/commenters" {:handler on-success})))
+   (fetch "/api/applications/commenters"
+          {:handler on-success
+           :error-handler (flash-message/default-error-handler :top "Fetch potential reviewers")})))
 
 (rf/reg-event-fx
  ::open-form

--- a/src/cljs/rems/administration/catalogue_item.cljs
+++ b/src/cljs/rems/administration/catalogue_item.cljs
@@ -19,7 +19,8 @@
 
 (defn- fetch-catalogue-item [catalogue-item-id]
   (fetch (str "/api/catalogue-items/" catalogue-item-id)
-         {:handler #(rf/dispatch [::fetch-catalogue-item-result %])}))
+         {:handler #(rf/dispatch [::fetch-catalogue-item-result %])
+          :error-handler (flash-message/default-error-handler :top "Fetch catalogue items")}))
 
 (rf/reg-fx ::fetch-catalogue-item (fn [[catalogue-item-id]] (fetch-catalogue-item catalogue-item-id)))
 

--- a/src/cljs/rems/administration/catalogue_items.cljs
+++ b/src/cljs/rems/administration/catalogue_items.cljs
@@ -21,7 +21,7 @@
  ::fetch-catalogue
  (fn [{:keys [db]}]
    (let [description (text :t.administration/catalogue-items)]
-     (fetch "/api/catalogue-items/"
+     (fetch "/api/catalogue-items"
             {:url-params {:expand :names
                           :disabled true
                           :expired (::display-old? db)

--- a/src/cljs/rems/administration/create_catalogue_item.cljs
+++ b/src/cljs/rems/administration/create_catalogue_item.cljs
@@ -113,7 +113,9 @@
 (rf/reg-event-fx ::edit-catalogue-item edit-catalogue-item!)
 
 (defn- fetch-workflows []
-  (fetch "/api/workflows" {:handler #(rf/dispatch [::fetch-workflows-result %])}))
+  (fetch "/api/workflows"
+         {:handler #(rf/dispatch [::fetch-workflows-result %])
+          :error-handler (flash-message/default-error-handler :top "Fetch workflows")}))
 
 (rf/reg-fx ::fetch-workflows fetch-workflows)
 
@@ -126,7 +128,9 @@
 (rf/reg-sub ::workflows (fn [db _] (::workflows db)))
 
 (defn- fetch-resources []
-  (fetch "/api/resources" {:handler #(rf/dispatch [::fetch-resources-result %])}))
+  (fetch "/api/resources"
+         {:handler #(rf/dispatch [::fetch-resources-result %])
+          :error-handler (flash-message/default-error-handler :top "Fetch resources")}))
 
 (rf/reg-fx ::fetch-resources fetch-resources)
 
@@ -140,7 +144,9 @@
 
 
 (defn- fetch-forms []
-  (fetch "/api/forms" {:handler #(rf/dispatch [::fetch-forms-result %])}))
+  (fetch "/api/forms"
+         {:handler #(rf/dispatch [::fetch-forms-result %])
+          :error-handler (flash-message/default-error-handler :top "Fetch forms")}))
 
 (rf/reg-fx ::fetch-forms fetch-forms)
 
@@ -155,7 +161,8 @@
 
 (defn- fetch-catalogue-item [id]
   (fetch (str "/api/catalogue-items/" id)
-         {:handler #(rf/dispatch [::fetch-catalogue-item-result %])}))
+         {:handler #(rf/dispatch [::fetch-catalogue-item-result %])
+          :error-handler (flash-message/default-error-handler :top "Fetch catalogue item")}))
 
 (rf/reg-fx
  ::fetch-catalogue-item

--- a/src/cljs/rems/administration/create_form.cljs
+++ b/src/cljs/rems/administration/create_form.cljs
@@ -28,7 +28,8 @@
  (fn [{:keys [db]} [_ form-id]]
    (when form-id
      (fetch (str "/api/forms/" form-id)
-            {:handler #(rf/dispatch [::fetch-form-result %])})
+            {:handler #(rf/dispatch [::fetch-form-result %])
+             :error-handler (flash-message/default-error-handler :top "Fetch form")})
      {:db (assoc db ::loading-form? true)})))
 
 (rf/reg-event-db

--- a/src/cljs/rems/administration/create_form.cljs
+++ b/src/cljs/rems/administration/create_form.cljs
@@ -448,7 +448,7 @@
      [flash-message/component :top]
      (if loading-form?
        [:div [spinner/big]]
-       [:div.container-fluid.editor-content
+       [:div.container-fluid
         [validation-errors-summary]
         [:div.row
          [:div.col-lg

--- a/src/cljs/rems/administration/create_license.cljs
+++ b/src/cljs/rems/administration/create_license.cljs
@@ -72,7 +72,8 @@
   (post! "/api/licenses/add_attachment"
          {:body form-data
           :handler (fn [response]
-                     (rf/dispatch [::attachment-saved language (:id response)]))}))
+                     (rf/dispatch [::attachment-saved language (:id response)]))
+          :error-handler (flash-message/default-error-handler :top "Save attachment")}))
 
 (rf/reg-event-db
  ::attachment-saved
@@ -82,7 +83,8 @@
 (defn- remove-attachment [attachment-id]
   (post! "/api/licenses/remove_attachment"
          {:url-params {:attachment-id attachment-id}
-          :body {}}))
+          :body {}
+          :error-handler (flash-message/default-error-handler :top "Remove attachment")}))
 
 (rf/reg-event-fx
  ::save-attachment

--- a/src/cljs/rems/administration/create_resource.cljs
+++ b/src/cljs/rems/administration/create_resource.cljs
@@ -59,7 +59,8 @@
 (defn- fetch-licenses []
   (fetch "/api/licenses"
          {:url-params {:active true}
-          :handler #(rf/dispatch [::fetch-licenses-result %])}))
+          :handler #(rf/dispatch [::fetch-licenses-result %])
+          :error-handler (flash-message/default-error-handler :top "Fetch licenses")}))
 
 (rf/reg-fx ::fetch-licenses (fn [_] (fetch-licenses)))
 

--- a/src/cljs/rems/administration/create_workflow.cljs
+++ b/src/cljs/rems/administration/create_workflow.cljs
@@ -39,7 +39,8 @@
  (fn [workflow-id]
    (when workflow-id
      (fetch (str "/api/workflows/" workflow-id)
-            {:handler #(rf/dispatch [::fetch-workflow-result %])}))))
+            {:handler #(rf/dispatch [::fetch-workflow-result %])
+             :error-handler (flash-message/default-error-handler :top "Fetch workflow")}))))
 
 (rf/reg-event-db
  ::fetch-workflow-result
@@ -108,7 +109,9 @@
 (rf/reg-event-db ::set-handlers (fn [db [_ handlers]] (assoc-in db [::form :handlers] (sort-by :userid handlers))))
 
 (defn- fetch-actors []
-  (fetch "/api/workflows/actors" {:handler #(rf/dispatch [::fetch-actors-result %])}))
+  (fetch "/api/workflows/actors"
+         {:handler #(rf/dispatch [::fetch-actors-result %])
+          :error-handler (flash-message/default-error-handler :top "Fetch actors")}))
 
 (rf/reg-fx ::fetch-actors fetch-actors)
 

--- a/src/cljs/rems/administration/form.cljs
+++ b/src/cljs/rems/administration/form.cljs
@@ -20,7 +20,8 @@
 
 (defn- fetch-form [form-id]
   (fetch (str "/api/forms/" form-id)
-         {:handler #(rf/dispatch [::fetch-form-result %])}))
+         {:handler #(rf/dispatch [::fetch-form-result %])
+          :error-handler (flash-message/default-error-handler :top "Fetch form")}))
 
 (rf/reg-fx ::fetch-form (fn [[form-id]] (fetch-form form-id)))
 

--- a/src/cljs/rems/administration/forms.cljs
+++ b/src/cljs/rems/administration/forms.cljs
@@ -21,7 +21,7 @@
  ::fetch-forms
  (fn [db]
    (let [description (text :t.administration/forms)]
-     (fetch "/api/forms/"
+     (fetch "/api/forms"
             {:url-params {:disabled true
                           :expired (::display-old? db)
                           :archived (::display-old? db)}

--- a/src/cljs/rems/administration/license.cljs
+++ b/src/cljs/rems/administration/license.cljs
@@ -19,7 +19,8 @@
 
 (defn- fetch-license [license-id]
   (fetch (str "/api/licenses/" license-id)
-         {:handler #(rf/dispatch [::fetch-license-result %])}))
+         {:handler #(rf/dispatch [::fetch-license-result %])
+          :error-handler (flash-message/default-error-handler :top "Fetch license")}))
 
 (rf/reg-fx ::fetch-license (fn [[license-id]] (fetch-license license-id)))
 

--- a/src/cljs/rems/administration/licenses.cljs
+++ b/src/cljs/rems/administration/licenses.cljs
@@ -20,7 +20,7 @@
  ::fetch-licenses
  (fn [db]
    (let [description (text :t.administration/licenses)]
-     (fetch "/api/licenses/"
+     (fetch "/api/licenses"
             {:url-params {:disabled true
                           :expired (::display-old? db)
                           :archived (::display-old? db)}

--- a/src/cljs/rems/administration/resource.cljs
+++ b/src/cljs/rems/administration/resource.cljs
@@ -20,7 +20,8 @@
 
 (defn- fetch-resource [resource-id]
   (fetch (str "/api/resources/" resource-id)
-         {:handler #(rf/dispatch [::fetch-resource-result %])}))
+         {:handler #(rf/dispatch [::fetch-resource-result %])
+          :error-handler (flash-message/default-error-handler :top "Fetch resource")}))
 
 (rf/reg-fx ::fetch-resource (fn [[resource-id]] (fetch-resource resource-id)))
 

--- a/src/cljs/rems/administration/workflow.cljs
+++ b/src/cljs/rems/administration/workflow.cljs
@@ -21,7 +21,8 @@
 
 (defn- fetch-workflow [workflow-id]
   (fetch (str "/api/workflows/" workflow-id)
-         {:handler #(rf/dispatch [::fetch-workflow-result %])}))
+         {:handler #(rf/dispatch [::fetch-workflow-result %])
+          :error-handler (flash-message/default-error-handler :top "Fetch workflow")}))
 
 (rf/reg-fx ::fetch-workflow (fn [[workflow-id]] (fetch-workflow workflow-id)))
 

--- a/src/cljs/rems/administration/workflows.cljs
+++ b/src/cljs/rems/administration/workflows.cljs
@@ -21,11 +21,12 @@
  ::fetch-workflows
  (fn [db]
    (let [description (text :t.administration/workflows)]
-     (fetch "/api/workflows/" {:url-params {:disabled true
-                                            :archived (::display-old? db)
-                                            :expired (::display-old? db)}
-                               :handler #(rf/dispatch [::fetch-workflows-result %])
-                               :error-handler (flash-message/default-error-handler :top description)}))
+     (fetch "/api/workflows"
+            {:url-params {:disabled true
+                          :archived (::display-old? db)
+                          :expired (::display-old? db)}
+             :handler #(rf/dispatch [::fetch-workflows-result %])
+             :error-handler (flash-message/default-error-handler :top description)}))
    (assoc db ::loading? true)))
 
 (rf/reg-event-db

--- a/src/cljs/rems/application.cljs
+++ b/src/cljs/rems/application.cljs
@@ -100,8 +100,8 @@
  ::fetch-application
  (fn [{:keys [db]} [_ id]]
    (fetch (str "/api/applications/" id)
-          {:handler #(rf/dispatch [::fetch-application-result {:data %}])
-           :error-handler (comp #(rf/dispatch [::fetch-application-result {:error %}])
+          {:handler #(rf/dispatch [::fetch-application-result %])
+           :error-handler (comp #(rf/dispatch [::fetch-application-result nil])
                                 (flash-message/default-error-handler :top (text :t.applications/application)))})
    {:db (assoc-in db [::application :fetching?] true)}))
 
@@ -116,10 +116,9 @@
 
 (rf/reg-event-db
  ::fetch-application-result
- (fn [db [_ result]]
+ (fn [db [_ application]]
    (let [initial-fetch? (not (:initialized? (::application db)))]
-     (cond-> (assoc db ::application {:data (:data result)
-                                      :error (:error result)
+     (cond-> (assoc db ::application {:data application
                                       :initialized? true
                                       :fetching? false})
        initial-fetch? (initialize-edit-application)))))

--- a/src/cljs/rems/application.cljs
+++ b/src/cljs/rems/application.cljs
@@ -697,11 +697,6 @@
       [flash-message/component :actions]
       [actions-form application]]]]])
 
-(defn- reload-indicator [reloading?]
-  (when reloading?
-    [:div {:style {:float :right}}
-     [spinner/small]]))
-
 ;;;; Entrypoint
 
 (defn application-page []
@@ -714,7 +709,6 @@
         attachment-success @(rf/subscribe [::attachment-success])
         userid (get-in @(rf/subscribe [:identity]) [:user :eppn])]
     [:div.container-fluid
-     [reload-indicator reloading?]
      [document-title (if application
                        (str (text :t.applications/application) " " (format-application-id config application))
                        (text :t.applications/application))]
@@ -727,7 +721,12 @@
                             :edit-application edit-application
                             :attachment-success attachment-success
                             :config config
-                            :userid userid}])]))
+                            :userid userid}])
+     ;; Located after the application to avoid re-rendering the application
+     ;; when this element is added or removed from virtual DOM.
+     (when reloading?
+       [:div.reload-indicator
+        [spinner/small]])]))
 
 ;;;; Guide
 

--- a/src/cljs/rems/application.cljs
+++ b/src/cljs/rems/application.cljs
@@ -697,6 +697,11 @@
       [flash-message/component :actions]
       [actions-form application]]]]])
 
+(defn- reload-indicator [reloading?]
+  (when reloading?
+    [:div {:style {:float :right}}
+     [spinner/small]]))
+
 ;;;; Entrypoint
 
 (defn application-page []
@@ -709,9 +714,7 @@
         attachment-success @(rf/subscribe [::attachment-success])
         userid (get-in @(rf/subscribe [:identity]) [:user :eppn])]
     [:div.container-fluid
-     (when reloading?
-       [:div {:style {:float :right}}
-        [spinner/small]])
+     [reload-indicator reloading?]
      [document-title (if application
                        (str (text :t.applications/application) " " (format-application-id config application))
                        (text :t.applications/application))]

--- a/src/cljs/rems/application.cljs
+++ b/src/cljs/rems/application.cljs
@@ -36,7 +36,7 @@
 ;;;; Helpers
 
 (defn reload! [application-id]
-  (rf/dispatch [:rems.application/reload-application-page application-id]))
+  (rf/dispatch [::fetch-application application-id]))
 
 (defn- in-processing? [application]
   (not (contains? #{:application.state/approved
@@ -84,49 +84,45 @@
 
 ;;;; State
 
-(rf/reg-sub ::application (fn [db _] (::application db)))
+(rf/reg-sub ::application-id (fn [db _] (::application-id db)))
+(rf/reg-sub ::application (fn [db [_ k]] (get-in db [::application (or k :data)])))
 (rf/reg-sub ::edit-application (fn [db _] (::edit-application db)))
 
 (rf/reg-event-fx
  ::enter-application-page
  (fn [{:keys [db]} [_ id]]
-   {:db (dissoc db ::application ::edit-application ::attachment-success)
+   {:db (-> db
+            (assoc ::application-id id)
+            (dissoc ::application ::edit-application ::attachment-success))
     :dispatch [::fetch-application id]}))
 
 (rf/reg-event-fx
  ::fetch-application
- (fn [_ [_ id]]
+ (fn [{:keys [db]} [_ id]]
    (fetch (str "/api/applications/" id)
-          {:handler #(rf/dispatch [::fetch-application-result %])})
-   {}))
+          {:handler #(rf/dispatch [::fetch-application-result {:data %}])
+           :error-handler (comp #(rf/dispatch [::fetch-application-result {:error %}])
+                                (flash-message/default-error-handler :top (text :t.applications/application)))})
+   {:db (assoc-in db [::application :fetching?] true)}))
+
+(defn- initialize-edit-application [db]
+  (let [application (get-in db [::application :data])
+        field-values (->> (get-in application [:application/form :form/fields])
+                          (map (juxt :field/id :field/value))
+                          (into {}))]
+    (assoc db ::edit-application {:field-values field-values
+                                  :show-diff {}
+                                  :validation-errors nil})))
 
 (rf/reg-event-db
  ::fetch-application-result
- (fn [db [_ application]]
-   (assoc db
-          ::application application
-          ::edit-application {:field-values (->> (get-in application [:application/form :form/fields])
-                                                 (map (juxt :field/id :field/value))
-                                                 (into {}))
-                              :show-diff {}
-                              :validation-errors nil})))
-
-(rf/reg-event-fx
- ::reload-application-page
- (fn [{:keys [db]} [_ id]]
-   {::reload-application id}))
-
-(rf/reg-fx
- ::reload-application
- (fn [id]
-   (fetch (str "/api/applications/" id)
-          {:handler #(rf/dispatch [::reload-application-result %])})))
-
-(rf/reg-event-db
- ::reload-application-result
- (fn [db [_ application]]
-   (assoc db
-          ::application application)))
+ (fn [db [_ result]]
+   (let [initial-fetch? (not (:initialized? (::application db)))]
+     (cond-> (assoc db ::application {:data (:data result)
+                                      :error (:error result)
+                                      :initialized? true
+                                      :fetching? false})
+       initial-fetch? (initialize-edit-application)))))
 
 (rf/reg-event-db
  ::set-validation-errors
@@ -151,7 +147,7 @@
 (rf/reg-event-fx
  ::save-application
  (fn [{:keys [db]} [_ description]]
-   (let [application (::application db)
+   (let [application (:data (::application db))
          edit-application (::edit-application db)]
      (save-application! description
                         (:application/id application)
@@ -189,7 +185,7 @@
 (rf/reg-event-fx
  ::submit-application
  (fn [{:keys [db]} [_ description]]
-   (let [application (::application db)
+   (let [application (:data (::application db))
          edit-application (::edit-application db)]
      (submit-application! application
                           description
@@ -201,7 +197,7 @@
 (rf/reg-event-fx
  ::copy-as-new-application
  (fn [{:keys [db]} _]
-   (let [application-id (get-in db [::application :application/id])
+   (let [application-id (get-in db [::application :data :application/id])
          description (text :t.form/copy-as-new)]
      (post! "/api/applications/copy-as-new"
             {:params {:application-id application-id}
@@ -215,7 +211,7 @@
    {}))
 
 (defn- save-attachment [{:keys [db]} [_ field-id file description]]
-  (let [application-id (get-in db [::application :application/id])]
+  (let [application-id (get-in db [::application :data :application/id])]
     (post! "/api/applications/add-attachment"
            {:url-params {:application-id application-id
                          :field-id field-id}
@@ -689,9 +685,7 @@
                 [change-resources-form application can-comment? (partial reload! application-id)]]]}]))
 
 (defn- render-application [{:keys [application edit-application attachment-success config userid]}]
-  [:div.container-fluid.editor-content
-   [document-title (str (text :t.applications/application) " " (format-application-id config application))]
-   [flash-message/component :top]
+  [:<>
    [disabled-items-warning application]
    (text :t.applications/intro)
    [:div.row
@@ -710,21 +704,32 @@
 
 (defn application-page []
   (let [config @(rf/subscribe [:rems.config/config])
+        application-id @(rf/subscribe [::application-id])
         application @(rf/subscribe [::application])
+        initialized? @(rf/subscribe [::application :initialized?])
+        fetching? @(rf/subscribe [::application :fetching?])
+        loading? (and fetching? (not initialized?))
+        reloading? (and fetching? initialized?)
         edit-application @(rf/subscribe [::edit-application])
         attachment-success @(rf/subscribe [::attachment-success])
-        userid (get-in @(rf/subscribe [:identity]) [:user :eppn])
-        loading? (not application)]
-    (if loading?
-      [:div
-       [document-title (text :t.applications/application)]
-       [spinner/big]]
-      [render-application {:application application
-                           :edit-application edit-application
-                           :attachment-success attachment-success
-                           :config config
-                           :userid userid}])))
-
+        userid (get-in @(rf/subscribe [:identity]) [:user :eppn])]
+    [:div.container-fluid
+     {:key application-id} ; re-render to clear flash messages when navigating to another application
+     (when reloading?
+       [:div {:style {:float :right}}
+        [spinner/small]])
+     [document-title (if application
+                       (str (text :t.applications/application) " " (format-application-id config application))
+                       (text :t.applications/application))]
+     [flash-message/component :top]
+     (when loading?
+       [spinner/big])
+     (when application
+       [render-application {:application application
+                            :edit-application edit-application
+                            :attachment-success attachment-success
+                            :config config
+                            :userid userid}])]))
 
 ;;;; Guide
 

--- a/src/cljs/rems/application.cljs
+++ b/src/cljs/rems/application.cljs
@@ -709,13 +709,13 @@
         attachment-success @(rf/subscribe [::attachment-success])
         userid (get-in @(rf/subscribe [:identity]) [:user :eppn])]
     [:div.container-fluid
-     {:key application-id} ; re-render to clear flash messages when navigating to another application
      (when reloading?
        [:div {:style {:float :right}}
         [spinner/small]])
      [document-title (if application
                        (str (text :t.applications/application) " " (format-application-id config application))
                        (text :t.applications/application))]
+     ^{:key application-id} ; re-render to clear flash messages when navigating to another application
      [flash-message/component :top]
      (when loading?
        [spinner/big])

--- a/src/cljs/rems/catalogue.cljs
+++ b/src/cljs/rems/catalogue.cljs
@@ -31,6 +31,7 @@
 (rf/reg-event-fx
  ::fetch-catalogue
  (fn [{:keys [db]} _]
+   ;; TODO: better error handler, don't show spinner if request has failed
    (fetch "/api/catalogue"
           {:handler #(rf/dispatch [::fetch-catalogue-result %])
            :error-handler (flash-message/default-error-handler :top "Fetch catalogue")})
@@ -61,6 +62,7 @@
 (rf/reg-event-fx
  ::fetch-drafts
  (fn [{:keys [db]} _]
+   ;; TODO: better error handler, don't show spinner if request has failed
    (fetch "/api/my-applications"
           {:handler #(rf/dispatch [::fetch-drafts-result %])
            :error-handler (flash-message/default-error-handler :top "Fetch drafts")})

--- a/src/cljs/rems/catalogue.cljs
+++ b/src/cljs/rems/catalogue.cljs
@@ -32,7 +32,8 @@
  ::fetch-catalogue
  (fn [{:keys [db]} _]
    (fetch "/api/catalogue"
-          {:handler #(rf/dispatch [::fetch-catalogue-result %])})
+          {:handler #(rf/dispatch [::fetch-catalogue-result %])
+           :error-handler (flash-message/default-error-handler :top "Fetch catalogue")})
    {:db (assoc db ::loading-catalogue? true)}))
 
 (rf/reg-event-db
@@ -61,7 +62,8 @@
  ::fetch-drafts
  (fn [{:keys [db]} _]
    (fetch "/api/my-applications"
-          {:handler #(rf/dispatch [::fetch-drafts-result %])})
+          {:handler #(rf/dispatch [::fetch-drafts-result %])
+           :error-handler (flash-message/default-error-handler :top "Fetch drafts")})
    {:db (assoc db ::loading-drafts? true)}))
 
 (rf/reg-event-db

--- a/src/cljs/rems/config.cljs
+++ b/src/cljs/rems/config.cljs
@@ -1,13 +1,15 @@
 (ns rems.config
   (:require [re-frame.core :as rf]
+            [rems.flash-message :as flash-message]
             [rems.util :refer [fetch]]))
 
 (rf/reg-event-db
  ::loaded-config
  (fn [db [_ config]]
-   (assoc db :config config
-             :default-language (get config :default-language)
-             :languages (get config :languages))))
+   (assoc db
+          :config config
+          :default-language (get config :default-language)
+          :languages (get config :languages))))
 
 (rf/reg-sub
  ::config
@@ -15,7 +17,9 @@
    (:config db)))
 
 (defn fetch-config! []
-  (fetch "/api/config" {:handler #(rf/dispatch [::loaded-config %])}))
+  (fetch "/api/config"
+         {:handler #(rf/dispatch [::loaded-config %])
+          :error-handler (flash-message/default-error-handler :top "Fetch config")}))
 
 (defn dev-environment? []
   (let [config @(rf/subscribe [::config])]

--- a/src/cljs/rems/fetcher.cljs
+++ b/src/cljs/rems/fetcher.cljs
@@ -1,0 +1,27 @@
+(ns rems.fetcher
+  "Helper functions for tracking the state of a data fetch request.
+
+  The state map will contain the following keys:
+    :data - the data which was fetched (nil if error or not fetched)
+    :fetching? - whether a fetch is in progress
+    :initialized? - whether at least one fetch has finished
+    :loading? - whether the first fetch is in progress
+    :reloading? - whether a subsequent fetch is in progress")
+
+(defn- update-derived-state [state]
+  (let [{:keys [initialized? fetching?]} state]
+    (assoc state
+           :loading? (and fetching? (not initialized?))
+           :reloading? (and fetching? initialized?))))
+
+(defn started [state]
+  (-> state
+      (assoc :fetching? true)
+      update-derived-state))
+
+(defn finished [state data]
+  (-> state
+      (assoc :data data
+             :initialized? true
+             :fetching? false)
+      update-derived-state))

--- a/src/cljs/rems/flash_message.cljs
+++ b/src/cljs/rems/flash_message.cljs
@@ -112,7 +112,8 @@
         (show-default-success! location description)
         (when on-success
           (on-success response)))
-      (show-default-error! location description (format-response-error response)))))
+      (show-default-error! location description (format-response-error response)))
+    response))
 
 (defn status-update-handler [location description on-success]
   (fn [response]
@@ -121,8 +122,10 @@
         (show-default-success! location description)
         (when on-success
           (on-success response)))
-      (show-default-error! location description (status-flags/format-update-failure response)))))
+      (show-default-error! location description (status-flags/format-update-failure response)))
+    response))
 
 (defn default-error-handler [location description]
   (fn [response]
-    (show-default-error! location description (format-response-error response))))
+    (show-default-error! location description (format-response-error response))
+    response))

--- a/src/cljs/rems/spa.cljs
+++ b/src/cljs/rems/spa.cljs
@@ -423,10 +423,14 @@
 ;; Initialize app
 
 (defn fetch-translations! []
-  (fetch "/api/translations" {:handler #(rf/dispatch [:loaded-translations %])}))
+  (fetch "/api/translations"
+         {:handler #(rf/dispatch [:loaded-translations %])
+          :error-handler (flash-message/default-error-handler :top "Fetch translations")}))
 
 (defn fetch-theme! []
-  (fetch "/api/theme" {:handler #(rf/dispatch [:loaded-theme %])}))
+  (fetch "/api/theme"
+         {:handler #(rf/dispatch [:loaded-theme %])
+          :error-handler (flash-message/default-error-handler :top "Fetch theme")}))
 
 (defn mount-components []
   (rf/clear-subscription-cache!)


### PR DESCRIPTION
Closes #1637

Adds proper error handling and HTTP request lifecycle management to the application page. The code is currently specific to the application page and has duplication with application search, but could maybe be extracted to be a reusable data fetcher.

Also adds minimal error handlers everywhere else where they were missing. The messages are not localized because hopefully users don't see them often.

The error message when an application doesn't exist:
![Application_-_REMS](https://user-images.githubusercontent.com/42678/65241849-4f0f0700-daed-11e9-9cb4-2a884b00021a.png)


# Definition of Done / Review checklist

## Reviewability
- [x] link to issue
- [x] consider adding screenshots for ease of review

## Documentation
- [x] add or update docstrings for namespaces and functions
