### PR TITLE
Improve error messages

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -23,6 +23,7 @@
                  [compojure "1.6.1"]
                  [conman "0.8.3"]
                  [cprop "0.1.14"]
+                 [funcool/promesa "4.0.0-SNAPSHOT"] ; version 3.0.0 is broken with JavaScript Promises https://github.com/funcool/promesa/issues/71
                  [garden "1.3.9"]
                  [haka-buddy "0.2.3" :exclusions [cheshire]]
                  [hiccup "1.0.5"]

--- a/src/cljc/rems/text.cljc
+++ b/src/cljc/rems/text.cljc
@@ -14,6 +14,13 @@
                     context/*tempura* (partial tr (locales/tempura-config) [lang])]
             (f))))
 
+(defn- failsafe-fallback
+  "Fallback for when loading the translations has failed."
+  [k args]
+  (pr-str (vec (if (= :t/missing k)
+                 (first args)
+                 (cons k args)))))
+
 (defn text-format
   "Return the tempura translation for a given key & format arguments"
   [k & args]
@@ -22,7 +29,7 @@
                  language (rf/subscribe [:language])]
              (tr {:dict @translations}
                  [@language]
-                 [k :t/missing]
+                 [k :t/missing (failsafe-fallback k args)]
                  (vec args)))))
 
 (defn text

--- a/src/cljs/rems/actions/accept_invitation.cljs
+++ b/src/cljs/rems/actions/accept_invitation.cljs
@@ -18,7 +18,7 @@
  ::accept-invitation
  (fn [token]
    (let [error-handler (fn [response]
-                         ((flash-message/default-error-handler :top (text :t.actions/accept-invitation))
+                         ((flash-message/default-error-handler :top [text :t.actions/accept-invitation])
                           response)
                          (navigate! "/catalogue"))]
      (post! "/api/applications/accept-invitation"
@@ -28,17 +28,17 @@
                           (cond
                             (:success response)
                             (do
-                              (flash-message/show-success! :top (text :t.actions/accept-invitation-success))
+                              (flash-message/show-success! :top [text :t.actions/accept-invitation-success])
                               (navigate! (str "/application/" (:application-id response))))
 
                             (= :already-member (:type error))
                             (do
-                              (flash-message/show-success! :top (text :t.actions/accept-invitation-already-member))
+                              (flash-message/show-success! :top [text :t.actions/accept-invitation-already-member])
                               (navigate! (str "/application/" (:application-id error))))
 
                             (= :t.actions.errors/invalid-token (:type error))
                             (do
-                              (flash-message/show-error! :top (text-format :t.actions.errors/invalid-token (:token error)))
+                              (flash-message/show-error! :top [text-format :t.actions.errors/invalid-token (:token error)])
                               (navigate! "/catalogue"))
 
                             :else (error-handler response))))

--- a/src/cljs/rems/actions/accept_licenses.cljs
+++ b/src/cljs/rems/actions/accept_licenses.cljs
@@ -8,7 +8,7 @@
 (rf/reg-event-fx
  ::send-accept-licenses
  (fn [_ [_ {:keys [application-id licenses on-finished]}]]
-   (let [description (text :t.actions/accept-licenses)]
+   (let [description [text :t.actions/accept-licenses]]
      (post! "/api/applications/accept-licenses"
             {:params {:application-id application-id
                       :accepted-licenses licenses}

--- a/src/cljs/rems/actions/add_licenses.cljs
+++ b/src/cljs/rems/actions/add_licenses.cljs
@@ -50,7 +50,7 @@
 (rf/reg-event-fx
  ::send-add-licenses
  (fn [_ [_ {:keys [application-id licenses comment on-finished]}]]
-   (let [description (text :t.actions/add-licenses)]
+   (let [description [text :t.actions/add-licenses]]
      (post! "/api/applications/add-licenses"
             {:params {:application-id application-id
                       :comment comment

--- a/src/cljs/rems/actions/add_member.cljs
+++ b/src/cljs/rems/actions/add_member.cljs
@@ -41,7 +41,7 @@
 (rf/reg-event-fx
  ::send-add-member
  (fn [_ [_ {:keys [member application-id on-finished]}]]
-   (let [description (text :t.actions/add-member)]
+   (let [description [text :t.actions/add-member]]
      (post! "/api/applications/add-member"
             {:params {:application-id application-id
                       :member (select-keys member [:userid])}

--- a/src/cljs/rems/actions/approve_reject.cljs
+++ b/src/cljs/rems/actions/approve_reject.cljs
@@ -18,7 +18,7 @@
 (rf/reg-event-fx
  ::send-approve
  (fn [_ [_ {:keys [application-id comment on-finished]}]]
-   (let [description (text :t.actions/approve)]
+   (let [description [text :t.actions/approve]]
      (post! "/api/applications/approve"
             {:params {:application-id application-id
                       :comment comment}
@@ -34,7 +34,7 @@
 (rf/reg-event-fx
  ::send-reject
  (fn [_ [_ {:keys [application-id comment on-finished]}]]
-   (let [description (text :t.actions/reject)]
+   (let [description [text :t.actions/reject]]
      (post! "/api/applications/reject"
             {:params {:application-id application-id
                       :comment comment}

--- a/src/cljs/rems/actions/change_resources.cljs
+++ b/src/cljs/rems/actions/change_resources.cljs
@@ -38,7 +38,7 @@
 (rf/reg-event-fx
  ::send-change-resources
  (fn [_ [_ {:keys [application-id resources comment on-finished]}]]
-   (let [description (text :t.actions/change-resources)]
+   (let [description [text :t.actions/change-resources]]
      (post! "/api/applications/change-resources"
             {:params (merge {:application-id application-id
                              :catalogue-item-ids (vec resources)}

--- a/src/cljs/rems/actions/close.cljs
+++ b/src/cljs/rems/actions/close.cljs
@@ -18,7 +18,7 @@
 (rf/reg-event-fx
  ::send-close
  (fn [_ [_ {:keys [application-id comment on-finished]}]]
-   (let [description (text :t.actions/close)]
+   (let [description [text :t.actions/close]]
      (post! "/api/applications/close"
             {:params {:application-id application-id
                       :comment comment}

--- a/src/cljs/rems/actions/decide.cljs
+++ b/src/cljs/rems/actions/decide.cljs
@@ -18,7 +18,7 @@
 (rf/reg-event-fx
  ::send-decide
  (fn [_ [_ {:keys [application-id comment decision on-finished]}]]
-   (let [description (text :t.actions/decide)]
+   (let [description [text :t.actions/decide]]
      (post! "/api/applications/decide"
             {:params {:application-id application-id
                       :decision decision

--- a/src/cljs/rems/actions/invite_member.cljs
+++ b/src/cljs/rems/actions/invite_member.cljs
@@ -28,7 +28,7 @@
 (rf/reg-event-fx
  ::send-invite-member
  (fn [_ [_ {:keys [member application-id on-finished]}]]
-   (let [description (text :t.actions/invite-member)]
+   (let [description [text :t.actions/invite-member]]
      (if-let [errors (validate-member member)]
        (flash-message/show-error! :invite-member-errors (flash-message/format-errors errors))
        (post! "/api/applications/invite-member"

--- a/src/cljs/rems/actions/remark.cljs
+++ b/src/cljs/rems/actions/remark.cljs
@@ -23,7 +23,7 @@
 (rf/reg-event-fx
  ::send-remark
  (fn [{:keys [db]} [_ {:keys [application-id on-finished]}]]
-   (let [description (text :t.actions/remark)]
+   (let [description [text :t.actions/remark]]
      (post! "/api/applications/remark"
             {:params {:application-id application-id
                       :comment (::comment db)

--- a/src/cljs/rems/actions/remove_member.cljs
+++ b/src/cljs/rems/actions/remove_member.cljs
@@ -23,7 +23,7 @@
 (rf/reg-event-fx
  ::remove-member
  (fn [_ [_ {:keys [collapse-id application-id member comment on-finished]}]]
-   (let [description (text :t.actions/remove-member)]
+   (let [description [text :t.actions/remove-member]]
      (post! (if (:userid member)
               "/api/applications/remove-member"
               "/api/applications/uninvite-member")

--- a/src/cljs/rems/actions/request_decision.cljs
+++ b/src/cljs/rems/actions/request_decision.cljs
@@ -43,7 +43,7 @@
 (rf/reg-event-fx
  ::send-request-decision
  (fn [_ [_ {:keys [deciders application-id comment on-finished]}]]
-   (let [description (text :t.actions/request-decision)]
+   (let [description [text :t.actions/request-decision]]
      (post! "/api/applications/request-decision"
             {:params {:application-id application-id
                       :comment comment

--- a/src/cljs/rems/actions/request_review.cljs
+++ b/src/cljs/rems/actions/request_review.cljs
@@ -45,7 +45,7 @@
 (rf/reg-event-fx
  ::send-request-review
  (fn [_ [_ {:keys [application-id reviewers comment on-finished]}]]
-   (let [description (text :t.actions/request-review)]
+   (let [description [text :t.actions/request-review]]
      (post! "/api/applications/request-comment"
             {:params {:application-id application-id
                       :comment comment

--- a/src/cljs/rems/actions/review.cljs
+++ b/src/cljs/rems/actions/review.cljs
@@ -18,7 +18,7 @@
 (rf/reg-event-fx
  ::send-review
  (fn [_ [_ {:keys [application-id comment on-finished]}]]
-   (let [description (text :t.actions/review)]
+   (let [description [text :t.actions/review]]
      (post! "/api/applications/comment"
             {:params {:application-id application-id
                       :comment comment}

--- a/src/cljs/rems/administration/catalogue_items.cljs
+++ b/src/cljs/rems/administration/catalogue_items.cljs
@@ -19,7 +19,7 @@
 (rf/reg-event-fx
  ::fetch-catalogue
  (fn [{:keys [db]}]
-   (let [description (text :t.administration/catalogue-items)]
+   (let [description [text :t.administration/catalogue-items]]
      (fetch "/api/catalogue-items"
             {:url-params {:expand :names
                           :disabled true

--- a/src/cljs/rems/administration/create_catalogue_item.cljs
+++ b/src/cljs/rems/administration/create_catalogue_item.cljs
@@ -81,7 +81,7 @@
     (text :t.administration/create-catalogue-item)))
 
 (defn- create-catalogue-item! [_ [_ request]]
-  (let [description (text :t.administration/create-catalogue-item)]
+  (let [description [text :t.administration/create-catalogue-item]]
     (post! "/api/catalogue-items/create"
            {:params (-> request
                         ;; create disabled catalogue items by default
@@ -97,7 +97,7 @@
 
 (defn- edit-catalogue-item! [{:keys [db]} [_ request]]
   (let [id (::catalogue-item-id db)
-        description (text :t.administration/edit-catalogue-item)]
+        description [text :t.administration/edit-catalogue-item]]
     (put! "/api/catalogue-items/edit"
           {:params {:id id
                     :localizations (:localizations request)}

--- a/src/cljs/rems/administration/create_form.cljs
+++ b/src/cljs/rems/administration/create_form.cljs
@@ -213,7 +213,7 @@
     (.scrollTo frame 0 position)))
 
 (defn first-partially-visible-edit-field []
-  (let [fields (array-seq (.querySelectorAll js/document "#create-form .form-field"))
+  (let [fields (array-seq (.querySelectorAll js/document "#create-form .form-field:not(.new-form-field)"))
         visible? #(<= 0 (-> % .getBoundingClientRect .-bottom))]
     (first (filter visible? fields))))
 

--- a/src/cljs/rems/administration/create_form.cljs
+++ b/src/cljs/rems/administration/create_form.cljs
@@ -179,7 +179,7 @@
          send-url (str "/api/forms/" (if edit?
                                        "edit"
                                        "create"))
-         description (page-title edit?)
+         description [page-title edit?]
          request (merge (build-request (::form db) (:languages db))
                         (when edit?
                           {:form/id (::form-id db)}))]

--- a/src/cljs/rems/administration/create_license.cljs
+++ b/src/cljs/rems/administration/create_license.cljs
@@ -60,7 +60,7 @@
 (rf/reg-event-fx
  ::create-license
  (fn [_ [_ request]]
-   (let [description (text :t.administration/create-license)]
+   (let [description [text :t.administration/create-license]]
      (post! "/api/licenses/create"
             {:params request
              :handler (flash-message/default-success-handler

--- a/src/cljs/rems/administration/create_resource.cljs
+++ b/src/cljs/rems/administration/create_resource.cljs
@@ -45,7 +45,7 @@
 (rf/reg-event-fx
  ::create-resource
  (fn [_ [_ request]]
-   (let [description (text :t.administration/save)]
+   (let [description [text :t.administration/save]]
      (post! "/api/resources/create"
             {:params request
              ;; TODO: render the catalogue items that use this resource in the error handler

--- a/src/cljs/rems/administration/create_workflow.cljs
+++ b/src/cljs/rems/administration/create_workflow.cljs
@@ -87,7 +87,7 @@
 (rf/reg-event-fx
  ::create-workflow
  (fn [_ [_ request]]
-   (let [description (text :t.administration/create-workflow)]
+   (let [description [text :t.administration/create-workflow]]
      (post! "/api/workflows/create"
             {:params request
              :handler (flash-message/default-success-handler
@@ -98,7 +98,7 @@
 (rf/reg-event-fx
  ::edit-workflow
  (fn [_ [_ request]]
-   (let [description (text :t.administration/edit-workflow)]
+   (let [description [text :t.administration/edit-workflow]]
      (put! "/api/workflows/edit"
            {:params request
             :handler (flash-message/default-success-handler

--- a/src/cljs/rems/administration/form.cljs
+++ b/src/cljs/rems/administration/form.cljs
@@ -38,7 +38,7 @@
 (rf/reg-event-fx
  ::edit-form
  (fn [_ [_ id]]
-   (let [description (text :t.administration/edit)]
+   (let [description [text :t.administration/edit]]
      (fetch (str "/api/forms/" id "/editable")
             {:handler (fn [response]
                         (if (:success response)

--- a/src/cljs/rems/administration/form.cljs
+++ b/src/cljs/rems/administration/form.cljs
@@ -44,7 +44,7 @@
                         (if (:success response)
                           (navigate! (str "/administration/edit-form/" id))
                           (flash-message/show-default-error!
-                           :top description (status-flags/format-update-failure response))))
+                           :top description [status-flags/format-update-failure response])))
              :error-handler (flash-message/default-error-handler :top description)}))
    {}))
 

--- a/src/cljs/rems/administration/forms.cljs
+++ b/src/cljs/rems/administration/forms.cljs
@@ -19,7 +19,7 @@
 (rf/reg-event-db
  ::fetch-forms
  (fn [db]
-   (let [description (text :t.administration/forms)]
+   (let [description [text :t.administration/forms]]
      (fetch "/api/forms"
             {:url-params {:disabled true
                           :expired (status-flags/display-archived? db)

--- a/src/cljs/rems/administration/licenses.cljs
+++ b/src/cljs/rems/administration/licenses.cljs
@@ -18,7 +18,7 @@
 (rf/reg-event-db
  ::fetch-licenses
  (fn [db]
-   (let [description (text :t.administration/licenses)]
+   (let [description [text :t.administration/licenses]]
      (fetch "/api/licenses"
             {:url-params {:disabled true
                           :expired (status-flags/display-archived? db)

--- a/src/cljs/rems/administration/resources.cljs
+++ b/src/cljs/rems/administration/resources.cljs
@@ -18,7 +18,7 @@
 (rf/reg-event-fx
  ::fetch-resources
  (fn [{:keys [db]}]
-   (let [description (text :t.administration/resources)]
+   (let [description [text :t.administration/resources]]
      (fetch "/api/resources"
             {:url-params {:disabled true
                           :expired (status-flags/display-archived? db)

--- a/src/cljs/rems/administration/status_flags.cljs
+++ b/src/cljs/rems/administration/status_flags.cljs
@@ -5,13 +5,13 @@
 (defn- disable-button [item on-change]
   [:button.btn.btn-secondary.button-min-width
    {:type :button
-    :on-click #(on-change (assoc item :enabled false) (text :t.administration/disable))}
+    :on-click #(on-change (assoc item :enabled false) [text :t.administration/disable])}
    (text :t.administration/disable)])
 
 (defn- enable-button [item on-change]
   [:button.btn.btn-primary.button-min-width
    {:type :button
-    :on-click #(on-change (assoc item :enabled true) (text :t.administration/enable))}
+    :on-click #(on-change (assoc item :enabled true) [text :t.administration/enable])}
    (text :t.administration/enable)])
 
 (defn enabled-toggle [item on-change]
@@ -23,13 +23,13 @@
 (defn- archive-button [item on-change]
   [:button.btn.btn-secondary.button-min-width
    {:type :button
-    :on-click #(on-change (assoc item :archived true) (text :t.administration/archive))}
+    :on-click #(on-change (assoc item :archived true) [text :t.administration/archive])}
    (text :t.administration/archive)])
 
 (defn- unarchive-button [item on-change]
   [:button.btn.btn-primary.button-min-width
    {:type :button
-    :on-click #(on-change (assoc item :archived false) (text :t.administration/unarchive))}
+    :on-click #(on-change (assoc item :archived false) [text :t.administration/unarchive])}
    (text :t.administration/unarchive)])
 
 (defn archived-toggle [item on-change]

--- a/src/cljs/rems/administration/workflows.cljs
+++ b/src/cljs/rems/administration/workflows.cljs
@@ -19,7 +19,7 @@
 (rf/reg-event-db
  ::fetch-workflows
  (fn [db]
-   (let [description (text :t.administration/workflows)]
+   (let [description [text :t.administration/workflows]]
      (fetch "/api/workflows"
             {:url-params {:disabled true
                           :archived (status-flags/display-archived? db)

--- a/src/cljs/rems/application.cljs
+++ b/src/cljs/rems/application.cljs
@@ -293,13 +293,13 @@
 (defn- save-button []
   [button-wrapper {:id "save"
                    :text (text :t.form/save)
-                   :on-click #(rf/dispatch [::save-application (text :t.form/save)])}])
+                   :on-click #(rf/dispatch [::save-application [text :t.form/save]])}])
 
 (defn- submit-button []
   [button-wrapper {:id "submit"
                    :text (text :t.form/submit)
                    :class :btn-primary
-                   :on-click #(rf/dispatch [::submit-application (text :t.form/submit)])}])
+                   :on-click #(rf/dispatch [::submit-application [text :t.form/submit]])}])
 
 (defn- copy-as-new-button []
   [button-wrapper {:id "copy-as-new"

--- a/src/cljs/rems/application.cljs
+++ b/src/cljs/rems/application.cljs
@@ -97,7 +97,7 @@
    (fetch (str "/api/applications/" id)
           {:handler #(rf/dispatch [::fetch-application-result %])
            :error-handler (comp #(rf/dispatch [::fetch-application-result nil])
-                                (flash-message/default-error-handler :top (text :t.applications/application)))})
+                                (flash-message/default-error-handler :top [text :t.applications/application]))})
    {:db (update db ::application fetcher/started)}))
 
 (defn- initialize-edit-application [db]
@@ -189,7 +189,7 @@
  ::copy-as-new-application
  (fn [{:keys [db]} _]
    (let [application-id (get-in db [::application :data :application/id])
-         description (text :t.form/copy-as-new)]
+         description [text :t.form/copy-as-new]]
      (post! "/api/applications/copy-as-new"
             {:params {:application-id application-id}
              :handler (flash-message/default-success-handler

--- a/src/cljs/rems/config.cljs
+++ b/src/cljs/rems/config.cljs
@@ -18,7 +18,7 @@
 
 (defn fetch-config! []
   (fetch "/api/config"
-         {:handler #(rf/dispatch [::loaded-config %])
+         {:handler #(rf/dispatch-sync [::loaded-config %])
           :error-handler (flash-message/default-error-handler :top "Fetch config")}))
 
 (defn dev-environment? []

--- a/src/cljs/rems/flash_message.cljs
+++ b/src/cljs/rems/flash_message.cljs
@@ -80,11 +80,11 @@
 
 (defn show-default-success! [location description]
   (show-success! location [:div#status-success.flash-message-title
-                           (str description ": " (text :t.form/success))]))
+                           description ": " (text :t.form/success)]))
 
 (defn show-default-error! [location description & more]
   (show-error! location (into [:<> [:div#status-failed.flash-message-title
-                                    (str description ": " (text :t.form/failed))]]
+                                    description ": " (text :t.form/failed)]]
                               more)))
 
 (defn format-errors [errors]

--- a/src/cljs/rems/flash_message.cljs
+++ b/src/cljs/rems/flash_message.cljs
@@ -80,11 +80,11 @@
 
 (defn show-default-success! [location description]
   (show-success! location [:div#status-success.flash-message-title
-                           description ": " (text :t.form/success)]))
+                           description ": " [text :t.form/success]]))
 
 (defn show-default-error! [location description & more]
   (show-error! location (into [:<> [:div#status-failed.flash-message-title
-                                    description ": " (text :t.form/failed)]]
+                                    description ": " [text :t.form/failed]]]
                               more)))
 
 (defn format-errors [errors]
@@ -112,7 +112,7 @@
         (show-default-success! location description)
         (when on-success
           (on-success response)))
-      (show-default-error! location description (format-response-error response)))
+      (show-default-error! location description [format-response-error response]))
     response))
 
 (defn status-update-handler [location description on-success]
@@ -122,10 +122,10 @@
         (show-default-success! location description)
         (when on-success
           (on-success response)))
-      (show-default-error! location description (status-flags/format-update-failure response)))
+      (show-default-error! location description [status-flags/format-update-failure response]))
     response))
 
 (defn default-error-handler [location description]
   (fn [response]
-    (show-default-error! location description (format-response-error response))
+    (show-default-error! location description [format-response-error response])
     response))

--- a/src/cljs/rems/new_application.cljs
+++ b/src/cljs/rems/new_application.cljs
@@ -13,7 +13,7 @@
 (rf/reg-event-fx
  ::enter-new-application-page
  (fn [{:keys [db]} [_ catalogue-item-ids]]
-   (let [description (text :t.applications/application)]
+   (let [description [text :t.applications/application]]
      (post! "/api/applications/create"
             {:params {:catalogue-item-ids catalogue-item-ids}
              :handler (fn [response]

--- a/src/cljs/rems/spa.cljs
+++ b/src/cljs/rems/spa.cljs
@@ -113,6 +113,12 @@
    {:dispatch [:set-active-page :forbidden]}))
 
 (rf/reg-event-fx
+ :not-found!
+ (fn [_ [_ current-url]]
+   (println "Received not-found from" current-url)
+   {:dispatch [:set-active-page :not-found]}))
+
+(rf/reg-event-fx
  :landing-page-redirect!
  (fn [{:keys [db]}]
    ;; do we have the roles set by set-identity already?

--- a/src/cljs/rems/spa.cljs
+++ b/src/cljs/rems/spa.cljs
@@ -441,12 +441,12 @@
 
 (defn fetch-translations! []
   (fetch "/api/translations"
-         {:handler #(rf/dispatch [:loaded-translations %])
+         {:handler #(rf/dispatch-sync [:loaded-translations %])
           :error-handler (flash-message/default-error-handler :top "Fetch translations")}))
 
 (defn fetch-theme! []
   (fetch "/api/theme"
-         {:handler #(rf/dispatch [:loaded-theme %])
+         {:handler #(rf/dispatch-sync [:loaded-theme %])
           :error-handler (flash-message/default-error-handler :top "Fetch theme")}))
 
 (defn mount-components []
@@ -459,6 +459,8 @@
   (-> (p/all [(fetch-translations!)
               (fetch-theme!)
               (config/fetch-config!)])
+      ;; all preceding code must use `rf/dispatch-sync` to avoid
+      ;; the first render flashing with e.g. missing translations
       (p/finally (fn []
                    (hook-browser-navigation!)
                    (mount-components)))))

--- a/src/cljs/rems/spa.cljs
+++ b/src/cljs/rems/spa.cljs
@@ -2,6 +2,7 @@
   (:require [accountant.core :as accountant]
             [goog.events :as events]
             [goog.history.EventType :as HistoryEventType]
+            [promesa.core :as p]
             [re-frame.core :as rf]
             [reagent.core :as r]
             [rems.actions :refer [actions-page]]
@@ -455,8 +456,9 @@
 (defn init! []
   (rf/dispatch-sync [:initialize-db])
   (load-interceptors!)
-  (fetch-translations!)
-  (fetch-theme!)
-  (config/fetch-config!)
-  (hook-browser-navigation!)
-  (mount-components))
+  (-> (p/all [(fetch-translations!)
+              (fetch-theme!)
+              (config/fetch-config!)])
+      (p/finally (fn []
+                   (hook-browser-navigation!)
+                   (mount-components)))))

--- a/src/cljs/rems/user_settings.cljs
+++ b/src/cljs/rems/user_settings.cljs
@@ -44,7 +44,6 @@
 (defn update-language [language]
   (set! (.. js/document -documentElement -lang) (name language))
   (set-language-cookie! language)
-  (rf/dispatch [:rems.flash-message/reset]) ; may have saved localized content
   (update-css language))
 
 (rf/reg-event-fx

--- a/src/cljs/rems/util.cljs
+++ b/src/cljs/rems/util.cljs
@@ -59,6 +59,9 @@
       403 (do
             (rf/dispatch [:forbidden! current-url])
             true)
+      404 (do
+            (rf/dispatch [:not-found! current-url])
+            true)
       false)))
 
 (defn- wrap-default-error-handler [handler]

--- a/src/cljs/rems/util.cljs
+++ b/src/cljs/rems/util.cljs
@@ -83,7 +83,10 @@
 
   Has sensible defaults with error handler, JSON and keywords.
 
-  Additionally calls event hooks."
+  Additionally calls event hooks.
+
+  Returns a promise, but it's okay to ignore it if you prefer using
+  the `:handler` and `:error-handler` callbacks instead."
   [url opts]
   (js/window.rems.hooks.get url (clj->js opts))
   ;; TODO: change also put! and post! to return a promise?

--- a/test/clj/rems/test_browser.clj
+++ b/test/clj/rems/test_browser.clj
@@ -240,6 +240,7 @@
 (deftest test-guide-page
   (with-postmortem *driver* {:dir reporting-dir}
     (go *driver* (str +test-url+ "guide"))
+    (wait-visible *driver* {:tag :h1 :fn/text "Component Guide"})
     ;; if there is a js exception, nothing renders, so let's check
     ;; that we have lots of examples in the dom:
     (is (< 60 (count (query-all *driver* {:class :example}))))))


### PR DESCRIPTION
Closes #1637

- show the "Not found" page if the application doesn't exist (or any other ajax request returns 404)
- resolve flash message text at render time instead of the time when the message was created, to support changing the language or translations which are not yet loaded
- if loading translations fails, show the translation key as a fallback:
![no translations](https://user-images.githubusercontent.com/42678/65966714-2da50800-e469-11e9-8bb6-1fdcef0bbd59.png)
- wait for the translations, themes and config to be loaded before the first render, to avoid a quick flash of an incomplete page


# Definition of Done / Review checklist

## Reviewability
- [x] link to issue
- [x] consider adding screenshots for ease of review
