### PR TITLE
change format of blacklist API

### DIFF
--- a/resources/sql/queries.sql
+++ b/resources/sql/queries.sql
@@ -522,10 +522,10 @@ VALUES (:eventdata::jsonb);
 SELECT id, eventdata::text FROM blacklist_event
 WHERE 1=1
 /*~ (when (:resource params) */
-  AND eventdata->>'blacklist/resource' = :resource
+  AND eventdata->>'resource/ext-id' = :resource
 /*~ ) ~*/
 /*~ (when (:user params) */
-  AND eventdata->>'blacklist/user' = :user
+  AND eventdata->>'userid' = :user
 /*~ ) ~*/
 ORDER BY id ASC
 ;

--- a/src/clj/rems/api/blacklist.clj
+++ b/src/clj/rems/api/blacklist.clj
@@ -33,8 +33,8 @@
       :query-params [{user :- blacklist/UserId nil}
                      {resource :- blacklist/ResourceId nil}]
       :return schema/Blacklist
-      (->> (blacklist/get-blacklist {:blacklist/user user ;; TODO change these keys
-                                     :blacklist/resource resource})
+      (->> (blacklist/get-blacklist {:userid user
+                                     :resource/ext-id resource})
            (mapv format-blacklist-entry)
            (ok)))
     (POST "/add" []

--- a/src/clj/rems/api/blacklist.clj
+++ b/src/clj/rems/api/blacklist.clj
@@ -9,23 +9,23 @@
             [schema.core :as s]))
 
 (s/defschema BlacklistCommand
-  {:resource blacklist/ResourceId
-   :user blacklist/UserId
+  {:blacklist/resource {:resource/ext-id blacklist/ResourceId}
+   :blacklist/user {:userid blacklist/UserId}
    :comment s/Str})
 
 (s/defschema BlacklistResponse
-  [{:resource blacklist/ResourceId
-    :user schema/UserWithAttributes}])
+  [{:blacklist/resource {:resource/ext-id blacklist/ResourceId}
+    :blacklist/user schema/UserWithAttributes}])
 
 (defn- command->event [command]
   {:event/actor (getx-user-id)
    :event/time (time/now)
-   :blacklist/user (:user command)
-   :blacklist/resource (:resource command)
+   :blacklist/user (get-in command [:blacklist/user :userid])
+   :blacklist/resource (get-in command [:blacklist/resource :resource/ext-id])
    :event/comment (:comment command)})
 
 (defn- format-blacklist-entry [entry]
-  (update entry :user users/get-user))
+  (update entry :blacklist/user users/get-user))
 
 (def blacklist-api
   (context "/blacklist" []

--- a/src/clj/rems/api/blacklist.clj
+++ b/src/clj/rems/api/blacklist.clj
@@ -13,10 +13,6 @@
    :blacklist/user {:userid blacklist/UserId}
    :comment s/Str})
 
-(s/defschema BlacklistResponse
-  [{:blacklist/resource {:resource/ext-id blacklist/ResourceId}
-    :blacklist/user schema/UserWithAttributes}])
-
 (defn- command->event [command]
   {:event/actor (getx-user-id)
    :event/time (time/now)
@@ -35,7 +31,7 @@
       :roles #{:handler :owner :reporter}
       :query-params [{user :- blacklist/UserId nil}
                      {resource :- blacklist/ResourceId nil}]
-      :return BlacklistResponse
+      :return schema/Blacklist
       (->> (blacklist/get-blacklist {:blacklist/user user
                                      :blacklist/resource resource})
            (mapv format-blacklist-entry)

--- a/src/clj/rems/api/blacklist.clj
+++ b/src/clj/rems/api/blacklist.clj
@@ -16,12 +16,13 @@
 (defn- command->event [command]
   {:event/actor (getx-user-id)
    :event/time (time/now)
-   :blacklist/user (get-in command [:blacklist/user :userid])
-   :blacklist/resource (get-in command [:blacklist/resource :resource/ext-id])
+   :userid (get-in command [:blacklist/user :userid])
+   :resource/ext-id (get-in command [:blacklist/resource :resource/ext-id])
    :event/comment (:comment command)})
 
 (defn- format-blacklist-entry [entry]
-  (update entry :blacklist/user users/get-user))
+  {:blacklist/resource {:resource/ext-id (:resource/ext-id entry)}
+   :blacklist/user (users/get-user (:userid entry))})
 
 (def blacklist-api
   (context "/blacklist" []
@@ -32,7 +33,7 @@
       :query-params [{user :- blacklist/UserId nil}
                      {resource :- blacklist/ResourceId nil}]
       :return schema/Blacklist
-      (->> (blacklist/get-blacklist {:blacklist/user user
+      (->> (blacklist/get-blacklist {:blacklist/user user ;; TODO change these keys
                                      :blacklist/resource resource})
            (mapv format-blacklist-entry)
            (ok)))

--- a/src/clj/rems/api/schema.clj
+++ b/src/clj/rems/api/schema.clj
@@ -173,6 +173,13 @@
    :attachment/filename s/Str
    :attachment/type s/Str})
 
+(s/defschema BlacklistEntry
+  {:blacklist/user UserWithAttributes
+   :blacklist/resource {:resource/ext-id s/Str}})
+
+(s/defschema Blacklist
+  [BlacklistEntry])
+
 (s/defschema Application
   {:application/id s/Int
    :application/external-id s/Str
@@ -197,8 +204,7 @@
    :application/invited-members #{{:name s/Str
                                    :email s/Str}}
    (s/optional-key :application/blacklist) (rjs/field
-                                            [{:blacklist/user UserWithAttributes
-                                              :blacklist/resource {:resource/ext-id s/Str}}]
+                                            Blacklist
                                             {:description "Which members of this application are blacklisted for which resources"})
    :application/resources [V2Resource]
    :application/licenses [V2License]

--- a/src/clj/rems/db/blacklist.clj
+++ b/src/clj/rems/db/blacklist.clj
@@ -51,7 +51,6 @@
 (defn- events->blacklist [events]
   ;; TODO: move computation to db for performance
   ;; should be enough to check latest event per user-resource pair
-  (prn :EVENTS events)
   (reduce (fn [blacklist event]
             (let [entry (select-keys event [:userid :resource/ext-id])]
               (case (:event/type event)

--- a/src/clj/rems/db/blacklist.clj
+++ b/src/clj/rems/db/blacklist.clj
@@ -45,8 +45,8 @@
          :event/id (:id event)))
 
 (defn get-events [params]
-  (mapv event-from-db (db/get-blacklist-events {:user (:blacklist/user params)
-                                                :resource (:blacklist/resource params)})))
+  (mapv event-from-db (db/get-blacklist-events {:user (:userid params)
+                                                :resource (:resource/ext-id params)})))
 
 (defn- events->blacklist [events]
   ;; TODO: move computation to db for performance
@@ -65,9 +65,9 @@
 (defn get-blacklist [params]
   (vec (sort-by (juxt :userid :resource/ext-id) (events->blacklist (get-events params)))))
 
-(defn blacklisted? [user resource]
-  (not (empty? (get-blacklist {:blacklist/user user
-                               :blacklist/resource resource}))))
+(defn blacklisted? [userid resource]
+  (not (empty? (get-blacklist {:userid userid
+                               :resource/ext-id resource}))))
 
 (defn add-to-blacklist! [{:keys [user resource actor comment]}]
   (add-event! {:event/type :blacklist.event/add

--- a/src/cljs/rems/administration/blacklist.cljs
+++ b/src/cljs/rems/administration/blacklist.cljs
@@ -27,7 +27,7 @@
 
 (defn- format-rows [rows]
   (doall
-   (for [{:keys [blacklist/resource blacklist/user]} rows]
+   (for [{resource :blacklist/resource user :blacklist/user} rows]
      {:key (str "blacklist-" resource (:userid user))
       :resource {:value (:resource/ext-id resource)}
       :user {:value (rems.application-util/get-member-name user)}

--- a/src/cljs/rems/administration/blacklist.cljs
+++ b/src/cljs/rems/administration/blacklist.cljs
@@ -27,9 +27,9 @@
 
 (defn- format-rows [rows]
   (doall
-   (for [{:keys [resource user]} rows]
+   (for [{:keys [blacklist/resource blacklist/user]} rows]
      {:key (str "blacklist-" resource (:userid user))
-      :resource {:value resource}
+      :resource {:value (:resource/ext-id resource)}
       :user {:value (rems.application-util/get-member-name user)}
       :email {:value (:email user)}})))
 

--- a/test/clj/rems/api/test_blacklist.clj
+++ b/test/clj/rems/api/test_blacklist.clj
@@ -36,45 +36,45 @@
   (testing "initially no blacklist"
     (is (= #{} (fetch {}))))
   (testing "add three entries"
-    (add! {:user "user1"
-           :resource "A"
+    (add! {:blacklist/user {:userid "user1"}
+           :blacklist/resource {:resource/ext-id "A"}
            :comment "bad"})
-    (add! {:user "user1"
-           :resource "B"
+    (add! {:blacklist/user {:userid "user1"}
+           :blacklist/resource {:resource/ext-id "B"}
            :comment "quite bad"})
-    (add! {:user "user2"
-           :resource "B"
+    (add! {:blacklist/user {:userid "user2"}
+           :blacklist/resource {:resource/ext-id "B"}
            :comment "very bad"})
-    (is (= #{{:resource "A" :user {:userid "user1" :name nil :email nil}}
-             {:resource "B" :user {:userid "user1" :name nil :email nil}}
-             {:resource "B" :user {:userid "user2" :name nil :email nil}}}
+    (is (= #{{:blacklist/resource {:resource/ext-id "A"} :blacklist/user {:userid "user1" :name nil :email nil}}
+             {:blacklist/resource {:resource/ext-id "B"} :blacklist/user {:userid "user1" :name nil :email nil}}
+             {:blacklist/resource {:resource/ext-id "B"} :blacklist/user {:userid "user2" :name nil :email nil}}}
            (fetch {}))))
   (testing "query parameters"
-    (is (= #{{:resource "A" :user {:userid "user1" :name nil :email nil}}
-             {:resource "B" :user {:userid "user1" :name nil :email nil}}}
+    (is (= #{{:blacklist/resource {:resource/ext-id "A"} :blacklist/user {:userid "user1" :name nil :email nil}}
+             {:blacklist/resource {:resource/ext-id "B"} :blacklist/user {:userid "user1" :name nil :email nil}}}
            (fetch {:user "user1"})))
-    (is (= #{{:resource "B" :user {:userid "user1" :name nil :email nil}}
-             {:resource "B" :user {:userid "user2" :name nil :email nil}}}
+    (is (= #{{:blacklist/resource {:resource/ext-id "B"} :blacklist/user {:userid "user1" :name nil :email nil}}
+             {:blacklist/resource {:resource/ext-id "B"} :blacklist/user {:userid "user2" :name nil :email nil}}}
            (fetch {:resource "B"})))
-    (is (= #{{:resource "B" :user {:userid "user2" :name nil :email nil}}}
+    (is (= #{{:blacklist/resource {:resource/ext-id "B"} :blacklist/user {:userid "user2" :name nil :email nil}}}
            (fetch {:resource "B" :user "user2"}))))
   (testing "remove entry"
-    (remove! {:user "user2"
-              :resource "B"
+    (remove! {:blacklist/user {:userid "user2"}
+              :blacklist/resource {:resource/ext-id "B"}
               :comment "oops"})
     (is (= #{}
            (fetch {:resource "B" :user "user2"}))))
   (testing "add entry again"
-    (add! {:user "user2"
-           :resource "B"
+    (add! {:blacklist/user {:userid "user2"}
+           :blacklist/resource {:resource/ext-id "B"}
            :comment "again"})
-    (is (= #{{:resource "B" :user {:userid "user2" :name nil :email nil}}}
+    (is (= #{{:blacklist/resource {:resource/ext-id "B"} :blacklist/user {:userid "user2" :name nil :email nil}}}
            (fetch {:resource "B" :user "user2"}))))
   (testing "remove nonexistent entry"
-    (remove! {:user "user3"
-              :resource "C"
+    (remove! {:blacklist/user {:userid "user3"}
+              :blacklist/resource {:resource/ext-id "C"}
               :comment "undo"})
-    (is (= #{{:resource "A" :user {:userid "user1" :name nil :email nil}}
-             {:resource "B" :user {:userid "user1" :name nil :email nil}}
-             {:resource "B" :user {:userid "user2" :name nil :email nil}}}
+    (is (= #{{:blacklist/resource {:resource/ext-id "A"} :blacklist/user {:userid "user1" :name nil :email nil}}
+             {:blacklist/resource {:resource/ext-id "B"} :blacklist/user {:userid "user1" :name nil :email nil}}
+             {:blacklist/resource {:resource/ext-id "B"} :blacklist/user {:userid "user2" :name nil :email nil}}}
            (fetch {})))))

--- a/test/clj/rems/api/test_end_to_end.clj
+++ b/test/clj/rems/api/test_end_to_end.clj
@@ -305,8 +305,8 @@
           (testing "user blacklisted"
             (let [[entry & _] (api-call :get (str "/api/blacklist?user=" applicant-id "&resource=" resource-ext-id) nil
                                         api-key handler-id)]
-              (is (= resource-ext-id (:resource entry)))
-              (is (= applicant-id (:userid (:user entry))))))))
+              (is (= {:resource/ext-id resource-ext-id} (:blacklist/resource entry)))
+              (is (= applicant-id (:userid (:blacklist/user entry))))))))
       (testing "second application"
         (let [application-id (testing "create application"
                                (:application-id

--- a/test/clj/rems/db/test_blacklist.clj
+++ b/test/clj/rems/db/test_blacklist.clj
@@ -51,7 +51,7 @@
            :resource/ext-id "urn.fi/124"
            :event/comment nil}]
          (blacklist/get-events {:userid "goodie"})))
-  (is (false? (blacklist/blacklisted? "baddie" "urn.fi/123")))
-  (is (false? (blacklist/blacklisted? "baddie" "urn.fi/124")))
-  (is (false? (blacklist/blacklisted? "goodie" "urn.fi/123")))
-  (is (true? (blacklist/blacklisted? "goodie" "urn.fi/124"))))
+  (is (not (blacklist/blacklisted? "baddie" "urn.fi/123")))
+  (is (not (blacklist/blacklisted? "baddie" "urn.fi/124")))
+  (is (not (blacklist/blacklisted? "goodie" "urn.fi/123")))
+  (is (blacklist/blacklisted? "goodie" "urn.fi/124")))

--- a/test/clj/rems/db/test_blacklist.clj
+++ b/test/clj/rems/db/test_blacklist.clj
@@ -51,7 +51,11 @@
            :resource/ext-id "urn.fi/124"
            :event/comment nil}]
          (blacklist/get-events {:userid "user2"})))
-  (is (not (blacklist/blacklisted? "user1" "urn.fi/123"))) ;; added and removed to blacklist
-  (is (not (blacklist/blacklisted? "user1" "urn.fi/124"))) ;; never added
-  (is (not (blacklist/blacklisted? "user2" "urn.fi/123"))) ;; never added
-  (is (blacklist/blacklisted? "user2" "urn.fi/124"))) ;; added but not removed
+  (is (not (blacklist/blacklisted? "user1" "urn.fi/123"))
+      "user was added to blacklist, then removed")
+  (is (not (blacklist/blacklisted? "user1" "urn.fi/124"))
+      "user was never added to blacklist")
+  (is (not (blacklist/blacklisted? "user2" "urn.fi/123"))
+      "user was never added to blacklist")
+  (is (blacklist/blacklisted? "user2" "urn.fi/124")
+      "user was added to blacklist but not removed"))

--- a/test/clj/rems/db/test_blacklist.clj
+++ b/test/clj/rems/db/test_blacklist.clj
@@ -42,7 +42,7 @@
            :userid "baddie"
            :resource/ext-id "urn.fi/123"
            :event/comment "it was ok"}]
-         (blacklist/get-events {:blacklist/resource "urn.fi/123"})))
+         (blacklist/get-events {:resource/ext-id "urn.fi/123"})))
   (is (= [{:event/id 3
            :event/type :blacklist.event/add
            :event/time (time/date-time 2019 01 01 01)
@@ -50,7 +50,7 @@
            :userid "goodie"
            :resource/ext-id "urn.fi/124"
            :event/comment nil}]
-         (blacklist/get-events {:blacklist/user "goodie"})))
+         (blacklist/get-events {:userid "goodie"})))
   (is (false? (blacklist/blacklisted? "baddie" "urn.fi/123")))
   (is (false? (blacklist/blacklisted? "baddie" "urn.fi/124")))
   (is (false? (blacklist/blacklisted? "goodie" "urn.fi/123")))

--- a/test/clj/rems/db/test_blacklist.clj
+++ b/test/clj/rems/db/test_blacklist.clj
@@ -13,42 +13,42 @@
   (blacklist/add-event! {:event/type :blacklist.event/add
                          :event/actor "handler"
                          :event/time (time/date-time 2019 1 2 8 0 0)
-                         :blacklist/user "baddie"
-                         :blacklist/resource "urn.fi/123"
+                         :userid "baddie"
+                         :resource/ext-id "urn.fi/123"
                          :event/comment nil})
   (blacklist/add-event! {:event/type :blacklist.event/remove
                          :event/actor "handler"
                          :event/time (time/date-time 2019 2 3 9 0 0)
-                         :blacklist/user "baddie"
-                         :blacklist/resource "urn.fi/123"
+                         :userid "baddie"
+                         :resource/ext-id "urn.fi/123"
                          :event/comment "it was ok"})
   (blacklist/add-event! {:event/type :blacklist.event/add
                          :event/actor "handler"
                          :event/time (time/date-time 2019 1 1 1 0 0)
-                         :blacklist/user "goodie"
-                         :blacklist/resource "urn.fi/124"
+                         :userid "goodie"
+                         :resource/ext-id "urn.fi/124"
                          :event/comment nil})
   (is (= [{:event/id 1
            :event/type :blacklist.event/add
            :event/time (time/date-time 2019 1 2 8 0 0)
            :event/actor "handler"
-           :blacklist/user "baddie"
-           :blacklist/resource "urn.fi/123"
+           :userid "baddie"
+           :resource/ext-id "urn.fi/123"
            :event/comment nil}
           {:event/id 2
            :event/type :blacklist.event/remove
            :event/time (time/date-time 2019 2 3 9 0 0)
            :event/actor "handler"
-           :blacklist/user "baddie"
-           :blacklist/resource "urn.fi/123"
+           :userid "baddie"
+           :resource/ext-id "urn.fi/123"
            :event/comment "it was ok"}]
          (blacklist/get-events {:blacklist/resource "urn.fi/123"})))
   (is (= [{:event/id 3
            :event/type :blacklist.event/add
            :event/time (time/date-time 2019 01 01 01)
            :event/actor "handler"
-           :blacklist/user "goodie"
-           :blacklist/resource "urn.fi/124"
+           :userid "goodie"
+           :resource/ext-id "urn.fi/124"
            :event/comment nil}]
          (blacklist/get-events {:blacklist/user "goodie"})))
   (is (false? (blacklist/blacklisted? "baddie" "urn.fi/123")))

--- a/test/clj/rems/db/test_blacklist.clj
+++ b/test/clj/rems/db/test_blacklist.clj
@@ -13,33 +13,33 @@
   (blacklist/add-event! {:event/type :blacklist.event/add
                          :event/actor "handler"
                          :event/time (time/date-time 2019 1 2 8 0 0)
-                         :userid "baddie"
+                         :userid "user1"
                          :resource/ext-id "urn.fi/123"
                          :event/comment nil})
   (blacklist/add-event! {:event/type :blacklist.event/remove
                          :event/actor "handler"
                          :event/time (time/date-time 2019 2 3 9 0 0)
-                         :userid "baddie"
+                         :userid "user1"
                          :resource/ext-id "urn.fi/123"
                          :event/comment "it was ok"})
   (blacklist/add-event! {:event/type :blacklist.event/add
                          :event/actor "handler"
                          :event/time (time/date-time 2019 1 1 1 0 0)
-                         :userid "goodie"
+                         :userid "user2"
                          :resource/ext-id "urn.fi/124"
                          :event/comment nil})
   (is (= [{:event/id 1
            :event/type :blacklist.event/add
            :event/time (time/date-time 2019 1 2 8 0 0)
            :event/actor "handler"
-           :userid "baddie"
+           :userid "user1"
            :resource/ext-id "urn.fi/123"
            :event/comment nil}
           {:event/id 2
            :event/type :blacklist.event/remove
            :event/time (time/date-time 2019 2 3 9 0 0)
            :event/actor "handler"
-           :userid "baddie"
+           :userid "user1"
            :resource/ext-id "urn.fi/123"
            :event/comment "it was ok"}]
          (blacklist/get-events {:resource/ext-id "urn.fi/123"})))
@@ -47,11 +47,11 @@
            :event/type :blacklist.event/add
            :event/time (time/date-time 2019 01 01 01)
            :event/actor "handler"
-           :userid "goodie"
+           :userid "user2"
            :resource/ext-id "urn.fi/124"
            :event/comment nil}]
-         (blacklist/get-events {:userid "goodie"})))
-  (is (not (blacklist/blacklisted? "baddie" "urn.fi/123")))
-  (is (not (blacklist/blacklisted? "baddie" "urn.fi/124")))
-  (is (not (blacklist/blacklisted? "goodie" "urn.fi/123")))
-  (is (blacklist/blacklisted? "goodie" "urn.fi/124")))
+         (blacklist/get-events {:userid "user2"})))
+  (is (not (blacklist/blacklisted? "user1" "urn.fi/123"))) ;; added and removed to blacklist
+  (is (not (blacklist/blacklisted? "user1" "urn.fi/124"))) ;; never added
+  (is (not (blacklist/blacklisted? "user2" "urn.fi/123"))) ;; never added
+  (is (blacklist/blacklisted? "user2" "urn.fi/124"))) ;; added but not removed


### PR DESCRIPTION
This breaks compatibility with old blacklist entries in the db, but
I didn't write a migration since blacklist isn't in production anywhere.

Also, the API change is obviously non-backwards compatible.

Closes #1745

# Definition of Done / Review checklist

## Reviewability
- [x] link to issue
- ~note if PR is on top of other PR~
- ~note if related change in rems-deploy repo~
- ~consider adding screenshots for ease of review~

## API
- [x] API is documented and shows up in Swagger UI
- [ ] API is backwards compatible or completely new
- [ ] Events are backwards compatible

## Documentation
- ~update changelog if necessary~
- ~add or update docstrings for namespaces and functions~
- ~components are added to guide page~
- ~documentation _at least_ for config options (i.e. docs folder)~
- [x] ADR for major architectural decisions or experiments #1760 

## Different installations
- ~new configuration options added to rems-deploy repository~
- ~instance specific translations (i.e. LBR kielivara)~

## Testing
- [x] complex logic is unit tested
- [x] valuable features are integration / browser / acceptance tested automatically

## Accessibility
- ~all icons have the aria-label attribute~
- ~all fields have a label~
- ~errors are linked to fields with aria-describedby~
- ~contrast is checked~
- ~conscious decision about where to move focus after an action~

## Follow-up
- ~new tasks are created for pending or remaining tasks~
- [x] no critical TODOs left to implement
