### PR TITLE
Show administration pages to handler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,7 @@ Changes since v2.4
 - Userid field in /api/entitlements response
 - Approver bot which approves applications automatically, unless the user+resource is blacklisted (#1660)
 - Administration view for blacklist
+- Read-only access to administration pages for handlers (#1705)
 
 ### Enhancements
 - Improved version information in footer

--- a/src/clj/rems/api/forms.clj
+++ b/src/clj/rems/api/forms.clj
@@ -30,7 +30,7 @@
 
     (GET "/" []
       :summary "Get forms"
-      :roles #{:owner}
+      :roles #{:owner :handler}
       :query-params [{disabled :- (describe s/Bool "whether to include disabled forms") false}
                      {archived :- (describe s/Bool "whether to include archived forms") false}]
       :return [FormTemplateOverview]
@@ -46,7 +46,7 @@
 
     (GET "/:form-id" []
       :summary "Get form by id"
-      :roles #{:owner}
+      :roles #{:owner :handler}
       :path-params [form-id :- (describe s/Int "form-id")]
       :return FormTemplate
       (let [form (form/get-form-template form-id)]

--- a/src/clj/rems/api/licenses.clj
+++ b/src/clj/rems/api/licenses.clj
@@ -42,7 +42,7 @@
 
     (GET "/" []
       :summary "Get licenses"
-      :roles #{:handler :owner}
+      :roles #{:owner :handler}
       :query-params [{disabled :- (describe s/Bool "whether to include disabled licenses") false}
                      {archived :- (describe s/Bool "whether to include archived licenses") false}]
       :return Licenses
@@ -51,7 +51,7 @@
 
     (GET "/:license-id" []
       :summary "Get license"
-      :roles #{:owner}
+      :roles #{:owner :handler}
       :path-params [license-id :- (describe s/Int "license id")]
       :return License
       (ok (licenses/get-license license-id)))

--- a/src/clj/rems/api/resources.clj
+++ b/src/clj/rems/api/resources.clj
@@ -38,7 +38,7 @@
 
     (GET "/" []
       :summary "Get resources"
-      :roles #{:owner}
+      :roles #{:owner :handler}
       :query-params [{disabled :- (describe s/Bool "whether to include disabled resources") false}
                      {archived :- (describe s/Bool "whether to include archived resources") false}]
       :return Resources
@@ -47,7 +47,7 @@
 
     (GET "/:resource-id" []
       :summary "Get resource by id"
-      :roles #{:owner}
+      :roles #{:owner :handler}
       :path-params [resource-id :- (describe s/Int "resource id")]
       :return Resource
       (ok (resource/get-resource resource-id)))

--- a/src/clj/rems/api/workflows.clj
+++ b/src/clj/rems/api/workflows.clj
@@ -33,7 +33,7 @@
 
     (GET "/" []
       :summary "Get workflows"
-      :roles #{:owner}
+      :roles #{:owner :handler}
       :query-params [{disabled :- (describe s/Bool "whether to include disabled workflows") false}
                      {archived :- (describe s/Bool "whether to include archived workflows") false}]
       :return [Workflow]
@@ -76,7 +76,7 @@
 
     (GET "/:workflow-id" []
       :summary "Get workflow by id"
-      :roles #{:owner}
+      :roles #{:owner :handler}
       :path-params [workflow-id :- (describe s/Int "workflow-id")]
       :return Workflow
       (ok (workflow/get-workflow workflow-id)))))

--- a/src/cljs/rems/administration/catalogue_item.cljs
+++ b/src/cljs/rems/administration/catalogue_item.cljs
@@ -7,6 +7,7 @@
             [rems.atoms :as atoms :refer [info-field readonly-checkbox document-title]]
             [rems.collapsible :as collapsible]
             [rems.flash-message :as flash-message]
+            [rems.roles :as roles]
             [rems.spinner :as spinner]
             [rems.text :refer [get-localized-title localize-time text text-format]]
             [rems.util :refer [fetch]]))
@@ -78,9 +79,10 @@
    (let [id (:id catalogue-item)]
      [:div.col.commands
       [back-button]
-      [edit-button id]
-      [status-flags/enabled-toggle catalogue-item #(rf/dispatch [:rems.administration.catalogue-items/set-catalogue-item-enabled %1 %2 [::enter-page id]])]
-      [status-flags/archived-toggle catalogue-item #(rf/dispatch [:rems.administration.catalogue-items/set-catalogue-item-archived %1 %2 [::enter-page id]])]])])
+      [roles/when roles/show-admin-edit-buttons?
+       [edit-button id]
+       [status-flags/enabled-toggle catalogue-item #(rf/dispatch [:rems.administration.catalogue-items/set-catalogue-item-enabled %1 %2 [::enter-page id]])]
+       [status-flags/archived-toggle catalogue-item #(rf/dispatch [:rems.administration.catalogue-items/set-catalogue-item-archived %1 %2 [::enter-page id]])]]])])
 
 (defn catalogue-item-page []
   (let [catalogue-item (rf/subscribe [::catalogue-item])

--- a/src/cljs/rems/administration/catalogue_items.cljs
+++ b/src/cljs/rems/administration/catalogue_items.cljs
@@ -5,6 +5,7 @@
             [rems.administration.status-flags :as status-flags]
             [rems.atoms :as atoms :refer [readonly-checkbox document-title]]
             [rems.flash-message :as flash-message]
+            [rems.roles :as roles]
             [rems.spinner :as spinner]
             [rems.table :as table]
             [rems.text :refer [localize-time text get-localized-title]]
@@ -105,9 +106,10 @@
                       :sort-value (if checked? 1 2)})
            :commands {:td [:td.commands
                            [to-catalogue-item (:id item)]
-                           [catalogue-item/edit-button (:id item)]
-                           [status-flags/enabled-toggle item #(rf/dispatch [::set-catalogue-item-enabled %1 %2 [::fetch-catalogue]])]
-                           [status-flags/archived-toggle item #(rf/dispatch [::set-catalogue-item-archived %1 %2 [::fetch-catalogue]])]]}})
+                           [roles/when roles/show-admin-edit-buttons?
+                            [catalogue-item/edit-button (:id item)]
+                            [status-flags/enabled-toggle item #(rf/dispatch [::set-catalogue-item-enabled %1 %2 [::fetch-catalogue]])]
+                            [status-flags/archived-toggle item #(rf/dispatch [::set-catalogue-item-archived %1 %2 [::fetch-catalogue]])]]]}})
         catalogue)))
 
 (defn- catalogue-list []
@@ -141,7 +143,8 @@
          [flash-message/component :top]]
         (if @(rf/subscribe [::loading?])
           [[spinner/big]]
-          [[to-create-catalogue-item]
-           [status-flags/display-archived-toggle #(rf/dispatch [::fetch-catalogue])]
-           [status-flags/disabled-and-archived-explanation]
+          [[roles/when roles/show-admin-edit-buttons?
+            [to-create-catalogue-item]
+            [status-flags/display-archived-toggle #(rf/dispatch [::fetch-catalogue])]
+            [status-flags/disabled-and-archived-explanation]]
            [catalogue-list]])))

--- a/src/cljs/rems/administration/form.cljs
+++ b/src/cljs/rems/administration/form.cljs
@@ -8,6 +8,7 @@
             [rems.collapsible :as collapsible]
             [rems.common-util :refer [andstr]]
             [rems.flash-message :as flash-message]
+            [rems.roles :as roles]
             [rems.spinner :as spinner]
             [rems.text :refer [text]]
             [rems.util :refer [navigate! fetch]]))
@@ -78,10 +79,11 @@
    (let [id (:form/id form)]
      [:div.col.commands
       [back-button]
-      [edit-button id]
-      [copy-as-new-button id]
-      [status-flags/enabled-toggle form #(rf/dispatch [:rems.administration.forms/set-form-enabled %1 %2 [::enter-page id]])]
-      [status-flags/archived-toggle form #(rf/dispatch [:rems.administration.forms/set-form-archived %1 %2 [::enter-page id]])]])
+      [roles/when roles/show-admin-edit-buttons?
+       [edit-button id]
+       [copy-as-new-button id]
+       [status-flags/enabled-toggle form #(rf/dispatch [:rems.administration.forms/set-form-enabled %1 %2 [::enter-page id]])]
+       [status-flags/archived-toggle form #(rf/dispatch [:rems.administration.forms/set-form-archived %1 %2 [::enter-page id]])]]])
    [form-preview form]])
 ;; TODO Do we support form licenses?
 

--- a/src/cljs/rems/administration/forms.cljs
+++ b/src/cljs/rems/administration/forms.cljs
@@ -5,6 +5,7 @@
             [rems.administration.status-flags :as status-flags]
             [rems.atoms :as atoms :refer [readonly-checkbox document-title]]
             [rems.flash-message :as flash-message]
+            [rems.roles :as roles]
             [rems.spinner :as spinner]
             [rems.table :as table]
             [rems.text :refer [text]]
@@ -89,10 +90,11 @@
                       :sort-value (if checked? 1 2)})
            :commands {:td [:td.commands
                            [to-view-form form]
-                           [form/edit-button (:form/id form)]
-                           [copy-as-new-form form]
-                           [status-flags/enabled-toggle form #(rf/dispatch [::set-form-enabled %1 %2 [::fetch-forms]])]
-                           [status-flags/archived-toggle form #(rf/dispatch [::set-form-archived %1 %2 [::fetch-forms]])]]}})
+                           [roles/when roles/show-admin-edit-buttons?
+                            [form/edit-button (:form/id form)]
+                            [copy-as-new-form form]
+                            [status-flags/enabled-toggle form #(rf/dispatch [::set-form-enabled %1 %2 [::fetch-forms]])]
+                            [status-flags/archived-toggle form #(rf/dispatch [::set-form-archived %1 %2 [::fetch-forms]])]]]}})
         forms)))
 
 (defn- forms-list []
@@ -120,7 +122,8 @@
          [flash-message/component :top]]
         (if @(rf/subscribe [::loading?])
           [[spinner/big]]
-          [[to-create-form]
-           [status-flags/display-archived-toggle #(rf/dispatch [::fetch-forms])]
-           [status-flags/disabled-and-archived-explanation]
+          [[roles/when roles/show-admin-edit-buttons?
+            [to-create-form]
+            [status-flags/display-archived-toggle #(rf/dispatch [::fetch-forms])]
+            [status-flags/disabled-and-archived-explanation]]
            [forms-list]])))

--- a/src/cljs/rems/administration/license.cljs
+++ b/src/cljs/rems/administration/license.cljs
@@ -7,6 +7,7 @@
             [rems.atoms :as atoms :refer [attachment-link external-link readonly-checkbox document-title]]
             [rems.collapsible :as collapsible]
             [rems.flash-message :as flash-message]
+            [rems.roles :as roles]
             [rems.spinner :as spinner]
             [rems.text :refer [get-localized-title localize-time text text-format]]
             [rems.util :refer [navigate! fetch]]))
@@ -76,8 +77,9 @@
    (let [id (:id license)]
      [:div.col.commands
       [back-button]
-      [status-flags/enabled-toggle license #(rf/dispatch [:rems.administration.licenses/set-license-enabled %1 %2 [::enter-page id]])]
-      [status-flags/archived-toggle license #(rf/dispatch [:rems.administration.licenses/set-license-archived %1 %2 [::enter-page id]])]])])
+      [roles/when roles/show-admin-edit-buttons?
+       [status-flags/enabled-toggle license #(rf/dispatch [:rems.administration.licenses/set-license-enabled %1 %2 [::enter-page id]])]
+       [status-flags/archived-toggle license #(rf/dispatch [:rems.administration.licenses/set-license-archived %1 %2 [::enter-page id]])]]])])
 
 ;; XXX: Duplicates much of license-view. One notable difference is that
 ;;      here the license text is only shown in the current language.

--- a/src/cljs/rems/administration/licenses.cljs
+++ b/src/cljs/rems/administration/licenses.cljs
@@ -4,6 +4,7 @@
             [rems.administration.status-flags :as status-flags]
             [rems.atoms :as atoms :refer [readonly-checkbox document-title]]
             [rems.flash-message :as flash-message]
+            [rems.roles :as roles]
             [rems.spinner :as spinner]
             [rems.table :as table]
             [rems.text :refer [localize-time text get-localized-title]]
@@ -82,8 +83,9 @@
                       :sort-value (if checked? 1 2)})
            :commands {:td [:td.commands
                            [to-view-license (:id license)]
-                           [status-flags/enabled-toggle license #(rf/dispatch [::set-license-enabled %1 %2 [::fetch-licenses]])]
-                           [status-flags/archived-toggle license #(rf/dispatch [::set-license-archived %1 %2 [::fetch-licenses]])]]}})
+                           [roles/when roles/show-admin-edit-buttons?
+                            [status-flags/enabled-toggle license #(rf/dispatch [::set-license-enabled %1 %2 [::fetch-licenses]])]
+                            [status-flags/archived-toggle license #(rf/dispatch [::set-license-archived %1 %2 [::fetch-licenses]])]]]}})
         licenses)))
 
 (defn- licenses-list []
@@ -111,7 +113,8 @@
          [flash-message/component :top]]
         (if @(rf/subscribe [::loading?])
           [[spinner/big]]
-          [[to-create-license]
-           [status-flags/display-archived-toggle #(rf/dispatch [::fetch-licenses])]
-           [status-flags/disabled-and-archived-explanation]
+          [[roles/when roles/show-admin-edit-buttons?
+            [to-create-license]
+            [status-flags/display-archived-toggle #(rf/dispatch [::fetch-licenses])]
+            [status-flags/disabled-and-archived-explanation]]
            [licenses-list]])))

--- a/src/cljs/rems/administration/resource.cljs
+++ b/src/cljs/rems/administration/resource.cljs
@@ -8,6 +8,7 @@
             [rems.collapsible :as collapsible]
             [rems.common-util :refer [andstr]]
             [rems.flash-message :as flash-message]
+            [rems.roles :as roles]
             [rems.spinner :as spinner]
             [rems.text :refer [text]]
             [rems.util :refer [fetch]]))
@@ -53,8 +54,9 @@
    (let [id (:id resource)]
      [:div.col.commands
       [back-button]
-      [status-flags/enabled-toggle resource #(rf/dispatch [:rems.administration.resources/set-resource-enabled %1 %2 [::enter-page id]])]
-      [status-flags/archived-toggle resource #(rf/dispatch [:rems.administration.resources/set-resource-archived %1 %2 [::enter-page id]])]])])
+      [roles/when roles/show-admin-edit-buttons?
+       [status-flags/enabled-toggle resource #(rf/dispatch [:rems.administration.resources/set-resource-enabled %1 %2 [::enter-page id]])]
+       [status-flags/archived-toggle resource #(rf/dispatch [:rems.administration.resources/set-resource-archived %1 %2 [::enter-page id]])]]])])
 
 (defn resource-page []
   (let [resource (rf/subscribe [::resource])

--- a/src/cljs/rems/administration/resources.cljs
+++ b/src/cljs/rems/administration/resources.cljs
@@ -4,6 +4,7 @@
             [rems.administration.status-flags :as status-flags]
             [rems.atoms :as atoms :refer [readonly-checkbox document-title]]
             [rems.flash-message :as flash-message]
+            [rems.roles :as roles]
             [rems.spinner :as spinner]
             [rems.table :as table]
             [rems.text :refer [text]]
@@ -81,8 +82,9 @@
                       :sort-value (if checked? 1 2)})
            :commands {:td [:td.commands
                            [to-view-resource (:id resource)]
-                           [status-flags/enabled-toggle resource #(rf/dispatch [::set-resource-enabled %1 %2 [::fetch-resources]])]
-                           [status-flags/archived-toggle resource #(rf/dispatch [::set-resource-archived %1 %2 [::fetch-resources]])]]}})
+                           [roles/when roles/show-admin-edit-buttons?
+                            [status-flags/enabled-toggle resource #(rf/dispatch [::set-resource-enabled %1 %2 [::fetch-resources]])]
+                            [status-flags/archived-toggle resource #(rf/dispatch [::set-resource-archived %1 %2 [::fetch-resources]])]]]}})
         resources)))
 
 (defn- resources-list []
@@ -110,7 +112,8 @@
          [flash-message/component :top]]
         (if @(rf/subscribe [::loading?])
           [[spinner/big]]
-          [[to-create-resource]
-           [status-flags/display-archived-toggle #(rf/dispatch [::fetch-resources])]
-           [status-flags/disabled-and-archived-explanation]
+          [[roles/when roles/show-admin-edit-buttons?
+            [to-create-resource]
+            [status-flags/display-archived-toggle #(rf/dispatch [::fetch-resources])]
+            [status-flags/disabled-and-archived-explanation]]
            [resources-list]])))

--- a/src/cljs/rems/administration/workflow.cljs
+++ b/src/cljs/rems/administration/workflow.cljs
@@ -9,6 +9,7 @@
             [rems.collapsible :as collapsible]
             [rems.common-util :refer [andstr]]
             [rems.flash-message :as flash-message]
+            [rems.roles :as roles]
             [rems.spinner :as spinner]
             [rems.text :refer [get-localized-title text text-format]]
             [rems.util :refer [navigate! fetch]]))
@@ -68,9 +69,10 @@
    (let [id (:id workflow)]
      [:div.col.commands
       [back-button]
-      [edit-button id]
-      [status-flags/enabled-toggle workflow #(rf/dispatch [:rems.administration.workflows/set-workflow-enabled %1 %2 [::enter-page id]])]
-      [status-flags/archived-toggle workflow #(rf/dispatch [:rems.administration.workflows/set-workflow-archived %1 %2 [::enter-page id]])]])])
+      [roles/when roles/show-admin-edit-buttons?
+       [edit-button id]
+       [status-flags/enabled-toggle workflow #(rf/dispatch [:rems.administration.workflows/set-workflow-enabled %1 %2 [::enter-page id]])]
+       [status-flags/archived-toggle workflow #(rf/dispatch [:rems.administration.workflows/set-workflow-archived %1 %2 [::enter-page id]])]]])])
 
 (defn workflow-page []
   (let [workflow (rf/subscribe [::workflow])

--- a/src/cljs/rems/administration/workflows.cljs
+++ b/src/cljs/rems/administration/workflows.cljs
@@ -5,6 +5,7 @@
             [rems.administration.workflow :as workflow]
             [rems.atoms :as atoms :refer [readonly-checkbox document-title]]
             [rems.flash-message :as flash-message]
+            [rems.roles :as roles]
             [rems.spinner :as spinner]
             [rems.table :as table]
             [rems.text :refer [text]]
@@ -82,9 +83,10 @@
                       :sort-value (if checked? 1 2)})
            :commands {:td [:td.commands
                            [to-view-workflow (:id workflow)]
-                           [workflow/edit-button (:id workflow)]
-                           [status-flags/enabled-toggle workflow #(rf/dispatch [::set-workflow-enabled %1 %2 [::fetch-workflows]])]
-                           [status-flags/archived-toggle workflow #(rf/dispatch [::set-workflow-archived %1 %2 [::fetch-workflows]])]]}})
+                           [roles/when roles/show-admin-edit-buttons?
+                            [workflow/edit-button (:id workflow)]
+                            [status-flags/enabled-toggle workflow #(rf/dispatch [::set-workflow-enabled %1 %2 [::fetch-workflows]])]
+                            [status-flags/archived-toggle workflow #(rf/dispatch [::set-workflow-archived %1 %2 [::fetch-workflows]])]]]}})
         workflows)))
 
 (defn- workflows-list []
@@ -113,7 +115,8 @@
          [flash-message/component :top]]
         (if @(rf/subscribe [::loading?])
           [[spinner/big]]
-          [[to-create-workflow]
-           [status-flags/display-archived-toggle #(rf/dispatch [::fetch-workflows])]
-           [status-flags/disabled-and-archived-explanation]
+          [[roles/when roles/show-admin-edit-buttons?
+            [to-create-workflow]
+            [status-flags/display-archived-toggle #(rf/dispatch [::fetch-workflows])]
+            [status-flags/disabled-and-archived-explanation]]
            [workflows-list]])))

--- a/src/cljs/rems/roles.cljs
+++ b/src/cljs/rems/roles.cljs
@@ -1,4 +1,6 @@
-(ns rems.roles)
+(ns rems.roles
+  (:refer-clojure :exclude [when])
+  (:require [re-frame.core :as rf]))
 
 (defn is-logged-in? [roles]
   (some #{:logged-in} roles))
@@ -14,3 +16,10 @@
 
 (defn show-admin-pages? [roles]
   (some #{:owner :handler} roles))
+
+(defn show-admin-edit-buttons? [roles]
+  (some #{:owner} roles))
+
+(defn when [predicate & body]
+  (clojure.core/when (predicate (:roles @(rf/subscribe [:identity])))
+    (into [:<>] body)))

--- a/src/cljs/rems/roles.cljs
+++ b/src/cljs/rems/roles.cljs
@@ -13,4 +13,4 @@
   (some #{:handler :commenter :decider :past-commenter :past-decider} roles))
 
 (defn show-admin-pages? [roles]
-  (some #{:owner} roles))
+  (some #{:owner :handler} roles))


### PR DESCRIPTION
Show all the administration pages to the handler, and give read-only access to the administration APIs.

Closes #1705.

# Definition of Done / Review checklist

## Reviewability
- [x] link to issue

## Documentation
- [x] update changelog if necessary

## Follow-up
- [x] new tasks are created for pending or remaining tasks
- [x] no critical TODOs left to implement
