### PR TITLE
feat: adjust formatting of empty application list

### DIFF
--- a/resources/translations/en.edn
+++ b/resources/translations/en.edn
@@ -14,7 +14,6 @@
             :close-intro [:div.intro [:p "Note that if the application is closed, it cannot be opened again."]]
             :comment "Comment"
             :decide "Decide"
-            :empty "No applications to process."
             :errors {:disabled-catalogue-item "Resource no longer available."
                      :invalid-token [:div [:p "Joining the application failed."] [:p "Check the invitation token " [:code "%1"]]]
                      :licenses-not-accepted "Terms of use not accepted."
@@ -28,7 +27,6 @@
             :member-email "Email"
             :member-name "Name"
             :name-and-email-required "Name and email are required."
-            :no-handled-yet "No processed applications."
             :reject "Reject"
             :remark "Remark"
             :remark-public "Show to applicant"

--- a/resources/translations/fi.edn
+++ b/resources/translations/fi.edn
@@ -14,7 +14,6 @@
             :close-intro [:div.intro [:p "Huomaa, että jos hakemus suljetaan, sitä ei voida avata uudelleen."]]
             :comment "Kommentti"
             :decide "Päätä"
-            :empty "Ei käsiteltäviä hakemuksia."
             :errors {:disabled-catalogue-item "Resurssit eivät ole enää saatavilla."
                      :invalid-token [:div [:p "Hakemukseen liittyminen epäonnistui."] [:p "Tarkista kutsukoodi " [:code "%1"]]]
                      :licenses-not-accepted "Käyttöehtoja ei ole hyväksytty."
@@ -28,7 +27,6 @@
             :member-email "Sähköposti"
             :member-name "Nimi"
             :name-and-email-required "Nimi ja sähköposti ovat pakollisia."
-            :no-handled-yet "Ei käsiteltyjä hakemuksia."
             :reject "Hylkää"
             :remark "Kirjaa huomio"
             :remark-public "Näytä huomio hakijalle"

--- a/src/cljs/rems/actions.cljs
+++ b/src/cljs/rems/actions.cljs
@@ -65,7 +65,6 @@
                                        :searching? @(rf/subscribe [::todo-applications :searching?])}]
                  [search/application-search-tips]
                  [application-list/component {:applications ::todo-applications
-                                              :empty-message :t.actions/empty
                                               :hidden-columns #{:state :created}
                                               :default-sort-column :last-activity
                                               :default-sort-order :desc}]]}]
@@ -79,7 +78,6 @@
                                        :searching? @(rf/subscribe [::handled-applications :searching?])}]
                  [search/application-search-tips]
                  [application-list/component {:applications ::handled-applications
-                                              :empty-message :t.actions/no-handled-yet
                                               :hidden-columns #{:todo :created :submitted}
                                               :default-sort-column :last-activity
                                               :default-sort-order :desc}]]}]]])

--- a/src/cljs/rems/application_list.cljs
+++ b/src/cljs/rems/application_list.cljs
@@ -142,7 +142,7 @@
 (defn component
   "An application list which shows a spinner on initial page load (meant to be
   used with rems.search/reg-fetcher) and a message if there are no applications."
-  [{:keys [applications empty-message hidden-columns] :as opts}]
+  [{:keys [applications hidden-columns] :as opts}]
   (cond
     (not @(rf/subscribe [applications :initialized?]))
     [spinner/big]
@@ -151,7 +151,7 @@
     [:div.applications.alert.alert-danger @(rf/subscribe [applications :error])]
 
     (empty? @(rf/subscribe [applications]))
-    [:div.applications.alert.alert-success (text (or empty-message :t.applications/empty))]
+    [:div.applications.alert.alert-secondary (text :t.applications/empty)]
 
     :else
     [list (-> (application-list-defaults)


### PR DESCRIPTION
The success message "No applications to process." is misleading when
the user has entered a search term. Use a more neutral "No
applications." in all cases.

Noticed when implementing #1786 

# Definition of Done / Review checklist

## Reviewability
- [x] consider adding screenshots for ease of review

## ~API~

## ~Documentation~

## ~Different installations~

## ~Testing~

## ~Accessibility~

## Follow-up
- [x] no critical TODOs left to implement
