### PR TITLE
Don't leak internal user attributes in API

### DIFF
--- a/src/clj/rems/api/applications.clj
+++ b/src/clj/rems/api/applications.clj
@@ -30,28 +30,17 @@
   (assoc SuccessResponse
          (s/optional-key :application-id) s/Int))
 
-(s/defschema User
-  {:userid s/Str
-   :name (s/maybe s/Str)
-   :email (s/maybe s/Str)})
-
 (s/defschema Applicant
-  {:userid s/Str
-   :name (s/maybe s/Str)
-   :email (s/maybe s/Str)})
+  UserWithAttributes)
 
 (s/defschema Commenter
-  {:userid s/Str
-   :name (s/maybe s/Str)
-   :email (s/maybe s/Str)})
+  UserWithAttributes)
 
 (s/defschema Commenters
   [Commenter])
 
 (s/defschema Decider
-  {:userid s/Str
-   :name (s/maybe s/Str)
-   :email (s/maybe s/Str)})
+  UserWithAttributes)
 
 (s/defschema Deciders
   [Decider])

--- a/src/clj/rems/api/schema.clj
+++ b/src/clj/rems/api/schema.clj
@@ -114,8 +114,8 @@
 
 (s/defschema UserWithAttributes
   {:userid UserId
-   :name s/Str
-   :email s/Str})
+   :name (s/maybe s/Str)
+   :email (s/maybe s/Str)})
 
 (s/defschema Workflow
   {:id s/Int

--- a/src/clj/rems/api/schema.clj
+++ b/src/clj/rems/api/schema.clj
@@ -195,8 +195,7 @@
    (s/optional-key :application/copied-to) [{:application/id s/Int
                                              :application/external-id s/Str}]
    :application/last-activity DateTime
-   :application/applicant s/Str
-   :application/applicant-attributes UserWithAttributes
+   :application/applicant UserWithAttributes
    :application/members #{UserWithAttributes}
    :application/invited-members #{{:name s/Str
                                    :email s/Str}}

--- a/src/clj/rems/api/schema.clj
+++ b/src/clj/rems/api/schema.clj
@@ -110,6 +110,13 @@
 
 (def UserId s/Str)
 
+(s/defschema User {:userid UserId})
+
+(s/defschema UserWithAttributes
+  {:userid UserId
+   :name s/Str
+   :email s/Str})
+
 (s/defschema Workflow
   {:id s/Int
    :organization s/Str
@@ -189,9 +196,8 @@
                                              :application/external-id s/Str}]
    :application/last-activity DateTime
    :application/applicant s/Str
-   :application/applicant-attributes {s/Keyword s/Str}
-   :application/members #{{:userid s/Str
-                           s/Keyword s/Str}}
+   :application/applicant-attributes UserWithAttributes
+   :application/members #{UserWithAttributes}
    :application/invited-members #{{:name s/Str
                                    :email s/Str}}
    :application/resources [V2Resource]

--- a/src/clj/rems/api/workflows.clj
+++ b/src/clj/rems/api/workflows.clj
@@ -1,7 +1,6 @@
 (ns rems.api.workflows
   (:require [compojure.api.sweet :refer :all]
-            [rems.api.applications :refer [User]]
-            [rems.api.schema :refer [SuccessResponse ArchivedCommand EnabledCommand UserId Workflow]]
+            [rems.api.schema :refer [SuccessResponse ArchivedCommand EnabledCommand UserId UserWithAttributes Workflow]]
             [rems.api.services.workflow :as workflow]
             [rems.api.util] ; required for route :roles
             [rems.util :refer [getx-user-id]]
@@ -25,7 +24,7 @@
    :id s/Int})
 
 ; TODO: deduplicate or decouple with /api/applications/reviewers API?
-(s/defschema AvailableActor User)
+(s/defschema AvailableActor UserWithAttributes)
 (s/defschema AvailableActors [AvailableActor])
 
 (def workflows-api

--- a/src/clj/rems/application/commands.clj
+++ b/src/clj/rems/application/commands.clj
@@ -253,7 +253,7 @@
 
 (defn- all-members [application]
   (conj (set (map :userid (:application/members application)))
-        (:application/applicant application)))
+        (:userid (:application/applicant application))))
 
 (defn already-member-error [application userid]
   (when (contains? (all-members application) userid)
@@ -460,7 +460,7 @@
 
 (defmethod command-handler :application.command/remove-member
   [cmd application _injections]
-  (or (when (= (:application/applicant application) (:userid (:member cmd)))
+  (or (when (= (:userid (:application/applicant application)) (:userid (:member cmd)))
         {:errors [{:type :cannot-remove-applicant}]})
       (when-not (contains? (all-members application) (:userid (:member cmd)))
         {:errors [{:type :user-not-member :user (:member cmd)}]})

--- a/src/clj/rems/application/model.clj
+++ b/src/clj/rems/application/model.clj
@@ -589,7 +589,8 @@
         (update :application/resources enrich-resources get-catalogue-item)
         (update :application/licenses enrich-licenses get-license)
         (update :application/events enrich-events get-user get-catalogue-item)
-        (assoc :application/applicant-attributes (get-user (:application/applicant application)))
+        ;; TODO application/applicant should be {:userid "x"} originally
+        (assoc :application/applicant (get-user (:application/applicant application)))
         (assoc :application/attachments (get-attachments-for-application (getx application :application/id)))
         (enrich-user-attributes get-user)
         (enrich-workflow-handlers get-workflow)

--- a/src/clj/rems/application/model.clj
+++ b/src/clj/rems/application/model.clj
@@ -200,7 +200,7 @@
              :application/todo nil
              :application/created (:event/time event)
              :application/modified (:event/time event)
-             :application/applicant (:event/actor event)
+             :application/applicant {:userid (:event/actor event)}
              :application/members #{}
              :application/past-members #{}
              :application/invitation-tokens {}
@@ -589,8 +589,7 @@
         (update :application/resources enrich-resources get-catalogue-item)
         (update :application/licenses enrich-licenses get-license)
         (update :application/events enrich-events get-user get-catalogue-item)
-        ;; TODO application/applicant should be {:userid "x"} originally
-        (assoc :application/applicant (get-user (:application/applicant application)))
+        (assoc :application/applicant (get-user (get-in application [:application/applicant :userid])))
         (assoc :application/attachments (get-attachments-for-application (getx application :application/id)))
         (enrich-user-attributes get-user)
         (enrich-workflow-handlers get-workflow)

--- a/src/clj/rems/application/search.clj
+++ b/src/clj/rems/application/search.clj
@@ -37,9 +37,9 @@
   {:id (->> [(:application/id app)
              (:application/external-id app)]
             (str/join " "))
-   :applicant (->> [(:application/applicant app)
+   :applicant (->> [(:userid (:application/applicant app))
                     (application-util/get-applicant-name app)
-                    (:email (:application/applicant-attributes app))]
+                    (:email (:application/applicant app))]
                    (str/join " "))
    :member (->> (:application/members app)
                 (mapcat (fn [member]

--- a/src/clj/rems/application/search.clj
+++ b/src/clj/rems/application/search.clj
@@ -39,13 +39,13 @@
             (str/join " "))
    :applicant (->> [(:application/applicant app)
                     (application-util/get-applicant-name app)
-                    (:mail (:application/applicant-attributes app))]
+                    (:email (:application/applicant-attributes app))]
                    (str/join " "))
    :member (->> (:application/members app)
                 (mapcat (fn [member]
                           [(:userid member)
                            (application-util/get-member-name member)
-                           (:mail member)]))
+                           (:email member)]))
                 (str/join " "))
    :title (:application/description app)
    :resource (->> (:application/resources app)

--- a/src/clj/rems/db/applications.clj
+++ b/src/clj/rems/db/applications.clj
@@ -55,7 +55,7 @@
     :items [catalogue-item-id]}))
 
 (defn- valid-user? [userid]
-  (not (nil? (users/get-user-attributes userid))))
+  (not (nil? (users/get-user userid))))
 
 (def ^:private command-injections
   {:valid-user? valid-user?

--- a/src/clj/rems/db/applications.clj
+++ b/src/clj/rems/db/applications.clj
@@ -91,7 +91,7 @@
    :get-form-template form/get-form-template
    :get-catalogue-item catalogue/get-localized-catalogue-item
    :get-license licenses/get-license
-   :get-user users/get-user-attributes
+   :get-user users/get-user
    :get-users-with-role users/get-users-with-role
    :get-workflow workflow/get-workflow})
 

--- a/src/clj/rems/db/applications.clj
+++ b/src/clj/rems/db/applications.clj
@@ -55,7 +55,7 @@
     :items [catalogue-item-id]}))
 
 (defn- valid-user? [userid]
-  (not (nil? (users/get-user userid))))
+  (some? (users/get-user userid)))
 
 (def ^:private command-injections
   {:valid-user? valid-user?

--- a/src/clj/rems/db/applications.clj
+++ b/src/clj/rems/db/applications.clj
@@ -54,11 +54,8 @@
    {:wfid (:wfid (catalogue/get-localized-catalogue-item catalogue-item-id))
     :items [catalogue-item-id]}))
 
-(defn- valid-user? [userid]
-  (some? (users/get-user userid)))
-
 (def ^:private command-injections
-  {:valid-user? valid-user?
+  {:valid-user? users/user-exists?
    :validate-fields form-validation/validate-fields
    :secure-token secure-token
    :get-catalogue-item catalogue/get-localized-catalogue-item

--- a/src/clj/rems/db/entitlements.clj
+++ b/src/clj/rems/db/entitlements.clj
@@ -96,7 +96,7 @@
   [application]
   (let [application-id (:application/id application)
         current-members (set (concat (map :userid (:application/members application))
-                                     [(:application/applicant application)]))
+                                     [(:userid (:application/applicant application))]))
         past-members (set (map :userid (:application/past-members application)))
         application-state (:application/state application)
         application-resources (->> application

--- a/src/clj/rems/db/users.clj
+++ b/src/clj/rems/db/users.clj
@@ -79,5 +79,5 @@
   (-> userid
       get-user-attributes
       format-user
-      ;; hack for users without attributes
+      ;; in case user attributes were not found, return at least the userid
       (assoc :userid userid)))

--- a/src/clj/rems/db/users.clj
+++ b/src/clj/rems/db/users.clj
@@ -3,8 +3,7 @@
             [rems.db.core :as db]
             [rems.json :as json]))
 
-;; XXX: Adding these attributes is not done consistently when retrieving
-;;   the data for a user.
+;; TODO could pass through additional (configurable?) attributes
 (defn format-user [u]
   {:userid (:eppn u)
    :name (:commonName u)
@@ -70,6 +69,8 @@
        (doall)))
 
 (defn get-user [userid]
-  (->> userid
-       get-user-attributes
-       format-user))
+  (-> userid
+      get-user-attributes
+      format-user
+      ;; hack for users without attributes
+      (assoc :userid userid)))

--- a/src/clj/rems/db/users.clj
+++ b/src/clj/rems/db/users.clj
@@ -71,7 +71,7 @@
        (doall)))
 
 (defn get-user
-  "Given a userid, returns a map with keys :userid, :mail and :name."
+  "Given a userid, returns a map with keys :userid, :email and :name."
   [userid]
   (-> userid
       get-user-attributes

--- a/src/clj/rems/db/users.clj
+++ b/src/clj/rems/db/users.clj
@@ -35,6 +35,9 @@
   [userid]
   (json/parse-string (:userattrs (db/get-user-attributes {:user userid}))))
 
+(defn user-exists? [userid]
+  (some? (get-user-attributes userid)))
+
 (defn- get-all-users []
   (->> (db/get-users)
        (map :userid)

--- a/src/clj/rems/db/users.clj
+++ b/src/clj/rems/db/users.clj
@@ -22,18 +22,20 @@
   (when user
     (add-user! user userattrs)))
 
-(defn get-user-attributes
+(defn- get-user-attributes
   "Takes as user id as an input and fetches user attributes that are stored in a json blob in the users table.
    Returns a structure like this:
    {:eppn \"developer\"
     :email \"developer@e.mail\"
     :displayName \"deve\"
     :surname \"loper\"
-    ...etc}"
+    ...etc}
+
+  You should use get-user instead."
   [userid]
   (json/parse-string (:userattrs (db/get-user-attributes {:user userid}))))
 
-(defn get-all-users []
+(defn- get-all-users []
   (->> (db/get-users)
        (map :userid)
        (map get-user-attributes)
@@ -68,7 +70,9 @@
        (map :userid)
        (doall)))
 
-(defn get-user [userid]
+(defn get-user
+  "Given a userid, returns a map with keys :userid, :mail and :name."
+  [userid]
   (-> userid
       get-user-attributes
       format-user

--- a/src/clj/rems/layout.clj
+++ b/src/clj/rems/layout.clj
@@ -79,7 +79,10 @@ window.rems = {
      (format "var csrfToken = '%s';" *anti-forgery-token*)]
     (include-js "/js/app.js")
     [:script {:type "text/javascript"}
-     (format "rems.app.setIdentity(%s);" (json/generate-string {:user context/*user* :roles context/*roles*}))])))
+     (format "rems.app.setIdentity(%s);"
+             (json/generate-string {:user (when context/*user*
+                                            (users/format-user context/*user*))
+                                    :roles context/*roles*}))])))
 
 (defn- error-content
   [error-details]

--- a/src/clj/rems/poller/email.clj
+++ b/src/clj/rems/poller/email.clj
@@ -39,6 +39,8 @@
    (when-not (empty? (:application/description application))
      (str ", \"" (:application/description application) "\""))))
 
+;; TODO user-for-email shouldn't need to call get-user since we add
+;; all this info to the application in rems.application.model/enrich-user-attributes
 (defn- user-for-email [user]
   (let [user-attributes (users/get-user user)]
     (or (:name user-attributes)

--- a/src/clj/rems/poller/email.clj
+++ b/src/clj/rems/poller/email.clj
@@ -52,9 +52,10 @@
 ;; There's a slight inconsistency here: we look at current members, so
 ;; a member might get an email for an event that happens before he was
 ;; added.
+;; TODO this function occurs in so many places
 (defn- applicant-and-members [application]
   (conj (map :userid (:application/members application))
-        (:application/applicant application)))
+        (:userid (:application/applicant application))))
 
 (defn- handlers [application]
   (get-in application [:application/workflow :workflow.dynamic/handlers]))
@@ -78,7 +79,7 @@
                                 (user-for-email recipient)
                                 (user-for-email (:event/actor event))
                                 (format-application-for-email application)
-                                (user-for-email (:application/applicant application))
+                                (user-for-email (:userid (:application/applicant application)))
                                 (resources-for-email application)
                                 (link-to-application (:application/id event)))
           :body (str
@@ -86,7 +87,7 @@
                               (user-for-email recipient)
                               (user-for-email (:event/actor event))
                               (format-application-for-email application)
-                              (user-for-email (:application/applicant application))
+                              (user-for-email (:userid (:application/applicant application)))
                               (resources-for-email application)
                               (link-to-application (:application/id event)))
                  (text :t.email/footer))})))))
@@ -132,7 +133,7 @@
                                 :t.email.application-closed/message-to-handler)))
 
 (defmethod event-to-emails-impl :application.event/returned [event application]
-  (concat (emails-to-recipients [(:application/applicant application)]
+  (concat (emails-to-recipients [(:userid (:application/applicant application))]
                                 event application
                                 :t.email.application-returned/subject-to-applicant
                                 :t.email.application-returned/message-to-applicant)
@@ -202,13 +203,13 @@
       [{:to (:email (:application/member event))
         :subject (text-format :t.email.member-invited/subject
                               (:name (:application/member event))
-                              (user-for-email (:application/applicant application))
+                              (user-for-email (:userid (:application/applicant application)))
                               (format-application-for-email application)
                               (invitation-link (:invitation/token event)))
         :body (str
                (text-format :t.email.member-invited/message
                             (:name (:application/member event))
-                            (user-for-email (:application/applicant application))
+                            (user-for-email (:userid (:application/applicant application)))
                             (format-application-for-email application)
                             (invitation-link (:invitation/token event)))
                (text :t.email/footer))}])))

--- a/src/clj/rems/poller/email.clj
+++ b/src/clj/rems/poller/email.clj
@@ -40,10 +40,9 @@
      (str ", \"" (:application/description application) "\""))))
 
 (defn- user-for-email [user]
-  (let [user-attributes (users/get-user-attributes user)]
-    (or (:commonName user-attributes)
-        (:eppn user-attributes)
-        user)))
+  (let [user-attributes (users/get-user user)]
+    (or (:name user-attributes)
+        (:userid user-attributes))))
 
 (defn- resources-for-email [application]
   (->> (:application/resources application)
@@ -261,8 +260,8 @@
         email (assoc email-spec
                      :from (:mail-from env)
                      :to (or (:to email-spec)
-                             (util/get-user-mail
-                              (users/get-user-attributes
+                             (:email
+                              (users/get-user
                                (:to-user email-spec)))))
         to-error (validate-address (:to email))]
     (log/info "sending email:" (pr-str email))

--- a/src/clj/rems/util.clj
+++ b/src/clj/rems/util.clj
@@ -51,18 +51,6 @@
   ([user]
    (getx user :eppn)))
 
-(defn get-username
-  ([]
-   (get-username context/*user*))
-  ([user]
-   (:commonName user)))
-
-(defn get-user-mail
-  ([]
-   (get-user-mail context/*user*))
-  ([user]
-   (:mail user)))
-
 (def conj-set (fnil conj #{}))
 
 (def conj-vec (fnil conj []))

--- a/src/cljc/rems/application_util.cljc
+++ b/src/cljc/rems/application_util.cljc
@@ -11,7 +11,7 @@
   (contains? (:application/permissions application)
              :application.command/save-draft))
 
-(def ^:private name-attribute-priority [:name :commonName :displayName :eppn])
+(def ^:private name-attribute-priority [:name :commonName :displayName :userid :eppn])
 
 (defn get-member-name [attributes]
   (when attributes

--- a/src/cljc/rems/application_util.cljc
+++ b/src/cljc/rems/application_util.cljc
@@ -20,4 +20,4 @@
          first)))
 
 (defn get-applicant-name [application]
-  (get-member-name (:application/applicant-attributes application)))
+  (get-member-name (:application/applicant application)))

--- a/src/cljc/rems/application_util.cljc
+++ b/src/cljc/rems/application_util.cljc
@@ -12,9 +12,8 @@
              :application.command/save-draft))
 
 (defn get-member-name [attributes]
-  (when attributes
-    (or (:name attributes)
-        (:userid attributes))))
+  (or (:name attributes)
+      (:userid attributes)))
 
 (defn get-applicant-name [application]
   (get-member-name (:application/applicant application)))

--- a/src/cljc/rems/application_util.cljc
+++ b/src/cljc/rems/application_util.cljc
@@ -11,13 +11,10 @@
   (contains? (:application/permissions application)
              :application.command/save-draft))
 
-(def ^:private name-attribute-priority [:name :commonName :displayName :userid :eppn])
-
 (defn get-member-name [attributes]
   (when attributes
-    (->> (map attributes name-attribute-priority)
-         (remove nil?)
-         first)))
+    (or (:name attributes)
+        (:userid attributes))))
 
 (defn get-applicant-name [application]
   (get-member-name (:application/applicant application)))

--- a/src/cljs/rems/application.cljs
+++ b/src/cljs/rems/application.cljs
@@ -521,7 +521,7 @@
   (let [application-id (:application/id application)
         user-id (:userid attributes)
         other-attributes (dissoc attributes :name :userid :email)
-        title (cond (= (:application/applicant application) user-id) (text :t.applicant-info/applicant)
+        title (cond (= (:userid (:application/applicant application)) user-id) (text :t.applicant-info/applicant)
                     (:userid attributes) (text :t.applicant-info/member)
                     :else (text :t.applicant-info/invited-member))]
     [collapsible/minimal
@@ -552,8 +552,7 @@
   "Renders the applicants, i.e. applicant and members."
   [application]
   (let [application-id (:application/id application)
-        applicant (merge {:userid (:application/applicant application)}
-                         (:application/applicant-attributes application))
+        applicant (:application/applicant application)
         members (:application/members application)
         invited-members (:application/invited-members application)
         permissions (:application/permissions application)
@@ -660,7 +659,7 @@
 (defn- applied-resources [application userid]
   (let [application-id (:application/id application)
         permissions (:application/permissions application)
-        applicant? (= (:application/applicant application) userid)
+        applicant? (= (:userid (:application/applicant application)) userid)
         can-change-resources? (contains? permissions :application.command/change-resources)
         can-comment? (not applicant?)]
     [collapsible/component
@@ -697,7 +696,7 @@
      [:div.mt-3 [applicants-info application]]
      [:div.mt-3 [applied-resources application userid]]
      (when (contains? (:application/permissions application) :see-everything)
-       [:div.mt-3 [previous-applications (get application :application/applicant)]])
+       [:div.mt-3 [previous-applications (get-in application [:application/applicant :userid])]])
      [:div.my-3 [application-licenses application edit-application userid]]
      [:div.my-3 [application-fields application edit-application attachment-success]]]
     [:div.col-lg-4
@@ -751,7 +750,7 @@
                                        :organization "Testers"
                                        :address "Testikatu 1, 00100 Helsinki"}
                           :application {:application/id 42
-                                        :application/applicant "developer"}
+                                        :application/applicant {:userid "developer"}}
                           :accepted-licenses? true}])
    (example "member-info with name missing"
             [member-info {:element-id "info2"
@@ -760,12 +759,12 @@
                                        :name "Testers"
                                        :address "Testikatu 1, 00100 Helsinki"}
                           :application {:application/id 42
-                                        :application/applicant "developer"}}])
+                                        :application/applicant {:userid "developer"}}}])
    (example "member-info"
             [member-info {:element-id "info3"
                           :attributes {:userid "alice"}
                           :application {:application/id 42
-                                        :application/applicant "developer"}
+                                        :application/applicant {:userid "developer"}}
                           :group? true
                           :can-remove? true}])
    (example "member-info"
@@ -773,13 +772,13 @@
                           :attributes {:name "John Smith"
                                        :email "john.smith@invited.com"}
                           :application {:application/id 42
-                                        :application/applicant "developer"}
+                                        :application/applicant {:userid "developer"}}
                           :group? true}])
 
    (component-info applicants-info)
    (example "applicants-info"
             [applicants-info {:application/id 42
-                              :application/applicant "developer"
+                              :application/applicant {:userid "developer"}
                               :application/applicant-attributes {:userid "developer"
                                                                  :email "developer@uu.id"
                                                                  :name "Deve Loper"}

--- a/src/cljs/rems/application.cljs
+++ b/src/cljs/rems/application.cljs
@@ -147,7 +147,7 @@
    {:db (assoc-in db [::edit-application :validation-errors] nil)}))
 
 (defn- submit-application! [application description application-id field-values
-                            userid]
+                            userid] ;; TODO remove unused parameter
   ;; TODO: deduplicate with save-application!
   (post! "/api/applications/save-draft"
          {:params {:application-id application-id
@@ -183,7 +183,7 @@
                           description
                           (:application/id application)
                           (:field-values edit-application)
-                          (get-in (:identity db) [:user :eppn])))
+                          (get-in (:identity db) [:user :userid])))
    {:db (assoc-in db [::edit-application :validation-errors] nil)}))
 
 (rf/reg-event-fx
@@ -717,7 +717,7 @@
         reloading? @(rf/subscribe [::application :reloading?])
         edit-application @(rf/subscribe [::edit-application])
         attachment-success @(rf/subscribe [::attachment-success])
-        userid (get-in @(rf/subscribe [:identity]) [:user :eppn])]
+        userid (:userid @(rf/subscribe [:user]))]
     [:div.container-fluid
      [document-title (str (text :t.applications/application)
                           (when application

--- a/src/cljs/rems/application.cljs
+++ b/src/cljs/rems/application.cljs
@@ -778,10 +778,9 @@
    (component-info applicants-info)
    (example "applicants-info"
             [applicants-info {:application/id 42
-                              :application/applicant {:userid "developer"}
-                              :application/applicant-attributes {:userid "developer"
-                                                                 :email "developer@uu.id"
-                                                                 :name "Deve Loper"}
+                              :application/applicant {:userid "developer"
+                                                      :email "developer@uu.id"
+                                                      :name "Deve Loper"}
                               :application/members #{{:userid "alice"}
                                                      {:userid "bob"}}
                               :application/invited-members #{{:name "John Smith" :email "john.smith@invited.com"}}
@@ -886,9 +885,9 @@
             [render-application
              {:application {:application/id 17
                             :application/state :application.state/approved
-                            :application/applicant-attributes {:userid "eppn"
-                                                               :email "email@example.com"
-                                                               :additional "additional field"}
+                            :application/applicant {:userid "eppn"
+                                                    :email "email@example.com"
+                                                    :additional "additional field"}
                             :application/resources [{:catalogue-item/title {:en "An applied item"}}]
                             :application/form {:form/fields [{:field/id 1
                                                               :field/type :text

--- a/src/cljs/rems/application.cljs
+++ b/src/cljs/rems/application.cljs
@@ -387,7 +387,7 @@
      (application-list/format-application-id config application)]))
 
 (defn- format-event [event]
-  {:user (:commonName (:event/actor-attributes event))
+  {:user (:name (:event/actor-attributes event)) ;; TODO use get-member-name?
    :event (localize-event event)
    :decision (when (= (:event/type event) :application.event/decided)
                (localize-decision event))
@@ -521,8 +521,8 @@
   `:accepted-licenses?` - has the member accepted the licenses?"
   [{:keys [element-id attributes application group? can-remove? accepted-licenses?]}]
   (let [application-id (:application/id application)
-        user-id (or (:eppn attributes) (:userid attributes))
-        other-attributes (dissoc attributes :commonName :name :eppn :userid :mail :email)
+        user-id (:userid attributes)
+        other-attributes (dissoc attributes :name :userid :email)
         title (cond (= (:application/applicant application) user-id) (text :t.applicant-info/applicant)
                     (:userid attributes) (text :t.applicant-info/member)
                     :else (text :t.applicant-info/invited-member))]
@@ -538,7 +538,7 @@
       :collapse (into [:div
                        (when user-id
                          [info-field (text :t.applicant-info/username) user-id {:inline? true}])
-                       (when-let [mail (or (:mail attributes) (:email attributes))]
+                       (when-let [mail (:email attributes)]
                          [info-field (text :t.applicant-info/email) mail {:inline? true}])]
                       (for [[k v] other-attributes]
                         [info-field k v {:inline? true}]))
@@ -747,9 +747,9 @@
    (component-info member-info)
    (example "member-info"
             [member-info {:element-id "info1"
-                          :attributes {:eppn "developer@uu.id"
-                                       :mail "developer@uu.id"
-                                       :commonName "Deve Loper"
+                          :attributes {:userid "developer@uu.id"
+                                       :email "developer@uu.id"
+                                       :name "Deve Loper"
                                        :organization "Testers"
                                        :address "Testikatu 1, 00100 Helsinki"}
                           :application {:application/id 42
@@ -757,9 +757,9 @@
                           :accepted-licenses? true}])
    (example "member-info with name missing"
             [member-info {:element-id "info2"
-                          :attributes {:eppn "developer"
-                                       :mail "developer@uu.id"
-                                       :organization "Testers"
+                          :attributes {:userid "developer"
+                                       :email "developer@uu.id"
+                                       :name "Testers"
                                        :address "Testikatu 1, 00100 Helsinki"}
                           :application {:application/id 42
                                         :application/applicant "developer"}}])
@@ -782,11 +782,9 @@
    (example "applicants-info"
             [applicants-info {:application/id 42
                               :application/applicant "developer"
-                              :application/applicant-attributes {:eppn "developer"
-                                                                 :mail "developer@uu.id"
-                                                                 :commonName "Deve Loper"
-                                                                 :organization "Testers"
-                                                                 :address "Testikatu 1, 00100 Helsinki"}
+                              :application/applicant-attributes {:userid "developer"
+                                                                 :email "developer@uu.id"
+                                                                 :name "Deve Loper"}
                               :application/members #{{:userid "alice"}
                                                      {:userid "bob"}}
                               :application/invited-members #{{:name "John Smith" :email "john.smith@invited.com"}}
@@ -891,8 +889,8 @@
             [render-application
              {:application {:application/id 17
                             :application/state :application.state/approved
-                            :application/applicant-attributes {:eppn "eppn"
-                                                               :mail "email@example.com"
+                            :application/applicant-attributes {:userid "eppn"
+                                                               :email "email@example.com"
                                                                :additional "additional field"}
                             :application/resources [{:catalogue-item/title {:en "An applied item"}}]
                             :application/form {:form/fields [{:field/id 1

--- a/src/cljs/rems/application.cljs
+++ b/src/cljs/rems/application.cljs
@@ -385,7 +385,7 @@
      (application-list/format-application-id config application)]))
 
 (defn- format-event [event]
-  {:user (:name (:event/actor-attributes event)) ;; TODO use get-member-name?
+  {:user (get-member-name (:event/actor-attributes event))
    :event (localize-event event)
    :decision (when (= (:event/type event) :application.event/decided)
                (localize-decision event))

--- a/src/cljs/rems/application.cljs
+++ b/src/cljs/rems/application.cljs
@@ -146,8 +146,7 @@
                         (:field-values edit-application)))
    {:db (assoc-in db [::edit-application :validation-errors] nil)}))
 
-(defn- submit-application! [application description application-id field-values
-                            userid] ;; TODO remove unused parameter
+(defn- submit-application! [application description application-id field-values]
   ;; TODO: deduplicate with save-application!
   (post! "/api/applications/save-draft"
          {:params {:application-id application-id
@@ -182,8 +181,7 @@
      (submit-application! application
                           description
                           (:application/id application)
-                          (:field-values edit-application)
-                          (get-in (:identity db) [:user :userid])))
+                          (:field-values edit-application)))
    {:db (assoc-in db [::edit-application :validation-errors] nil)}))
 
 (rf/reg-event-fx

--- a/src/cljs/rems/application_list.cljs
+++ b/src/cljs/rems/application_list.cljs
@@ -172,16 +172,16 @@
        :application/resources [{:catalogue-item/title {:en "Item 5"}}]
        :application/state :application.state/draft
        :application/applicant "alice"
-       :application/applicant-attributes {:eppn "alice"
-                                          :commonName "Alice Applicant"}
+       :application/applicant-attributes {:userid "alice"
+                                          :name "Alice Applicant"}
        :application/created "1980-01-02T13:45:00.000Z"
        :application/last-activity "2017-01-01T01:01:01:001Z"}
       {:application/id 2
        :application/resources [{:catalogue-item/title {:en "Item 3"}}]
        :application/state :application.state/submitted
        :application/applicant "bob"
-       :application/applicant-attributes {:eppn "bob"
-                                          :commonName "Bob Tester"}
+       :application/applicant-attributes {:userid "bob"
+                                          :name "Bob Tester"}
        :application/created "1971-02-03T23:59:00.000Z"
        :application/last-activity "2017-01-01T01:01:01:001Z"}
       {:application/id 3
@@ -189,24 +189,24 @@
                                {:catalogue-item/title {:en "Item 5"}}]
        :application/state :application.state/approved
        :application/applicant "charlie"
-       :application/applicant-attributes {:eppn "charlie"
-                                          :commonName "Charlie Tester"}
+       :application/applicant-attributes {:userid "charlie"
+                                          :name "Charlie Tester"}
        :application/created "1980-01-01T01:01:00.000Z"
        :application/last-activity "2017-01-01T01:01:01:001Z"}
       {:application/id 4
        :application/resources [{:catalogue-item/title {:en "Item 2"}}]
        :application/state :application.state/rejected
        :application/applicant "david"
-       :application/applicant-attributes {:eppn "david"
-                                          :commonName "David Newuser"}
+       :application/applicant-attributes {:userid "david"
+                                          :name "David Newuser"}
        :application/created "1972-12-12T12:12:00.000Z"
        :application/last-activity "2017-01-01T01:01:01:001Z"}
       {:application/id 5
        :application/resources [{:catalogue-item/title {:en "Item 2"}}]
        :application/state :application.state/closed
        :application/applicant "ernie"
-       :application/applicant-attributes {:eppn "ernie"
-                                          :commonName "Ernie Tester"}
+       :application/applicant-attributes {:userid "ernie"
+                                          :name "Ernie Tester"}
        :application/created "1972-12-12T12:12:00.000Z"
        :application/last-activity "2017-01-01T01:01:01:001Z"}]))
 

--- a/src/cljs/rems/application_list.cljs
+++ b/src/cljs/rems/application_list.cljs
@@ -171,42 +171,37 @@
      [{:application/id 1
        :application/resources [{:catalogue-item/title {:en "Item 5"}}]
        :application/state :application.state/draft
-       :application/applicant "alice"
-       :application/applicant-attributes {:userid "alice"
-                                          :name "Alice Applicant"}
+       :application/applicant {:userid "alice"
+                               :name "Alice Applicant"}
        :application/created "1980-01-02T13:45:00.000Z"
        :application/last-activity "2017-01-01T01:01:01:001Z"}
       {:application/id 2
        :application/resources [{:catalogue-item/title {:en "Item 3"}}]
        :application/state :application.state/submitted
-       :application/applicant "bob"
-       :application/applicant-attributes {:userid "bob"
-                                          :name "Bob Tester"}
+       :application/applicant {:userid "bob"
+                               :name "Bob Tester"}
        :application/created "1971-02-03T23:59:00.000Z"
        :application/last-activity "2017-01-01T01:01:01:001Z"}
       {:application/id 3
        :application/resources [{:catalogue-item/title {:en "Item 2"}}
                                {:catalogue-item/title {:en "Item 5"}}]
        :application/state :application.state/approved
-       :application/applicant "charlie"
-       :application/applicant-attributes {:userid "charlie"
-                                          :name "Charlie Tester"}
+       :application/applicant {:userid "charlie"
+                               :name "Charlie Tester"}
        :application/created "1980-01-01T01:01:00.000Z"
        :application/last-activity "2017-01-01T01:01:01:001Z"}
       {:application/id 4
        :application/resources [{:catalogue-item/title {:en "Item 2"}}]
        :application/state :application.state/rejected
-       :application/applicant "david"
-       :application/applicant-attributes {:userid "david"
-                                          :name "David Newuser"}
+       :application/applicant {:userid "david"
+                               :name "David Newuser"}
        :application/created "1972-12-12T12:12:00.000Z"
        :application/last-activity "2017-01-01T01:01:01:001Z"}
       {:application/id 5
        :application/resources [{:catalogue-item/title {:en "Item 2"}}]
        :application/state :application.state/closed
-       :application/applicant "ernie"
-       :application/applicant-attributes {:userid "ernie"
-                                          :name "Ernie Tester"}
+       :application/applicant {:userid "ernie"
+                               :name "Ernie Tester"}
        :application/created "1972-12-12T12:12:00.000Z"
        :application/last-activity "2017-01-01T01:01:01:001Z"}]))
 

--- a/src/cljs/rems/identity.cljs
+++ b/src/cljs/rems/identity.cljs
@@ -32,10 +32,10 @@
 
 (defn set-identity!
   "Receives as a parameter following kind of structure:
-   {:user {:eppn \"\"eppn\" \"developer\"
+   {:user {:userid \"developer\"
            :email \"developer@e.mail\"
-           :displayName \"deve\"
-           :surname \"loper\"
+           :name \"deve loper\"
+           :organization \"Foocorp\"
            ...}
     :roles [\"applicant\" \"approver\"]}
     Roles are converted to clojure keywords inside the function before dispatching"

--- a/src/cljs/rems/navbar.cljs
+++ b/src/cljs/rems/navbar.cljs
@@ -21,7 +21,7 @@
   (when user
     [:div.user.px-2.px-sm-0
      [:i.fa.fa-user]
-     [:span.user-name (str (:commonName user) " /")]
+     [:span.user-name (str (:name user) " /")]
      [atoms/link {:id "logout", :class (str "px-0 nav-link")} (url-dest "/logout") (text :t.navigation/logout)]]))
 
 (defn navbar-extra-pages [page-id]

--- a/src/cljs/rems/user_settings.cljs
+++ b/src/cljs/rems/user_settings.cljs
@@ -78,7 +78,7 @@
 (rf/reg-event-fx
  ::save-user-settings!
  (fn [{:keys [db]} [_]]
-   (let [user-id (get-in db [:identity :user :eppn])
+   (let [user-id (get-in db [:identity :user :userid])
          new-settings (assoc (:user-settings db)
                              :language (get-language db))]
      (when user-id

--- a/test/clj/rems/api/test_users.clj
+++ b/test/clj/rems/api/test_users.clj
@@ -16,15 +16,15 @@
 
 (deftest users-api-test
   (testing "create"
-    (is (= nil (users/get-user-attributes "david")))
+    (is (= nil (:name (users/get-user "david"))))
     (-> (request :post (str "/api/users/create"))
         (json-body new-user)
         (authenticate "42" "owner")
         handler
         assert-response-is-ok)
-    (is (= {:eppn "david"
-            :mail "d@av.id"
-            :commonName "David Newuser"} (users/get-user-attributes "david")))))
+    (is (= {:userid "david"
+            :email "d@av.id"
+            :name "David Newuser"} (users/get-user "david")))))
 
 (deftest workflows-api-security-test
   (testing "without authentication"

--- a/test/clj/rems/application/test_commands.clj
+++ b/test/clj/rems/application/test_commands.clj
@@ -45,7 +45,7 @@
    :get-form-template dummy-forms
    :get-catalogue-item dummy-get-catalogue-item
    :get-license dummy-licenses
-   :get-user (constantly nil)
+   :get-user (fn [userid] {:userid userid})
    :get-users-with-role (constantly nil)
    :get-attachments-for-application (constantly nil)})
 

--- a/test/clj/rems/application/test_model.clj
+++ b/test/clj/rems/application/test_model.clj
@@ -142,21 +142,21 @@
        :archived false}})
 
 (def ^:private get-user
-  {"applicant" {:eppn "applicant"
-                :mail "applicant@example.com"
-                :commonName "Applicant"}
-   "commenter" {:eppn "commenter"
-                :mail "commenter@example.com"
-                :commonName "Commenter"}
-   "decider" {:eppn "decider"
-              :mail "decider@example.com"
-              :commonName "Decider"}
-   "handler" {:eppn "handler"
-              :mail "handler@example.com"
-              :commonName "Handler"}
-   "member" {:eppn "member"
-             :mail "member@example.com"
-             :commonName "Member"}})
+  {"applicant" {:userid "applicant"
+                :email "applicant@example.com"
+                :name "Applicant"}
+   "commenter" {:userid "commenter"
+                :email "commenter@example.com"
+                :name "Commenter"}
+   "decider" {:userid "decider"
+              :email "decider@example.com"
+              :name "Decider"}
+   "handler" {:userid "handler"
+              :email "handler@example.com"
+              :name "Handler"}
+   "member" {:userid "member"
+             :email "member@example.com"
+             :name "Member"}})
 
 (def ^:private get-users-with-role
   {:owner ["owner1"]
@@ -279,9 +279,9 @@
                                   :application/last-activity (DateTime. 1000)
                                   ;; TODO: unify applicant, members, handlers etc. to use either {:userid "user"} or "user"
                                   :application/applicant "applicant"
-                                  :application/applicant-attributes {:eppn "applicant"
-                                                                     :mail "applicant@example.com"
-                                                                     :commonName "Applicant"}
+                                  :application/applicant-attributes {:userid "applicant"
+                                                                     :email "applicant@example.com"
+                                                                     :name "Applicant"}
                                   :application/members #{}
                                   :application/past-members #{}
                                   :application/invitation-tokens {}
@@ -760,7 +760,7 @@
                                         expected-application (merge expected-application
                                                                     {:application/last-activity (DateTime. 4600)
                                                                      :application/events enriched-events
-                                                                     :application/members #{{:userid "member", :eppn "member", :mail "member@example.com", :commonName "Member"}}})]
+                                                                     :application/members #{{:userid "member", :email "member@example.com", :name "Member"}}})]
                                     (is (= expected-application (apply-events events)))
                                     (testing "> licenses accepted for new member"
                                       (let [new-event {:event/type :application.event/licenses-accepted
@@ -955,7 +955,7 @@
                                     expected-application (merge expected-application
                                                                 {:application/last-activity (DateTime. 5000)
                                                                  :application/events enriched-events
-                                                                 :application/members #{{:userid "member", :eppn "member", :mail "member@example.com", :commonName "Member"}}
+                                                                 :application/members #{{:userid "member", :email "member@example.com", :name "Member"}}
                                                                  :application/invitation-tokens {}})]
                                 (is (= expected-application (apply-events events)))))))
 
@@ -972,7 +972,7 @@
                                 expected-application (merge expected-application
                                                             {:application/last-activity (DateTime. 4000)
                                                              :application/events enriched-events
-                                                             :application/members #{{:userid "member", :eppn "member", :mail "member@example.com", :commonName "Member"}}})]
+                                                             :application/members #{{:userid "member", :email "member@example.com", :name "Member"}}})]
                             (is (= expected-application (apply-events events)))
 
                             (testing "> member removed"

--- a/test/clj/rems/application/test_model.clj
+++ b/test/clj/rems/application/test_model.clj
@@ -277,11 +277,9 @@
                                   :application/created (DateTime. 1000)
                                   :application/modified (DateTime. 1000)
                                   :application/last-activity (DateTime. 1000)
-                                  ;; TODO: unify applicant, members, handlers etc. to use either {:userid "user"} or "user"
-                                  :application/applicant "applicant"
-                                  :application/applicant-attributes {:userid "applicant"
-                                                                     :email "applicant@example.com"
-                                                                     :name "Applicant"}
+                                  :application/applicant {:userid "applicant"
+                                                          :email "applicant@example.com"
+                                                          :name "Applicant"}
                                   :application/members #{}
                                   :application/past-members #{}
                                   :application/invitation-tokens {}

--- a/test/clj/rems/db/test_users.clj
+++ b/test/clj/rems/db/test_users.clj
@@ -26,3 +26,9 @@
     (roles/add-role! "user1" :owner)
     (is (= ["user1"] (users/get-users-with-role :owner)))
     (is (= [] (users/get-users-with-role :reporter)))))
+
+(deftest test-nonexistent-user
+  (is (= {:userid "nonexistent"
+          :name nil
+          :email nil}
+         (users/get-user "nonexistent"))))

--- a/test/clj/rems/db/test_users.clj
+++ b/test/clj/rems/db/test_users.clj
@@ -15,12 +15,12 @@
   (testing "get-user-attributes"
     (is (= {:eppn "whatever"
             :some-attr "some value"}
-           (users/get-user-attributes "user1"))))
+           (#'users/get-user-attributes "user1"))))
 
   (testing "get-all-users"
     (is (= [{:eppn "whatever"
              :some-attr "some value"}]
-           (users/get-all-users))))
+           (#'users/get-all-users))))
 
   (testing "get-users-with-role"
     (roles/add-role! "user1" :owner)

--- a/test/clj/rems/test_db.clj
+++ b/test/clj/rems/test_db.clj
@@ -61,15 +61,6 @@
     (is (= ["resid111" "resid222"] (sort (map :resid (db/get-entitlements {:application app-id}))))
         "should create entitlements for both resources")))
 
-(deftest test-users
-  (db/add-user! {:user "pekka", :userattrs nil})
-  (db/add-user! {:user "simo", :userattrs nil})
-  (is (= 2 (count (db/get-users))))
-  (db/add-user! {:user "pekka", :userattrs (cheshire/generate-string {:key "value"})})
-  (db/add-user! {:user "simo", :userattrs nil})
-  (is (= 2 (count (db/get-users))))
-  (is (= {:key "value"} (users/get-user-attributes "pekka"))))
-
 (deftest test-roles
   (db/add-user! {:user "pekka", :userattrs nil})
   (db/add-user! {:user "simo", :userattrs nil})


### PR DESCRIPTION
Follow-up for #1634

This is a breaking change for the API, but it mostly breaks stuff that was just added by #1650. The other stuff that breaks (e.g. `/api/applications/:id` field `:application/applicant-attributes` was never documented.

# Definition of Done / Review checklist

## Reviewability
- [x] link to issue

## API
- [x] API is documented and shows up in Swagger UI
- [ ] API is backwards compatible or completely new

## Testing
- [x] complex logic is unit tested
- [x] valuable features are integration / browser / acceptance tested automatically

## Follow-up
- [x] no critical TODOs left to implement
