### PR TITLE
Use checkbox in archived

### DIFF
--- a/src/clj/rems/guide_macros.clj
+++ b/src/clj/rems/guide_macros.clj
@@ -65,4 +65,4 @@
                     (if (static-hiccup? block)
                       block
                       [:pre (with-out-str (write block :dispatch code-dispatch))])))]
-    `(rems.guide-functions/render-example ~title ~src (do ~@content))))
+    `[rems.guide-functions/render-example ~title ~src (do ~@content)]))

--- a/src/cljs/rems/administration/catalogue_item.cljs
+++ b/src/cljs/rems/administration/catalogue_item.cljs
@@ -74,7 +74,7 @@
                        (:form-name catalogue-item)]]
                      [inline-info-field (text :t.administration/start) (localize-time (:start catalogue-item))]
                      [inline-info-field (text :t.administration/end) (localize-time (:end catalogue-item))]
-                     [inline-info-field (text :t.administration/active) [readonly-checkbox (status-flags/active? catalogue-item)]]]))}]
+                     [inline-info-field (text :t.administration/active) [readonly-checkbox {:value (status-flags/active? catalogue-item)}]]]))}]
    (let [id (:id catalogue-item)]
      [:div.col.commands
       [back-button]

--- a/src/cljs/rems/administration/catalogue_items.cljs
+++ b/src/cljs/rems/administration/catalogue_items.cljs
@@ -101,7 +101,7 @@
                        :display-value (localize-time value)})
            :active (let [checked? (status-flags/active? item)]
                      {:td [:td.active
-                           [readonly-checkbox checked?]]
+                           [readonly-checkbox {:value checked?}]]
                       :sort-value (if checked? 1 2)})
            :commands {:td [:td.commands
                            [to-catalogue-item (:id item)]

--- a/src/cljs/rems/administration/form.cljs
+++ b/src/cljs/rems/administration/form.cljs
@@ -74,7 +74,7 @@
      :always [:div
               [inline-info-field (text :t.administration/organization) (:form/organization form)]
               [inline-info-field (text :t.administration/title) (:form/title form)]
-              [inline-info-field (text :t.administration/active) [readonly-checkbox (status-flags/active? form)]]]}]
+              [inline-info-field (text :t.administration/active) [readonly-checkbox {:value (status-flags/active? form)}]]]}]
    (let [id (:form/id form)]
      [:div.col.commands
       [back-button]

--- a/src/cljs/rems/administration/forms.cljs
+++ b/src/cljs/rems/administration/forms.cljs
@@ -85,7 +85,7 @@
            :title {:value (:form/title form)}
            :active (let [checked? (status-flags/active? form)]
                      {:td [:td.active
-                           [readonly-checkbox checked?]]
+                           [readonly-checkbox {:value checked?}]]
                       :sort-value (if checked? 1 2)})
            :commands {:td [:td.commands
                            [to-view-form form]

--- a/src/cljs/rems/administration/license.cljs
+++ b/src/cljs/rems/administration/license.cljs
@@ -72,7 +72,7 @@
                                 " (" (str/upper-case (name langcode)) ")")
                            [attachment-link (:attachment-id localization) (:title localization)]
                            {:box? false}])))
-                    [[inline-info-field (text :t.administration/active) [readonly-checkbox (status-flags/active? license)]]]))}]
+                    [[inline-info-field (text :t.administration/active) [readonly-checkbox {:value (status-flags/active? license)}]]]))}]
    (let [id (:id license)]
      [:div.col.commands
       [back-button]

--- a/src/cljs/rems/administration/licenses.cljs
+++ b/src/cljs/rems/administration/licenses.cljs
@@ -78,7 +78,7 @@
            :type {:value (:licensetype license)}
            :active (let [checked? (status-flags/active? license)]
                      {:td [:td.active
-                           [readonly-checkbox checked?]]
+                           [readonly-checkbox {:value checked?}]]
                       :sort-value (if checked? 1 2)})
            :commands {:td [:td.commands
                            [to-view-license (:id license)]

--- a/src/cljs/rems/administration/resource.cljs
+++ b/src/cljs/rems/administration/resource.cljs
@@ -48,7 +48,7 @@
      :always [:div
               [inline-info-field (text :t.administration/organization) (:organization resource)]
               [inline-info-field (text :t.administration/resource) (:resid resource)]
-              [inline-info-field (text :t.administration/active) [readonly-checkbox (status-flags/active? resource)]]]}]
+              [inline-info-field (text :t.administration/active) [readonly-checkbox {:value (status-flags/active? resource)}]]]}]
    [licenses-view (:licenses resource) language]
    (let [id (:id resource)]
      [:div.col.commands

--- a/src/cljs/rems/administration/resources.cljs
+++ b/src/cljs/rems/administration/resources.cljs
@@ -77,7 +77,7 @@
            :title {:value (:resid resource)}
            :active (let [checked? (status-flags/active? resource)]
                      {:td [:td.active
-                           [readonly-checkbox checked?]]
+                           [readonly-checkbox {:value checked?}]]
                       :sort-value (if checked? 1 2)})
            :commands {:td [:td.commands
                            [to-view-resource (:id resource)]

--- a/src/cljs/rems/administration/status_flags.cljs
+++ b/src/cljs/rems/administration/status_flags.cljs
@@ -51,16 +51,15 @@
 
 (defn display-archived-toggle [on-change]
   (let [display-archived? @(rf/subscribe [::display-archived?])
-        on-change (fn [value]
-                    (rf/dispatch [::set-display-archived? value])
-                    (when on-change
-                      (on-change)))]
+        on-change (fn []
+                    (rf/dispatch [::set-display-archived? (not display-archived?)])
+                    (when on-change (on-change)))]
     [:div.form-check.form-check-inline {:style {:float "right"}}
      [checkbox {:id :display-archived
                 :class :form-check-input
                 :value display-archived?
-                :on-change #(on-change (not display-archived?))}]
-     [:label.form-check-label {:for :display-archived :on-click #(on-change (not display-archived?))}
+                :on-change on-change}]
+     [:label.form-check-label {:for :display-archived :on-click on-change}
       (text :t.administration/display-archived)]]))
 
 (defn disabled-and-archived-explanation []

--- a/src/cljs/rems/administration/status_flags.cljs
+++ b/src/cljs/rems/administration/status_flags.cljs
@@ -1,5 +1,6 @@
 (ns rems.administration.status-flags
   (:require [re-frame.core :as rf]
+            [rems.atoms :refer [checkbox]]
             [rems.text :refer [text get-localized-title]]))
 
 (defn- disable-button [item on-change]
@@ -55,11 +56,11 @@
                     (when on-change
                       (on-change)))]
     [:div.form-check.form-check-inline {:style {:float "right"}}
-     [:input.form-check-input {:type "checkbox"
-                               :id "display-archived"
-                               :checked display-archived?
-                               :on-change #(on-change (not display-archived?))}]
-     [:label.form-check-label {:for "display-archived"}
+     [checkbox {:id :display-archived
+                :class :form-check-input
+                :value display-archived?
+                :on-change #(on-change (not display-archived?))}]
+     [:label.form-check-label {:for :display-archived :on-click #(on-change (not display-archived?))}
       (text :t.administration/display-archived)]]))
 
 (defn disabled-and-archived-explanation []

--- a/src/cljs/rems/administration/workflow.cljs
+++ b/src/cljs/rems/administration/workflow.cljs
@@ -63,7 +63,7 @@
                                                                          (map enrich-user)
                                                                          (map :display)
                                                                          (str/join ", "))]
-              [inline-info-field (text :t.administration/active) [readonly-checkbox (status-flags/active? workflow)]]]}]
+              [inline-info-field (text :t.administration/active) [readonly-checkbox {:value (status-flags/active? workflow)}]]]}]
    [licenses-view (:licenses workflow) language]
    (let [id (:id workflow)]
      [:div.col.commands

--- a/src/cljs/rems/administration/workflows.cljs
+++ b/src/cljs/rems/administration/workflows.cljs
@@ -78,7 +78,7 @@
            :title {:value (:title workflow)}
            :active (let [checked? (status-flags/active? workflow)]
                      {:td [:td.active
-                           [readonly-checkbox checked?]]
+                           [readonly-checkbox {:value checked?}]]
                       :sort-value (if checked? 1 2)})
            :commands {:td [:td.commands
                            [to-view-workflow (:id workflow)]

--- a/src/cljs/rems/application.cljs
+++ b/src/cljs/rems/application.cljs
@@ -556,7 +556,7 @@
                (when-let [name (get-member-name attributes)]
                  [info-field (text :t.applicant-info/name) name {:inline? true}])
                (when-not (nil? accepted-licenses?)
-                 [info-field (text :t.form/accepted-licenses) [readonly-checkbox accepted-licenses?] {:inline? true}])]
+                 [info-field (text :t.form/accepted-licenses) [readonly-checkbox {:value accepted-licenses?}] {:inline? true}])]
       :collapse (into [:div
                        (when user-id
                          [info-field (text :t.applicant-info/username) user-id {:inline? true}])

--- a/src/cljs/rems/atoms.cljs
+++ b/src/cljs/rems/atoms.cljs
@@ -61,20 +61,22 @@
 
 (defn checkbox
   "Displays a checkbox."
-  [{:keys [value on-change]}]
+  [{:keys [id class value on-change]}]
   (let [wrapped-on-change (fn [e]
                             (.preventDefault e)
                             (.stopPropagation e)
                             (when on-change
                               (on-change value)))]
-    [:i.far.fa-lg {:class [(if value :fa-check-square :fa-square) (when-not on-change :readonly-checkbox)]
-                   :tabIndex 0
-                   :role :checkbox
-                   :aria-checked value
-                   :aria-label (if value (text :t.form/checkbox-checked) (text :t.form/checkbox-unchecked))
-                   :on-click wrapped-on-change
-                   :on-key-press #(when (= (.-key %) " ")
-                                    (wrapped-on-change %))}]))
+    [:i.far.fa-lg
+     {:id id
+      :class [class (if value :fa-check-square :fa-square) (when-not on-change :readonly-checkbox)]
+      :tabIndex 0
+      :role :checkbox
+      :aria-checked value
+      :aria-label (if value (text :t.form/checkbox-checked) (text :t.form/checkbox-unchecked))
+      :on-click wrapped-on-change
+      :on-key-press #(when (= (.-key %) " ")
+                       (wrapped-on-change %))}]))
 
 (defn readonly-checkbox
   "Displays a readonly checkbox."
@@ -150,6 +152,8 @@
                 [readonly-checkbox {:value true}])
        (example (str "checkbox interactive " (if @state "checked" "unchecked"))
                 [checkbox {:value @state :on-change on-change}])
+       (example "checkbox with id and class"
+                [checkbox {:id :special :class :text-danger :value @state :on-change on-change}])
        (component-info info-field)
        (example "info-field with data"
                 [info-field "Name" "Bob Tester"])

--- a/src/cljs/rems/atoms.cljs
+++ b/src/cljs/rems/atoms.cljs
@@ -61,25 +61,25 @@
 
 (defn checkbox
   "Displays a checkbox."
-  [checked? on-change]
+  [{:keys [value on-change]}]
   (let [wrapped-on-change (fn [e]
                             (.preventDefault e)
                             (.stopPropagation e)
                             (when on-change
-                              (on-change checked?)))]
-    [:i.far.fa-lg {:class [(if checked? :fa-check-square :fa-square) (when-not on-change :readonly-checkbox)]
+                              (on-change value)))]
+    [:i.far.fa-lg {:class [(if value :fa-check-square :fa-square) (when-not on-change :readonly-checkbox)]
                    :tabIndex 0
                    :role :checkbox
-                   :aria-checked checked?
-                   :aria-label (if checked? (text :t.form/checkbox-checked) (text :t.form/checkbox-unchecked))
+                   :aria-checked value
+                   :aria-label (if value (text :t.form/checkbox-checked) (text :t.form/checkbox-unchecked))
                    :on-click wrapped-on-change
                    :on-key-press #(when (= (.-key %) " ")
                                     (wrapped-on-change %))}]))
 
 (defn readonly-checkbox
   "Displays a readonly checkbox."
-  [checked?]
-  [checkbox checked? nil])
+  [{:keys [value]}]
+  [checkbox {:value value}])
 
 (defn info-field
   "A component that shows a readonly field with title and value.
@@ -145,11 +145,11 @@
                                 :contents "You fail"}])
        (component-info readonly-checkbox)
        (example "readonly-checkbox unchecked"
-                [readonly-checkbox false])
+                [readonly-checkbox {:value false}])
        (example "readonly-checkbox checked"
-                [readonly-checkbox true])
+                [readonly-checkbox {:value true}])
        (example "checkbox interactive unchecked"
-                [checkbox @state on-change])
+                [checkbox {:value @state :on-change on-change}])
        (component-info info-field)
        (example "info-field with data"
                 [info-field "Name" "Bob Tester"])

--- a/src/cljs/rems/atoms.cljs
+++ b/src/cljs/rems/atoms.cljs
@@ -148,7 +148,7 @@
                 [readonly-checkbox {:value false}])
        (example "readonly-checkbox checked"
                 [readonly-checkbox {:value true}])
-       (example "checkbox interactive unchecked"
+       (example (str "checkbox interactive " (if @state "checked" "unchecked"))
                 [checkbox {:value @state :on-change on-change}])
        (component-info info-field)
        (example "info-field with data"


### PR DESCRIPTION
Improve the checkbox and use it in display archived for the admin.

![checkbox_with](https://user-images.githubusercontent.com/823661/67952317-cdcf8780-fbf5-11e9-9924-c3488cc4c753.png)
![display_archived](https://user-images.githubusercontent.com/823661/67952320-ce681e00-fbf5-11e9-9f0f-32f4f3c3ed46.png)


## Reviewability
- [x] consider adding screenshots for ease of review

## Documentation
- [x] update changelog if necessary
- [x] add or update docstrings for namespaces and functions
- [x] components are added to guide page
