### PR TITLE
Remove the :focused test suite from Kaocha config

### DIFF
--- a/tests.edn
+++ b/tests.edn
@@ -9,11 +9,7 @@
                     {:id :integration
                      :ns-patterns ["rems"]
                      :test-paths ["src" "test"]
-                     :focus-meta [:integration]}
-                    {:id :focused
-                     :ns-patterns ["rems"]
-                     :test-paths ["src" "test"]
-                     :focus-meta [:focused]}]
+                     :focus-meta [:integration]}]
             :kaocha/reporter kaocha.report.progress/report
             :plugins [:kaocha.plugin/print-invocations
                       :kaocha.plugin/profiling]}


### PR DESCRIPTION
When no tests are tagged with the :focused meta, Kaocha will run all tests, which results in `lein kaocha` running all tests twice. It's better to use the --focus or --focus-meta CLI argument instead.
