### PR TITLE
fix: fix redirect loop when session has expired

### DIFF
--- a/src/cljs/rems/spa.cljs
+++ b/src/cljs/rems/spa.cljs
@@ -41,7 +41,7 @@
             [rems.roles :as roles]
             [rems.text :refer [text]]
             [rems.user-settings :refer [fetch-user-settings!]]
-            [rems.util :refer [navigate! fetch parse-int]]
+            [rems.util :refer [navigate! fetch parse-int set-location!]]
             [secretary.core :as secretary])
   (:require-macros [rems.read-gitlog :refer [read-current-version]])
   (:import goog.history.Html5History))
@@ -116,7 +116,7 @@
  (fn [_ [_ current-url]]
    (println "Received unauthorized from" current-url)
    (.setItem js/sessionStorage "rems-redirect-url" current-url)
-   (navigate! "/")
+   (set-location! "/") ;; we want to refresh identity
    {}))
 
 (rf/reg-event-fx

--- a/src/cljs/rems/util.cljs
+++ b/src/cljs/rems/util.cljs
@@ -44,6 +44,11 @@
   [url]
   (accountant/navigate! url))
 
+(defn set-location!
+  "Sets the browser URL. We use this to force a reload when e.g. the identity changes."
+  [location]
+  (set! (.-location js/window) location))
+
 (defn unauthorized! []
   (rf/dispatch [:unauthorized! (.. js/window -location -href)]))
 


### PR DESCRIPTION
force a page reload to get an up-to-date identity from the
server (that is, notice when our identity has disappeared)

fixes #1755