### PR TITLE
feat: 404s urls starting with /api/

### DIFF
--- a/src/clj/rems/api.clj
+++ b/src/clj/rems/api.clj
@@ -51,6 +51,11 @@
   (-> (internal-server-error (with-out-str (print-cause-trace exception)))
       (plain-text)))
 
+(defn not-found-handler
+  [request]
+  (-> (not-found "not found")
+      (plain-text)))
+
 (defn with-logging
   ;; Like in compojure.api.exception, but logs some of the data (with pprint)
   "Wrap compojure-api exception-handler a function which will log the
@@ -126,4 +131,7 @@
       resources-api
       user-settings-api
       users-api
-      workflows-api)))
+      workflows-api
+
+      ;; keep this last
+      not-found-handler)))

--- a/test/clj/rems/api/test_api.clj
+++ b/test/clj/rems/api/test_api.clj
@@ -1,0 +1,27 @@
+(ns ^:integration rems.api.test-api
+  (:require [clojure.test :refer :all]
+            [rems.api.testing :refer :all]
+            [rems.handler :refer [handler]]
+            [ring.mock.request :refer :all]))
+
+(use-fixtures :once api-fixture)
+
+(deftest test-api-not-found
+  (testing "unknown endpoint"
+    (let [resp (-> (request :get "/api/unknown")
+                   handler)]
+      (is (response-is-not-found? resp))))
+  (testing "known endpoint, wrong method,"
+    (testing "unauthorized"
+      (let [resp (-> (request :get "/api/blacklist/remove")
+                     handler)]
+        (is (response-is-not-found? resp))))
+    (testing "authorized,"
+      (testing "missing params"
+        ;; Surprisingly hard to find a POST route that isn't shadowed
+        ;; by a GET route. For example, GET /api/applications/command
+        ;; hits the /api/applications/:application-id route.
+        (let [resp (-> (request :get "/api/blacklist/remove")
+                       (authenticate "42" "handler")
+                       handler)]
+          (is (response-is-not-found? resp)))))))


### PR DESCRIPTION
we can't do them for other urls yet, see #1656