### PR TITLE
Fix user settings randomly not being loaded

### DIFF
--- a/src/clj/rems/api/user_settings.clj
+++ b/src/clj/rems/api/user_settings.clj
@@ -2,7 +2,7 @@
   (:require [compojure.api.sweet :refer :all]
             [rems.api.schema :refer :all]
             [rems.db.user-settings :as user-settings]
-            [rems.util :refer [getx-user-id]]
+            [rems.util :refer [getx-user-id get-user-id]]
             [ring.util.http-response :refer :all]
             [schema.core :as s]))
 
@@ -15,9 +15,8 @@
 
     (GET "/" []
       :summary "Get user settings"
-      :roles #{:logged-in}
       :return UserSettings
-      (ok (user-settings/get-user-settings (getx-user-id))))
+      (ok (user-settings/get-user-settings (get-user-id))))
 
     (PUT "/" []
       :summary "Update user settings"

--- a/src/clj/rems/db/user_settings.clj
+++ b/src/clj/rems/db/user_settings.clj
@@ -13,7 +13,8 @@
 
 (defn get-user-settings [user]
   (merge (default-settings)
-         (parse-settings (:settings (db/get-user-settings {:user user})))))
+         (when user
+           (parse-settings (:settings (db/get-user-settings {:user user}))))))
 
 (defn- validate-settings [settings]
   (let [{:keys [language]} settings]

--- a/src/cljs/rems/spa.cljs
+++ b/src/cljs/rems/spa.cljs
@@ -154,7 +154,6 @@
 (defn home-page []
   (if @(rf/subscribe [:user])
     (do
-      (fetch-user-settings!)
       ;; TODO: separate :init default page that does the navigation/redirect logic, instead of using :home as the default
       (when (= "/" js/window.location.pathname)
         (navigate! "/catalogue"))
@@ -458,7 +457,8 @@
   (load-interceptors!)
   (-> (p/all [(fetch-translations!)
               (fetch-theme!)
-              (config/fetch-config!)])
+              (config/fetch-config!)
+              (fetch-user-settings!)])
       ;; all preceding code must use `rf/dispatch-sync` to avoid
       ;; the first render flashing with e.g. missing translations
       (p/finally (fn []

--- a/src/cljs/rems/user_settings.cljs
+++ b/src/cljs/rems/user_settings.cljs
@@ -72,7 +72,7 @@
 
 (defn fetch-user-settings! []
   (fetch "/api/user-settings"
-         {:handler #(rf/dispatch [:loaded-user-settings %])
+         {:handler #(rf/dispatch-sync [:loaded-user-settings %])
           :error-handler (flash-message/default-error-handler :top "Fetch user settings")}))
 
 (rf/reg-event-fx


### PR DESCRIPTION
Fixes #1664

- Fixes a race condition between loading user settings and finding out whether the user is logged in
- If user is not logged in, return defaults as the user settings

# Definition of Done / Review checklist

## Reviewability
- [x] link to issue

## API
- [x] API is backwards compatible or completely new