### PR TITLE
fix: remove compojure warning about nonconforming route

### DIFF
--- a/src/clj/rems/api.clj
+++ b/src/clj/rems/api.clj
@@ -134,4 +134,4 @@
       workflows-api
 
       ;; keep this last
-      not-found-handler)))
+      (undocumented not-found-handler))))


### PR DESCRIPTION
introduced in #1718

removes this warning from startup:

```
2019-10-21 16:08:13,913 [main - - -] WARN  compojure.api.routes - Not all child routes satisfy compojure.api.routing/Routing. {:path "/api", :method nil}, invalid child routes: [#object[rems.api$not_found_handler 0x796a1925 "rems.api$not_found_handler@796a1925"]]
```