### PR TITLE
Use GitHub Pages for /docs

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,0 +1,5 @@
+defaults:
+  - scope:
+      path: ""
+    values:
+      layout: "default"

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>REMS Documentation</title>
+</head>
+<body>
+
+<nav>
+    <a href="/">Documentation</a>
+    <a href="https://github.com/CSCfi/rems/releases">Releases</a>
+    <a href="https://github.com/CSCfi/rems/issues">Issue Tracker</a>
+    <a href="https://github.com/CSCfi/rems">Source Code</a>
+</nav>
+
+<main>{{ content }}</main>
+
+</body>
+</html>

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,6 +1,16 @@
+---
+---
+
 # Architecture decisions
 
-We use Architecture Decision Records, submitted via pull requests and stored under the [architecture](architecture) directory.
+We use Architecture Decision Records, submitted via pull requests and stored under the [architecture](https://github.com/CSCfi/rems/tree/master/docs/architecture) directory.
+
+* [001: Event and API versioning](architecture/001-event-and-api-versioning.html)
+* [002: Event side effects](architecture/002-event-side-effects.html)
+* [003: Namespaced keywords](architecture/003-namespaced-keywords.html)
+* [004: re-frame handlers](architecture/004-reframe-style.html)
+* [005: admin api](architecture/005-admin-api.html)
+* [006: Authentication using OIDC](architecture/006-authentication.html)
 
 # Diagram
 

--- a/docs/architecture/001-event-and-api-versioning.md
+++ b/docs/architecture/001-event-and-api-versioning.md
@@ -1,3 +1,6 @@
+---
+---
+
 # 001: Event and API versioning
 
 Authors: @opqdonut @Macroz @luontola @cscwooller

--- a/docs/architecture/002-event-side-effects.md
+++ b/docs/architecture/002-event-side-effects.md
@@ -1,3 +1,6 @@
+---
+---
+
 # 002: Event side effects
 
 Authors: @opqdonut @Macroz @luontola @cscwooller

--- a/docs/architecture/003-namespaced-keywords.md
+++ b/docs/architecture/003-namespaced-keywords.md
@@ -1,3 +1,6 @@
+---
+---
+
 # 003: Namespaced keywords
 
 Authors: @opqdonut @Macroz @luontola @cscwooller

--- a/docs/architecture/004-reframe-style.md
+++ b/docs/architecture/004-reframe-style.md
@@ -1,3 +1,6 @@
+---
+---
+
 # 004: re-frame handlers
 
 Authors: @hukka
@@ -10,6 +13,7 @@ The input consists of the event vector with the event name and parameters, and a
 
 **This is how re-frame suggests you should to do things:**
 
+{% raw  %}
 ```clojure
 (rf/reg-event-fx
  ::send-request-decision
@@ -28,7 +32,8 @@ The input consists of the event vector with the event name and parameters, and a
 [action-button {:id action-form-id
                 :text (text :t.actions/request-decision)
                 :on-click #(rf/dispatch [::send-request-decision])}])         ; first indirection
-```
+```       
+{% endraw  %}
 
 [The listed reasons are](https://github.com/Day8/re-frame/blob/master/docs/EffectfulHandlers.md#bad-why)
 
@@ -46,6 +51,7 @@ Furthermore we haven't used a time travelling debugger or anything else that ben
 
 **We will therefore write our handlers like this:**
 
+{% raw  %}
 ```clojure
 (rf/reg-event-fx
  ::send-request-decision
@@ -57,9 +63,11 @@ Furthermore we haven't used a time travelling debugger or anything else that ben
            :handler #(rf/dispatch [::decision-results %]})})
    {}))
 ```
+{% endraw  %}
 
 In particular we do not want to mix side-effects and effect handlers in the same flow! **Please avoid doing this mixed model** because it's even more confusing than either solution!
 
+{% raw  %}
 ```clojure
 (rf/reg-event-fx
  ::send-request-decision
@@ -67,6 +75,7 @@ In particular we do not want to mix side-effects and effect handlers in the same
    (do-another-kind-of-side-effect!)
    {:request-decision-effect [deciders application-id comment]}))
 ```
+{% endraw  %}
 
 ## Handling user interaction in components
 

--- a/docs/architecture/005-admin-api.md
+++ b/docs/architecture/005-admin-api.md
@@ -1,3 +1,6 @@
+---
+---
+
 # 005: admin api
 
 Authors: @Macroz @okahilak @opqdonut

--- a/docs/architecture/006-authentication.md
+++ b/docs/architecture/006-authentication.md
@@ -1,3 +1,6 @@
+---
+---
+
 # 006: Authentication using OIDC
 
 Authors: @hukka

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,3 +1,6 @@
+---
+---
+
 # Configuration
 
 REMS contains a number of configuration options that can be used to alter authentication options, theming or to add integration points, just to name a few.

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -1,3 +1,6 @@
+---
+---
+
 # REMS Glossary
 
 ## Core concepts

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -1,3 +1,6 @@
+---
+---
+
 # Hooks
 
 ## Extra scripts

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,3 +1,6 @@
+---
+---
+
 # Resource Entitlement Management System (REMS)
 
 REMS is an open source tool for managing access rights to resources, such as research datasets.
@@ -5,3 +8,18 @@ REMS is an open source tool for managing access rights to resources, such as res
 Applicants can use their federated user IDs to log in to REMS, fill in the data access application and agree to the dataset's terms of use. The REMS system then circulates the application to the resource owner or designated representative for approval. REMS also produces the necessary reports on the applications and the granted data access rights. 
 
 You can try out REMS using publicly available demo instance at <https://rems2demo.csc.fi>.
+
+## User Documentation
+
+* [Configuration](configuration.html)
+* [REMS Glossary](glossary.html)
+* [Hooks](hooks.html)
+* [Linking to REMS](linking.html)
+* [Releases and releasing](release.html)
+* [Search](search.html)
+* [Using the API](usingtheapi.html)
+
+## Developer Documentation
+
+* [Architecture decisions](architecture.html)
+* [Definition of Done / Review checklist](pull_request_template.html)

--- a/docs/linking.md
+++ b/docs/linking.md
@@ -1,3 +1,6 @@
+---
+---
+
 # Linking to REMS
 
 REMS supports linking users directly to application forms, pre-existing applications etc. Unauthenticated users will be redirected to a login page before being sent to the desired url. Below are listed a couple of examples on how the linking works.

--- a/docs/pull_request_template.md
+++ b/docs/pull_request_template.md
@@ -1,3 +1,6 @@
+---
+---
+
 # Definition of Done / Review checklist
 
 ## Reviewability

--- a/docs/release.md
+++ b/docs/release.md
@@ -1,3 +1,6 @@
+---
+---
+
 # Releases and releasing
 
 ## Naming

--- a/docs/search.md
+++ b/docs/search.md
@@ -1,3 +1,6 @@
+---
+---
+
 # Search
 
 ## Application Search

--- a/docs/serve.sh
+++ b/docs/serve.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+set -eux
+docker run -it --rm -v "$PWD":/usr/src/app -p "4000:4000" starefossen/github-pages

--- a/docs/usingtheapi.md
+++ b/docs/usingtheapi.md
@@ -1,3 +1,6 @@
+---
+---
+
 # Using the API
 
 These examples assume that the REMS instance you want to talk to is running locally at `localhost:3000`.


### PR DESCRIPTION
PR #1683 adds a .html file to the /docs folder, but GitHub only shows it with the text/plain content-type, so viewing it would require checking out the project. GitHub Pages is needed to support pure HTML in the docs. This PR updates the /docs folder to work with GitHub Pages/Jekyll.