### PR TITLE
Print styles for application page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,7 @@ Changes since v2.4
 ### Fixes
 - Entitlement API
 - Search on the catalogue and admin pages did not support multiple search terms (#1541)
+- Printing application pages now works (except for drafts) (#1643)
 
 ## v2.5 "Maarintie" 2019-07-18
 

--- a/src/clj/rems/css/styles.clj
+++ b/src/clj/rems/css/styles.clj
@@ -768,8 +768,16 @@
     [:body {:display :block}]
 
     ;; hide some unnecessary elements
-    [:.fixed-top {:display :none}])
+    ;; TODO: consider a hide-print class?
+    [:.fixed-top {:display :none}]
+    [:#actions {:display :none}]
+    [:.commands {:display :none}]
+    [:#member-action-forms {:display :none}]
+    [:#resource-action-forms {:display :none}]
 
+    ;; open "show more" drawers
+    [".collapse:not(.show)" {:display :block}]
+    [:.collapse-toggle.collapse {:display :none}])
 
    ;; These must be last as the parsing fails when the first non-standard element is met
    (generate-form-placeholder-styles)))

--- a/src/clj/rems/css/styles.clj
+++ b/src/clj/rems/css/styles.clj
@@ -774,6 +774,7 @@
     [:.commands {:display :none}]
     [:#member-action-forms {:display :none}]
     [:#resource-action-forms {:display :none}]
+    [:.flash-message {:display :none}]
 
     ;; open "show more" drawers
     [".collapse:not(.show)" {:display :block}]

--- a/src/clj/rems/css/styles.clj
+++ b/src/clj/rems/css/styles.clj
@@ -754,6 +754,19 @@
 
    (generate-phase-styles)
    [(s/descendant :.document :h3) {:margin-top (u/rem 4)}]
+
+   ;; print styling
+   (stylesheet/at-media
+    {:print true}
+    ;; workaround for firefox only printing one page of flex elements
+    ;; https://github.com/twbs/bootstrap/issues/23489
+    ;; https://bugzilla.mozilla.org/show_bug.cgi?id=939897
+    [:.row {:display :block}]
+    [:#app {:display :block}]
+    [(s/> :#app :div) {:display :block}]
+    [:#main-content {:display :block}]
+    [:body {:display :block}])
+
    ;; These must be last as the parsing fails when the first non-standard element is met
    (generate-form-placeholder-styles)))
 

--- a/src/clj/rems/css/styles.clj
+++ b/src/clj/rems/css/styles.clj
@@ -765,7 +765,11 @@
     [:#app {:display :block}]
     [(s/> :#app :div) {:display :block}]
     [:#main-content {:display :block}]
-    [:body {:display :block}])
+    [:body {:display :block}]
+
+    ;; hide some unnecessary elements
+    [:.fixed-top {:display :none}])
+
 
    ;; These must be last as the parsing fails when the first non-standard element is met
    (generate-form-placeholder-styles)))


### PR DESCRIPTION
With these styles, the application page prints nicely in firefox & chrome. Since the changes are small, I decided to go with the existing page and CSS. An alternative would have been a fresh print.css, or a separate printable application page with less styling and no interactions.

The main caveat is that large (>1 page) textareas don't get printed nicely. Luckily we don't use textarea for readonly applicaitons, so this problem affects only drafts.

For #1643.

# Definition of Done / Review checklist

## Reviewability
- [x] link to issue
- ~note if PR is on top of other PR~
- ~note if related change in rems-deploy repo~
- [x] consider adding screenshots for ease of review

## API
- ~API is documented and shows up in Swagger UI~
- ~API is backwards compatible or completely new~
- ~Events are backwards compatible~

## Documentation
- [x] update changelog if necessary
- ~add or update docstrings for namespaces and functions~
- ~components are added to guide page~
- ~documentation _at least_ for config options (i.e. docs folder)~
- ~ADR for major architectural decisions or experiments~

## Different installations
- ~new configuration options added to rems-deploy repository~
- ~instance specific translations (i.e. LBR kielivara)~

## Testing
- ~complex logic is unit tested~
- [ ] valuable features are integration / browser / acceptance tested automatically

## Accessibility
- ~all icons have the aria-label attribute~
- ~all fields have a label~
- ~errors are linked to fields with aria-describedby~
- ~contrast is checked~
- ~conscious decision about where to move focus after an action~

## Follow-up
- ~new tasks are created for pending or remaining tasks~
- ~no critical TODOs left to implement~
