### PR TITLE
Improve guide table

### DIFF
--- a/src/clj/rems/guide_macros.clj
+++ b/src/clj/rems/guide_macros.clj
@@ -9,7 +9,33 @@
       (ns-name (:ns m#))
       m#)))
 
+
+(defn- static-hiccup?
+  "Does the content look like static hiccup markup?"
+  [x]
+  (and (vector? x)
+       (keyword? (first x))))
+
 (defmacro example
-  ([title content]
-   (let [src (with-out-str (write content :dispatch code-dispatch))]
-     `(rems.guide-functions/render-example ~title ~src ~content))))
+  "Render an example of a component use into the guide.
+
+  Captures the code into a preformatted element and shows it along with
+  the rendered result.
+
+  (example \"simple use\"
+           [my-component \"hello\"])
+
+  Static content can be added between code blocks with regular static hiccup markup.
+
+  (example \"simple use\"
+           [:p \"This is a very simple use case with no data\"]
+           [my-component \"hello\" []]
+           [:p \"Which can be written also like this\"]
+           [my-component \"hello\"])"
+  [title & content]
+  (let [src (into [:div]
+                  (for [block content]
+                    (if (static-hiccup? block)
+                      block
+                      [:pre (with-out-str (write block :dispatch code-dispatch))])))]
+    `(rems.guide-functions/render-example ~title ~src (do ~@content))))

--- a/src/clj/rems/guide_macros.clj
+++ b/src/clj/rems/guide_macros.clj
@@ -7,7 +7,7 @@
      (rems.guide-functions/render-component-info
       (:name m#)
       (ns-name (:ns m#))
-      (:doc m#))))
+      m#)))
 
 (defmacro example
   ([title content]

--- a/src/clj/rems/read_gitlog.clj
+++ b/src/clj/rems/read_gitlog.clj
@@ -1,11 +1,11 @@
 (ns rems.read-gitlog
   (:require [clojure.java.io :as io]
-            [clojure.string :as str])
+            [clojure.string :as str]
+            [rems.git :as git])
   (:import [java.io IOException]))
 
 (def ^:private version-description-file "git-describe.txt")
 (def ^:private version-revision-file "git-revision.txt")
-(def ^:private repo-url "https://github.com/CSCfi/rems/commits/")
 
 (defn- read-file [name]
   (some-> name
@@ -19,6 +19,5 @@
           revision (read-file version-revision-file)]
       (when (and version revision)
         {:version version
-         :revision revision
-         :repo-url repo-url}))
+         :revision revision}))
     (catch IOException _ nil)))

--- a/src/cljc/rems/git.cljc
+++ b/src/cljc/rems/git.cljc
@@ -1,0 +1,6 @@
+(ns rems.git)
+
+(def +repo-url+ "https://github.com/CSCfi/rems/")
+(def +commits-url+ (str +repo-url+ "commits/"))
+(def +tree-url+ (str +repo-url+ "tree/"))
+(def +master-url+ (str +tree-url+ "master/"))

--- a/src/cljs/rems/auth/auth.cljs
+++ b/src/cljs/rems/auth/auth.cljs
@@ -20,7 +20,10 @@
 
 (defn guide []
   [:div
+   (component-info shibboleth/login-component)
    (example "shibboleth login" [shibboleth/login-component nil])
    (example "shibboleth login with alternatives" [shibboleth/login-component "/alternative"])
+   (component-info ldap/login-component)
    (example "ldap login" [ldap/login-component])
+   (component-info oidc/login-component)
    (example "oidc login" [oidc/login-component])])

--- a/src/cljs/rems/guide_functions.cljs
+++ b/src/cljs/rems/guide_functions.cljs
@@ -15,21 +15,21 @@
                (str git/+master-url+ path))]
     [:a {:href href} link-text]))
 
+(defn- docstring [meta]
+  [:pre.docstring
+   (if-let [doc (:doc meta)]
+     (remove-indentation doc)
+     "No documentation available.")])
+
 (defn render-namespace-info [title meta]
   [:div.namespace-info
    [:h3 title [:small " (" (link-to-source meta) ")"]]
-   [:pre.example-source
-    (if-let [doc (:doc meta)]
-      (remove-indentation doc)
-      "No documentation available.")]])
+   [docstring meta]])
 
 (defn render-component-info [title ns meta]
   [:div.component-info
    [:h3 ns "/" title [:small " (" (link-to-source meta) ")"]]
-   [:pre.example-source
-    (if-let [doc (:doc meta)]
-      (remove-indentation doc)
-      "No documentation available.")]])
+   [docstring meta]])
 
 (defn render-example [title src content]
   [:div.example

--- a/src/cljs/rems/guide_functions.cljs
+++ b/src/cljs/rems/guide_functions.cljs
@@ -5,7 +5,7 @@
 
 (defn- remove-indentation [docstring]
   (str/join "\n" (for [line (str/split (str "  " docstring) #"\n")]
-                 (apply str (drop 2 line)))))
+                   (apply str (drop 2 line)))))
 
 (defn render-namespace-info [title meta]
   (let [source (str (:file meta) ":" (:line meta) ":" (:column meta))

--- a/src/cljs/rems/guide_functions.cljs
+++ b/src/cljs/rems/guide_functions.cljs
@@ -1,17 +1,22 @@
 (ns rems.guide-functions
   (:require [clojure.string :as str]))
 
+(def ^:private +rems-github-master+ "https://github.com/CSCfi/rems/tree/master")
+
 (defn- remove-indentation [docstring]
   (str/join "\n" (for [line (str/split (str "  " docstring) #"\n")]
                  (apply str (drop 2 line)))))
 
-(defn render-component-info [title ns doc]
-  [:div.component-info
-   [:h3 ns "/" title]
-   [:pre.example-source
-    (if doc
-      (remove-indentation doc)
-      "No documentation available.")]])
+(defn render-component-info [title ns meta]
+  (let [source (str (:file meta) ":" (:line meta) ":" (:column meta))
+        href (str +rems-github-master+ "/" (:file meta) "#L" (:line meta))
+        doc (:doc meta)]
+    [:div.component-info
+     [:h3 ns "/" title [:small " (" [:a {:href href} source] ")"]]
+     [:pre.example-source
+      (if doc
+        (remove-indentation doc)
+        "No documentation available.")]]))
 
 (defn render-example [title src content]
   [:div.example

--- a/src/cljs/rems/guide_functions.cljs
+++ b/src/cljs/rems/guide_functions.cljs
@@ -7,6 +7,17 @@
   (str/join "\n" (for [line (str/split (str "  " docstring) #"\n")]
                  (apply str (drop 2 line)))))
 
+(defn render-namespace-info [title meta]
+  (let [source (str (:file meta) ":" (:line meta) ":" (:column meta))
+        href (str +rems-github-master+ "/" (:file meta) "#L" (:line meta))
+        doc (:doc meta)]
+    [:div.namespace-info
+     [:h3 title [:small " (" [:a {:href href} source] ")"]]
+     [:pre.example-source
+      (if doc
+        (remove-indentation doc)
+        "No documentation available.")]]))
+
 (defn render-component-info [title ns meta]
   (let [source (str (:file meta) ":" (:line meta) ":" (:column meta))
         href (str +rems-github-master+ "/" (:file meta) "#L" (:line meta))

--- a/src/cljs/rems/guide_functions.cljs
+++ b/src/cljs/rems/guide_functions.cljs
@@ -21,6 +21,6 @@
 (defn render-example [title src content]
   [:div.example
    [:h3 title]
-   [:pre.example-source src]
+   [:div.example-source src]
    [:div.example-content content
     [:div.example-content-end]]])

--- a/src/cljs/rems/spa.cljs
+++ b/src/cljs/rems/spa.cljs
@@ -33,6 +33,7 @@
             [rems.config :as config]
             [rems.extra-pages :refer [extra-pages]]
             [rems.flash-message :as flash-message]
+            [rems.git :as git]
             [rems.guide-page :refer [guide-page]]
             [rems.navbar :as nav]
             [rems.new-application :refer [new-application-page]]
@@ -219,9 +220,9 @@
    [:div.container
     [:div.navbar
      [:div.navbar-text (text :t/footer)]
-     (when-let [{:keys [version revision repo-url]} (read-current-version)]
+     (when-let [{:keys [version revision]} (read-current-version)]
        [:div#footer-release-number
-        [:a {:href (str repo-url revision)}
+        [:a {:href (str git/+commits-url+ revision)}
          version]])]]])
 
 (defn logo []

--- a/src/cljs/rems/table.cljs
+++ b/src/cljs/rems/table.cljs
@@ -300,22 +300,36 @@
    (component-info table)
    ;; slight abuse of example macro, but it works since reg-sub returns a fn which reagent doesn't render
    (example "data for examples"
-            (rf/reg-sub
-             ::example-table-rows
-             (fn [_ _]
-               [{:key 1
-                 :first-name {:value "Cody"}
-                 :last-name {:value "Turner"}
-                 :commands {:td [:td.commands [:button.btn.btn-primary "View"]]}}
-                {:key 2
-                 :first-name {:value "Melanie"}
-                 :last-name {:value "Palmer"}
-                 :commands {:td [:td.commands [:button.btn.btn-primary "View"]]}}
-                {:key 3
-                 :first-name {:value "Henry"}
-                 :last-name {:value "Herring"}
-                 :commands {:td [:td.commands [:button.btn.btn-primary "View"]]}}])))
-   (example "static table"
+            [:<>
+             (rf/reg-sub ::empty-table-rows (fn [_ _] []))
+             (rf/reg-sub
+              ::example-table-rows
+              (fn [_ _]
+                [{:key 1
+                  :first-name {:value "Cody"}
+                  :last-name {:value "Turner"}
+                  :commands {:td [:td.commands [:button.btn.btn-primary "View"]]}}
+                 {:key 2
+                  :first-name {:value "Melanie"}
+                  :last-name {:value "Palmer"}
+                  :commands {:td [:td.commands [:button.btn.btn-primary "View"]]}}
+                 {:key 3
+                  :first-name {:value "Henry"}
+                  :last-name {:value "Herring"}
+                  :commands {:td [:td.commands [:button.btn.btn-primary "View"]]}}]))])
+   (example "empty table"
+            [table {:id ::example0
+                    :columns [{:key :first-name
+                               :title "First name"
+                               :sortable? false
+                               :filterable? false}
+                              {:key :last-name
+                               :title "Last name"
+                               :sortable? false
+                               :filterable? false}]
+                    :rows [::empty-table-rows]
+                    :default-sort-column :first-name}])
+   (example "static table with three rows"
             (let [example1 {:id ::example1
                             :columns [{:key :first-name
                                        :title "First name"

--- a/src/cljs/rems/table.cljs
+++ b/src/cljs/rems/table.cljs
@@ -224,7 +224,7 @@
 (defn search
   "Search field component for filtering a `rems.table/table` instance
   which takes the same `table` parameter as this component.
-  
+
   See `rems.table/Table` for the `table` parameter schema."
   [table]
   (s/validate Table table)
@@ -264,7 +264,7 @@
 (defn table
   "A filterable and sortable table component.
   Meant to be used together with the `rems.table/search` component.
-  
+
   See `rems.table/Table` for the `table` parameter schema."
   [table]
   (s/validate Table table)

--- a/src/cljs/rems/table.cljs
+++ b/src/cljs/rems/table.cljs
@@ -23,7 +23,7 @@
             [rems.search :as search]
             [rems.text :refer [text-format]]
             [schema.core :as s])
-  (:require-macros [rems.guide-macros :refer [component-info example]]))
+  (:require-macros [rems.guide-macros :refer [component-info example namespace-info]]))
 
 (s/defschema ColumnKey
   s/Keyword)
@@ -297,6 +297,7 @@
 
 (defn guide []
   [:div
+   (namespace-info rems.table)
    (component-info table)
    ;; slight abuse of example macro, but it works since reg-sub returns a fn which reagent doesn't render
    (example "data for examples"

--- a/src/cljs/rems/table.cljs
+++ b/src/cljs/rems/table.cljs
@@ -300,23 +300,23 @@
    (component-info table)
    ;; slight abuse of example macro, but it works since reg-sub returns a fn which reagent doesn't render
    (example "data for examples"
-            [:<>
-             (rf/reg-sub ::empty-table-rows (fn [_ _] []))
-             (rf/reg-sub
-              ::example-table-rows
-              (fn [_ _]
-                [{:key 1
-                  :first-name {:value "Cody"}
-                  :last-name {:value "Turner"}
-                  :commands {:td [:td.commands [:button.btn.btn-primary "View"]]}}
-                 {:key 2
-                  :first-name {:value "Melanie"}
-                  :last-name {:value "Palmer"}
-                  :commands {:td [:td.commands [:button.btn.btn-primary "View"]]}}
-                 {:key 3
-                  :first-name {:value "Henry"}
-                  :last-name {:value "Herring"}
-                  :commands {:td [:td.commands [:button.btn.btn-primary "View"]]}}]))])
+            [:p "Data is provided to the table component as a subscription"]
+            (rf/reg-sub ::empty-table-rows (fn [_ _] []))
+            (rf/reg-sub
+             ::example-table-rows
+             (fn [_ _]
+               [{:key 1
+                 :first-name {:value "Cody"}
+                 :last-name {:value "Turner"}
+                 :commands {:td [:td.commands [:button.btn.btn-primary "View"]]}}
+                {:key 2
+                 :first-name {:value "Melanie"}
+                 :last-name {:value "Palmer"}
+                 :commands {:td [:td.commands [:button.btn.btn-primary "View"]]}}
+                {:key 3
+                 :first-name {:value "Henry"}
+                 :last-name {:value "Herring"}
+                 :commands {:td [:td.commands [:button.btn.btn-primary "View"]]}}])))
    (example "empty table"
             [table {:id ::example0
                     :columns [{:key :first-name
@@ -343,6 +343,7 @@
                             :default-sort-column :first-name}]
               [table example1]))
    (example "sortable and filterable table"
+            [:p "Filtering and search can be added by using the " [:code "rems.table/search"] " component"]
             (let [example2 {:id ::example2
                             :columns [{:key :first-name
                                        :title "First name"}
@@ -357,33 +358,33 @@
                [search example2]
                [table example2]]))
    (example "richer example data"
-            (do
-              (comment "Hawks have a special sort-value so they are always listed first (or last if order is flipped)."
-                       "Also, filtering ignores the word \"Team\"."
-                       "Also, the score has special styling."
-                       "Eagles have special styling. :value is used for sorting & filtering but :td for rendering.")
-              (rf/reg-sub
-               ::example-rich-table-rows
-               (fn [_ _]
-                 [{:key 1
-                   :team {:display-value "Team Hawks"
-                          :filter-value "hawks"
-                          :sort-value "0000hawks"}
-                   :points {:value 3
-                            :display-value "-> 3 <-"}}
-                  {:key 2
-                   :team {:value "Eagles"
-                          :td [:td.eagles-are-best [:em "Eagles"]]}
-                   :points {:value 4}}
-                  {:key 3
-                   :team {:value "Ravens"}
-                   :points {:value 0}}]))
-              (let [example3 {:id ::example3
-                              :columns [{:key :team
-                                         :title "Team"}
-                                        {:key :points
-                                         :title "Points"}]
-                              :rows [::example-rich-table-rows]}]
-                [:div
-                 [search example3]
-                 [table example3]])))])
+            [:p "Hawks have a special sort-value so they are always listed first (or last if order is flipped)."
+             "Also, filtering ignores the word \"Team\"."
+             "Also, the score has special styling."
+             "Eagles have special styling. :value is used for sorting & filtering but :td for rendering."]
+            (rf/reg-sub
+             ::example-rich-table-rows
+             (fn [_ _]
+               [{:key 1
+                 :team {:display-value "Team Hawks"
+                        :filter-value "hawks"
+                        :sort-value "0000hawks"}
+                 :points {:value 3
+                          :display-value "-> 3 <-"}}
+                {:key 2
+                 :team {:value "Eagles"
+                        :td [:td.eagles-are-best [:em "Eagles"]]}
+                 :points {:value 4}}
+                {:key 3
+                 :team {:value "Ravens"}
+                 :points {:value 0}}]))
+            [:p "Now the data can be used like so"]
+            (let [example3 {:id ::example3
+                            :columns [{:key :team
+                                       :title "Team"}
+                                      {:key :points
+                                       :title "Points"}]
+                            :rows [::example-rich-table-rows]}]
+              [:div
+               [search example3]
+               [table example3]]))])


### PR DESCRIPTION
Improve both the guide as well as table component that is using it.

- links to the GitHub master source code from guide
- allows adding static text into the examples
- adds `namespace-info` component for guide
- example of empty table

![Screenshot_2019-10-10_16-55-59](https://user-images.githubusercontent.com/823661/66575603-dac10400-eb7e-11e9-9e5e-d3e98c466cf0.png)
