### PR TITLE
Give error responses content-type text/plain

### DIFF
--- a/src/clj/rems/api.clj
+++ b/src/clj/rems/api.clj
@@ -19,28 +19,36 @@
             [rems.json :refer [muuntaja]]
             [ring.middleware.cors :refer [wrap-cors]]
             [ring.util.http-response :refer :all]
+            [ring.util.response :as response]
             [schema.core :as s])
   (:import [rems.auth ForbiddenException UnauthorizedException]
            rems.InvalidRequestException))
 
+(defn- plain-text [response]
+  (response/content-type response "text/plain"))
+
 (defn unauthorized-handler
   [exception ex-data request]
   (log/info "unauthorized" (.getMessage exception))
-  (unauthorized "unauthorized"))
+  (-> (unauthorized "unauthorized")
+      (plain-text)))
 
 (defn forbidden-handler
   [exception ex-data request]
   (log/info "forbidden" (.getMessage exception))
-  (forbidden "forbidden"))
+  (-> (forbidden "forbidden")
+      (plain-text)))
 
 (defn invalid-handler
   [exception ex-data request]
   (log/info "bad-request" (.getMessage exception))
-  (bad-request (.getMessage exception)))
+  (-> (bad-request (.getMessage exception))
+      (plain-text)))
 
 (defn debug-handler
   [exception ex-data request]
-  (internal-server-error (with-out-str (print-cause-trace exception))))
+  (-> (internal-server-error (with-out-str (print-cause-trace exception)))
+      (plain-text)))
 
 (defn with-logging
   ;; Like in compojure.api.exception, but logs some of the data (with pprint)


### PR DESCRIPTION
Otherwise Chrome shows ERR_INVALID_RESPONSE when the content-type is application/octet-stream
