### PR TITLE
refactor navigation

### DIFF
--- a/src/cljs/rems/administration/administration.cljs
+++ b/src/cljs/rems/administration/administration.cljs
@@ -19,13 +19,13 @@
 
 (defn administration-navigator [selected]
   [:div.navbar.mb-4.mr-auto.ml-auto
-   [navbar/nav-link+ "/administration" (text :t.navigation/administration) :exact]
-   [navbar/nav-link+ "/administration/catalogue-items" (text :t.administration/catalogue-items)]
-   [navbar/nav-link+ "/administration/resources" (text :t.administration/resources)]
-   [navbar/nav-link+ "/administration/forms" (text :t.administration/forms)]
-   [navbar/nav-link+ "/administration/workflows" (text :t.administration/workflows)]
-   [navbar/nav-link+ "/administration/licenses" (text :t.administration/licenses)]
-   [navbar/nav-link+ "/administration/blacklist" (text :t.administration/blacklist)]])
+   [navbar/nav-link "/administration" (text :t.navigation/administration) :exact]
+   [navbar/nav-link "/administration/catalogue-items" (text :t.administration/catalogue-items)]
+   [navbar/nav-link "/administration/resources" (text :t.administration/resources)]
+   [navbar/nav-link "/administration/forms" (text :t.administration/forms)]
+   [navbar/nav-link "/administration/workflows" (text :t.administration/workflows)]
+   [navbar/nav-link "/administration/licenses" (text :t.administration/licenses)]
+   [navbar/nav-link "/administration/blacklist" (text :t.administration/blacklist)]])
 
 (defn administration-navigator-container
   "Component for showing a navigator in the administration pages.

--- a/src/cljs/rems/administration/administration.cljs
+++ b/src/cljs/rems/administration/administration.cljs
@@ -19,29 +19,13 @@
 
 (defn administration-navigator [selected]
   [:div.navbar.mb-4.mr-auto.ml-auto
-   [navbar/nav-link "/administration" (text :t.navigation/administration) (contains? #{:rems.administration/administration} selected)]
-   [navbar/nav-link "/administration/catalogue-items" (text :t.administration/catalogue-items) (contains? #{:rems.administration/catalogue-items
-                                                                                                            :rems.administration/catalogue-item
-                                                                                                            :rems.administration/create-catalogue-item}
-                                                                                                          selected)]
-   [navbar/nav-link "/administration/resources" (text :t.administration/resources) (contains? #{:rems.administration/resources
-                                                                                                :rems.administration/resource
-                                                                                                :rems.administration/create-resource}
-                                                                                              selected)]
-   [navbar/nav-link "/administration/forms" (text :t.administration/forms) (contains? #{:rems.administration/forms
-                                                                                        :rems.administration/form
-                                                                                        :rems.administration/create-form}
-                                                                                      selected)]
-   [navbar/nav-link "/administration/workflows" (text :t.administration/workflows) (contains? #{:rems.administration/workflows
-                                                                                                :rems.administration/workflow
-                                                                                                :rems.administration/create-workflow}
-                                                                                              selected)]
-   [navbar/nav-link "/administration/licenses" (text :t.administration/licenses) (contains? #{:rems.administration/licenses
-                                                                                             :rems.administration/license
-                                                                                             :rems.administration/create-license}
-                                                                                           selected)]
-   [navbar/nav-link "/administration/blacklist" (text :t.administration/blacklist) (contains? #{:rems.administration/blacklist}
-                                                                                              selected)]])
+   [navbar/nav-link+ "/administration" (text :t.navigation/administration) :exact]
+   [navbar/nav-link+ "/administration/catalogue-items" (text :t.administration/catalogue-items)]
+   [navbar/nav-link+ "/administration/resources" (text :t.administration/resources)]
+   [navbar/nav-link+ "/administration/forms" (text :t.administration/forms)]
+   [navbar/nav-link+ "/administration/workflows" (text :t.administration/workflows)]
+   [navbar/nav-link+ "/administration/licenses" (text :t.administration/licenses)]
+   [navbar/nav-link+ "/administration/blacklist" (text :t.administration/blacklist)]])
 
 (defn administration-navigator-container
   "Component for showing a navigator in the administration pages.

--- a/src/cljs/rems/administration/catalogue_item.cljs
+++ b/src/cljs/rems/administration/catalogue_item.cljs
@@ -41,7 +41,7 @@
 
 (defn edit-button [id]
   [atoms/link {:class "btn btn-primary"}
-   (str "/administration/edit-catalogue-item/" id)
+   (str "/administration/catalogue-items/edit/" id)
    (text :t.administration/edit)])
 
 (defn catalogue-item-view [catalogue-item language]

--- a/src/cljs/rems/administration/catalogue_items.cljs
+++ b/src/cljs/rems/administration/catalogue_items.cljs
@@ -61,7 +61,7 @@
 
 (defn- to-create-catalogue-item []
   [atoms/link {:class "btn btn-primary"}
-   "/administration/create-catalogue-item"
+   "/administration/catalogue-items/create"
    (text :t.administration/create-catalogue-item)])
 
 (defn- to-catalogue-item [catalogue-item-id]

--- a/src/cljs/rems/administration/form.cljs
+++ b/src/cljs/rems/administration/form.cljs
@@ -42,7 +42,7 @@
      (fetch (str "/api/forms/" id "/editable")
             {:handler (fn [response]
                         (if (:success response)
-                          (navigate! (str "/administration/edit-form/" id))
+                          (navigate! (str "/administration/forms/edit/" id))
                           (flash-message/show-default-error!
                            :top description [status-flags/format-update-failure response])))
              :error-handler (flash-message/default-error-handler :top description)}))
@@ -63,7 +63,7 @@
 
 (defn- copy-as-new-button [id]
   [atoms/link {:class "btn btn-secondary"}
-   (str "/administration/create-form/" id)
+   (str "/administration/forms/create/" id)
    (text :t.administration/copy-as-new)])
 
 (defn form-view [form]

--- a/src/cljs/rems/administration/forms.cljs
+++ b/src/cljs/rems/administration/forms.cljs
@@ -61,7 +61,7 @@
 
 (defn- to-create-form []
   [atoms/link {:class "btn btn-primary"}
-   "/administration/create-form"
+   "/administration/forms/create"
    (text :t.administration/create-form)])
 
 (defn- to-view-form [form]
@@ -71,7 +71,7 @@
 
 (defn- copy-as-new-form [form]
   [atoms/link {:class "btn btn-primary"}
-   (str "/administration/create-form/" (:form/id form))
+   (str "/administration/forms/create/" (:form/id form))
    (text :t.administration/copy-as-new)])
 
 (rf/reg-sub

--- a/src/cljs/rems/administration/licenses.cljs
+++ b/src/cljs/rems/administration/licenses.cljs
@@ -58,7 +58,7 @@
 
 (defn- to-create-license []
   [atoms/link {:class "btn btn-primary"}
-   "/administration/create-license"
+   "/administration/licenses/create"
    (text :t.administration/create-license)])
 
 (defn- to-view-license [license-id]

--- a/src/cljs/rems/administration/resources.cljs
+++ b/src/cljs/rems/administration/resources.cljs
@@ -58,7 +58,7 @@
 
 (defn- to-create-resource []
   [atoms/link {:class "btn btn-primary"}
-   "/administration/create-resource"
+   "/administration/resources/create"
    (text :t.administration/create-resource)])
 
 (defn- to-view-resource [resource-id]

--- a/src/cljs/rems/administration/workflow.cljs
+++ b/src/cljs/rems/administration/workflow.cljs
@@ -43,7 +43,7 @@
 
 (defn edit-button [id]
   [atoms/link {:class "btn btn-primary"}
-   (str "/administration/edit-workflow/" id)
+   (str "/administration/workflows/edit/" id)
    (text :t.administration/edit)])
 
 (defn workflow-view [workflow language]

--- a/src/cljs/rems/administration/workflows.cljs
+++ b/src/cljs/rems/administration/workflows.cljs
@@ -59,7 +59,7 @@
 
 (defn- to-create-workflow []
   [atoms/link {:class "btn btn-primary"}
-   "/administration/create-workflow"
+   "/administration/workflows/create"
    (text :t.administration/create-workflow)])
 
 (defn- to-view-workflow [workflow-id]

--- a/src/cljs/rems/navbar.cljs
+++ b/src/cljs/rems/navbar.cljs
@@ -14,17 +14,22 @@
   [dest]
   (str (:root-path context) dest))
 
-(defn nav-link [path title & [active?]]
+(defn- nav-link-impl [path title & [active?]]
   [atoms/link {:class (str "nav-item nav-link" (if active? " active" ""))} (url-dest path) title])
 
-(defn nav-link+ [path title & [match-mode]]
+(defn nav-link
+  "A link to path that is shown as active when the current browser location matches the path.
+
+   By default checks if path is a prefix of location, but if match-mode is :exact,
+   checks that path is exactly location."
+  [path title & [match-mode]]
   (let [location @(rf/subscribe [:path])
         active? (case match-mode
                   :exact
                   (= location path)
                   ;; default: prefix
                   (str/starts-with? location path))]
-    [nav-link path title active?]))
+    [nav-link-impl path title active?]))
 
 (defn user-widget [user]
   (when user
@@ -43,22 +48,22 @@
         (let [url (or (page :url)
                       (str "/extra-pages/" (page :id)))
               text (get-in page [:translations language :title] (text :t/missing))]
-          [nav-link+ url text])))))
+          [nav-link url text])))))
 
 (defn navbar-items [e page-id identity]
   ;;TODO: get navigation options from subscription
   (let [roles (:roles identity)]
     [e (into [:div.navbar-nav.mr-auto
               (when (roles/is-logged-in? roles)
-                [nav-link+ "/catalogue" (text :t.navigation/catalogue)])
+                [nav-link "/catalogue" (text :t.navigation/catalogue)])
               (when (roles/show-applications? roles)
-                [nav-link+ "/applications" (text :t.navigation/applications)])
+                [nav-link "/applications" (text :t.navigation/applications)])
               (when (roles/show-reviews? roles)
-                [nav-link+ "/actions" (text :t.navigation/actions)])
+                [nav-link "/actions" (text :t.navigation/actions)])
               (when (roles/show-admin-pages? roles)
-                [nav-link+ "/administration" (text :t.navigation/administration)])
+                [nav-link "/administration" (text :t.navigation/administration)])
               (when-not (:user identity)
-                [nav-link+ "/" (text :t.navigation/home) :exact])]
+                [nav-link "/" (text :t.navigation/home) :exact])]
              (navbar-extra-pages page-id))
      [language-switcher]]))
 
@@ -93,6 +98,6 @@
   [:div
    (component-info nav-link)
    (example "nav-link"
-            [nav-link "example/path" "link text"])
+            [nav-link-impl "example/path" "link text"])
    (example "nav-link active"
-            [nav-link "example/path" "link text" "page-name" "page-name"])])
+            [nav-link-impl "example/path" "link text" true])])

--- a/src/cljs/rems/navbar.cljs
+++ b/src/cljs/rems/navbar.cljs
@@ -97,7 +97,9 @@
 (defn guide []
   [:div
    (component-info nav-link)
-   (example "nav-link"
-            [nav-link-impl "example/path" "link text"])
+   [:p "Here are examples of what the inactive and active nav-links look like."
+    "The examples use nav-link-impl because we can't fake the :path subscription."]
+   (example "nav-link inactive"
+            [nav-link-impl "example/path" "Link text" false])
    (example "nav-link active"
-            [nav-link-impl "example/path" "link text" true])])
+            [nav-link-impl "example/path" "Link text" true])])

--- a/src/cljs/rems/navbar.cljs
+++ b/src/cljs/rems/navbar.cljs
@@ -18,8 +18,7 @@
   [atoms/link {:class (str "nav-item nav-link" (if active? " active" ""))} (url-dest path) title])
 
 (defn nav-link+ [path title & [match-mode]]
-  (let [_redraw-when-page-changes @(rf/subscribe [:page]) ;; TODO: hack
-        location (.-pathname (.-location js/window))
+  (let [location @(rf/subscribe [:path])
         active? (case match-mode
                   :exact
                   (= location path)

--- a/src/cljs/rems/spa.cljs
+++ b/src/cljs/rems/spa.cljs
@@ -54,6 +54,11 @@
    (:page db)))
 
 (rf/reg-sub
+ :path
+ (fn [db _]
+   (or (:path db) "")))
+
+(rf/reg-sub
  :docs
  (fn [db _]
    (:docs db)))
@@ -85,6 +90,11 @@
  :set-active-page
  (fn [db [_ page]]
    (assoc db :page page)))
+
+(rf/reg-event-db
+ :set-path
+ (fn [db [_ path]]
+   (assoc db :path path)))
 
 (rf/reg-event-db
  :set-docs
@@ -423,6 +433,7 @@
                      ;; XXX: workaround for Secretary/Accountant considering URLs with different hash to be different pages
                      (let [url (js/URL. path js/location)
                            path-without-hash (str (.-pathname url) (.-search url))]
+                       (rf/dispatch [:set-path path-without-hash])
                        (when-not (= @previous-path path-without-hash)
                          (reset! previous-path path-without-hash)
                          (secretary/dispatch! path-without-hash)))))

--- a/src/cljs/rems/spa.cljs
+++ b/src/cljs/rems/spa.cljs
@@ -325,6 +325,18 @@
   (rf/dispatch [:rems.administration.catalogue-items/enter-page])
   (rf/dispatch [:set-active-page :rems.administration/catalogue-items]))
 
+(secretary/defroute "/administration/forms/create" []
+  (rf/dispatch [:rems.administration.create-form/enter-page])
+  (rf/dispatch [:set-active-page :rems.administration/create-form]))
+
+(secretary/defroute "/administration/forms/create/:form-id" [form-id]
+  (rf/dispatch [:rems.administration.create-form/enter-page (parse-int form-id)])
+  (rf/dispatch [:set-active-page :rems.administration/create-form]))
+
+(secretary/defroute "/administration/forms/edit/:form-id" [form-id]
+  (rf/dispatch [:rems.administration.create-form/enter-page (parse-int form-id) true])
+  (rf/dispatch [:set-active-page :rems.administration/create-form]))
+
 (secretary/defroute "/administration/forms/:form-id" [form-id]
   (rf/dispatch [:rems.administration.form/enter-page form-id])
   (rf/dispatch [:set-active-page :rems.administration/form]))
@@ -356,18 +368,6 @@
 (secretary/defroute "/administration/licenses" []
   (rf/dispatch [:rems.administration.licenses/enter-page])
   (rf/dispatch [:set-active-page :rems.administration/licenses]))
-
-(secretary/defroute "/administration/create-form" []
-  (rf/dispatch [:rems.administration.create-form/enter-page])
-  (rf/dispatch [:set-active-page :rems.administration/create-form]))
-
-(secretary/defroute "/administration/create-form/:form-id" [form-id]
-  (rf/dispatch [:rems.administration.create-form/enter-page (parse-int form-id)])
-  (rf/dispatch [:set-active-page :rems.administration/create-form]))
-
-(secretary/defroute "/administration/edit-form/:form-id" [form-id]
-  (rf/dispatch [:rems.administration.create-form/enter-page (parse-int form-id) true])
-  (rf/dispatch [:set-active-page :rems.administration/create-form]))
 
 (secretary/defroute "/administration/create-license" []
   (rf/dispatch [:rems.administration.create-license/enter-page])

--- a/src/cljs/rems/spa.cljs
+++ b/src/cljs/rems/spa.cljs
@@ -345,6 +345,10 @@
   (rf/dispatch [:rems.administration.forms/enter-page])
   (rf/dispatch [:set-active-page :rems.administration/forms]))
 
+(secretary/defroute "/administration/resources/create" []
+  (rf/dispatch [:rems.administration.create-resource/enter-page])
+  (rf/dispatch [:set-active-page :rems.administration/create-resource]))
+
 (secretary/defroute "/administration/resources/:resource-id" [resource-id]
   (rf/dispatch [:rems.administration.resource/enter-page resource-id])
   (rf/dispatch [:set-active-page :rems.administration/resource]))
@@ -361,6 +365,10 @@
   (rf/dispatch [:rems.administration.workflows/enter-page])
   (rf/dispatch [:set-active-page :rems.administration/workflows]))
 
+(secretary/defroute "/administration/licenses/create" []
+  (rf/dispatch [:rems.administration.create-license/enter-page])
+  (rf/dispatch [:set-active-page :rems.administration/create-license]))
+
 (secretary/defroute "/administration/licenses/:license-id" [license-id]
   (rf/dispatch [:rems.administration.license/enter-page license-id])
   (rf/dispatch [:set-active-page :rems.administration/license]))
@@ -368,14 +376,6 @@
 (secretary/defroute "/administration/licenses" []
   (rf/dispatch [:rems.administration.licenses/enter-page])
   (rf/dispatch [:set-active-page :rems.administration/licenses]))
-
-(secretary/defroute "/administration/create-license" []
-  (rf/dispatch [:rems.administration.create-license/enter-page])
-  (rf/dispatch [:set-active-page :rems.administration/create-license]))
-
-(secretary/defroute "/administration/create-resource" []
-  (rf/dispatch [:rems.administration.create-resource/enter-page])
-  (rf/dispatch [:set-active-page :rems.administration/create-resource]))
 
 (secretary/defroute "/administration/create-workflow" []
   (rf/dispatch [:rems.administration.create-workflow/enter-page])

--- a/src/cljs/rems/spa.cljs
+++ b/src/cljs/rems/spa.cljs
@@ -309,6 +309,14 @@
   (rf/dispatch [:rems.administration.blacklist/enter-page])
   (rf/dispatch [:set-active-page :rems.administration/blacklist]))
 
+(secretary/defroute "/administration/catalogue-items/create" []
+  (rf/dispatch [:rems.administration.create-catalogue-item/enter-page])
+  (rf/dispatch [:set-active-page :rems.administration/create-catalogue-item]))
+
+(secretary/defroute "/administration/catalogue-items/edit/:catalogue-item-id" [catalogue-item-id]
+  (rf/dispatch [:rems.administration.create-catalogue-item/enter-page (parse-int catalogue-item-id)])
+  (rf/dispatch [:set-active-page :rems.administration/create-catalogue-item]))
+
 (secretary/defroute "/administration/catalogue-items/:catalogue-item-id" [catalogue-item-id]
   (rf/dispatch [:rems.administration.catalogue-item/enter-page catalogue-item-id])
   (rf/dispatch [:set-active-page :rems.administration/catalogue-item]))
@@ -348,14 +356,6 @@
 (secretary/defroute "/administration/licenses" []
   (rf/dispatch [:rems.administration.licenses/enter-page])
   (rf/dispatch [:set-active-page :rems.administration/licenses]))
-
-(secretary/defroute "/administration/create-catalogue-item" []
-  (rf/dispatch [:rems.administration.create-catalogue-item/enter-page])
-  (rf/dispatch [:set-active-page :rems.administration/create-catalogue-item]))
-
-(secretary/defroute "/administration/edit-catalogue-item/:catalogue-item-id" [catalogue-item-id]
-  (rf/dispatch [:rems.administration.create-catalogue-item/enter-page (parse-int catalogue-item-id)])
-  (rf/dispatch [:set-active-page :rems.administration/create-catalogue-item]))
 
 (secretary/defroute "/administration/create-form" []
   (rf/dispatch [:rems.administration.create-form/enter-page])

--- a/src/cljs/rems/spa.cljs
+++ b/src/cljs/rems/spa.cljs
@@ -357,6 +357,14 @@
   (rf/dispatch [:rems.administration.resources/enter-page])
   (rf/dispatch [:set-active-page :rems.administration/resources]))
 
+(secretary/defroute "/administration/workflows/create" []
+  (rf/dispatch [:rems.administration.create-workflow/enter-page])
+  (rf/dispatch [:set-active-page :rems.administration/create-workflow]))
+
+(secretary/defroute "/administration/workflows/edit/:workflow-id" [workflow-id]
+  (rf/dispatch [:rems.administration.create-workflow/enter-page (parse-int workflow-id)])
+  (rf/dispatch [:set-active-page :rems.administration/create-workflow]))
+
 (secretary/defroute "/administration/workflows/:workflow-id" [workflow-id]
   (rf/dispatch [:rems.administration.workflow/enter-page workflow-id])
   (rf/dispatch [:set-active-page :rems.administration/workflow]))
@@ -376,14 +384,6 @@
 (secretary/defroute "/administration/licenses" []
   (rf/dispatch [:rems.administration.licenses/enter-page])
   (rf/dispatch [:set-active-page :rems.administration/licenses]))
-
-(secretary/defroute "/administration/create-workflow" []
-  (rf/dispatch [:rems.administration.create-workflow/enter-page])
-  (rf/dispatch [:set-active-page :rems.administration/create-workflow]))
-
-(secretary/defroute "/administration/edit-workflow/:workflow-id" [workflow-id]
-  (rf/dispatch [:rems.administration.create-workflow/enter-page (parse-int workflow-id)])
-  (rf/dispatch [:set-active-page :rems.administration/create-workflow]))
 
 (secretary/defroute "/extra-pages/:page-id" [page-id]
   (rf/dispatch [:rems.extra-pages/enter-page page-id])


### PR DESCRIPTION
Simplifies navigation code by checking the URL instead of re-frame `:page`. This means that the navigation hierarchy should be visible in the URLs, which is why some administration page URLs were changed.

In preparation for #1705.

# Definition of Done / Review checklist

## Reviewability
- [x] link to issue

## Documentation
- ~update changelog if necessary~
- [x] add or update docstrings for namespaces and functions
- [x] components are added to guide page

## Follow-up
- [x] no critical TODOs left to implement
