### PR TITLE
Fix dropdown

### DIFF
--- a/src/cljs/rems/dropdown.cljs
+++ b/src/cljs/rems/dropdown.cljs
@@ -48,6 +48,12 @@
                          :item-key :id
                          :item-label :userid
                          :on-change on-change}])
+     (example "dropdown menu, single-choice, selected item Bob"
+              [dropdown {:items items
+                         :item-key :id
+                         :item-label :userid
+                         :item-selected? #(= "Bob" (:userid %))
+                         :on-change on-change}])
      (example "dropdown menu, multi-choice, several values selected"
               [dropdown {:items items
                          :item-key :id

--- a/src/cljs/rems/dropdown.cljs
+++ b/src/cljs/rems/dropdown.cljs
@@ -29,28 +29,28 @@
 (defn guide
   []
   (let [on-change (fn [items] (println "items" items))
-        items [{:id 1 :userid "Alice"}
-               {:id 2 :userid "Bob"}
-               {:id 3 :userid "Carl"}
-               {:id 4 :userid "Own"}
-               {:id 5 :userid "Deve"}]]
+        items [{:id 1 :name "Alice"}
+               {:id 2 :name "Bob"}
+               {:id 3 :name "Carl"}
+               {:id 4 :name "Own"}
+               {:id 5 :name "Deve"}]]
     [:div
      (component-info dropdown)
      (example "dropdown menu, single-choice, empty"
               [dropdown {:items items
                          :item-key :id
-                         :item-label :userid
+                         :item-label :name
                          :on-change on-change}])
      (example "dropdown menu, single-choice, selected item Bob"
               [dropdown {:items items
                          :item-key :id
-                         :item-label :userid
-                         :item-selected? #(= "Bob" (:userid %))
+                         :item-label :name
+                         :item-selected? #(= "Bob" (:name %))
                          :on-change on-change}])
      (example "dropdown menu, multi-choice, several values selected"
               [dropdown {:items items
                          :item-key :id
-                         :item-label :userid
+                         :item-label :name
                          :item-selected? #(contains? #{1 3 5} (% :id))
                          :multi? true
                          :on-change on-change}])]))

--- a/src/cljs/rems/dropdown.cljs
+++ b/src/cljs/rems/dropdown.cljs
@@ -45,12 +45,12 @@
      (component-info dropdown)
      (example "dropdown menu, single-choice, empty"
               [dropdown {:items items
-                         :item-key :userid
+                         :item-key :id
                          :item-label :userid
                          :on-change on-change}])
      (example "dropdown menu, multi-choice, several values selected"
               [dropdown {:items items
-                         :item-key :userid
+                         :item-key :id
                          :item-label :userid
                          :item-selected? #(contains? #{1 3 5} (% :id))
                          :multi? true

--- a/src/cljs/rems/dropdown.cljs
+++ b/src/cljs/rems/dropdown.cljs
@@ -9,29 +9,22 @@
   [{:keys [id items item-key item-label item-selected? item-disabled? multi? clearable? on-change]
     :or {item-selected? (constantly false)
          item-disabled? (constantly false)}}]
-  (let [options (map (fn [item] {:value item
-                                 :label (item-label item)
-                                 :isDisabled (item-disabled? item)})
-                     items)
-        grouped (group-by #(item-selected? (% :value)) options)]
-    [:> js/Select {:className "dropdown-container"
-                   :classNamePrefix "dropdown-select"
-                   :getOptionValue #(let [item (:value (js->clj % :keywordize-keys true))]
-                                      (item-key item))
-                   :inputId id
-                   :isMulti multi?
-                   :isClearable clearable?
-                   :maxMenuHeight 200
-                   :noOptionsMessage #(text :t.dropdown/no-results)
-                   :options (if multi?
-                              (get grouped false [])
-                              options)
-                   :onChange #(let [new-value (js->clj %1 :keywordize-keys true)]
-                                (on-change (if multi?
-                                             (map :value new-value)
-                                             (:value new-value))))
-                   :placeholder (text :t.dropdown/placeholder)
-                   :value (get grouped true [])}]))
+  ;; some of the callbacks may be keywords which aren't JS fns so we wrap them in anonymous fns
+  [:> js/Select {:className "dropdown-container"
+                 :classNamePrefix "dropdown-select"
+                 :getOptionLabel #(item-label %)
+                 :getOptionValue #(item-key %)
+                 :inputId id
+                 :isMulti multi?
+                 :isClearable clearable?
+                 :isOptionDisabled #(item-disabled? %)
+                 :isOptionSelected #(item-selected? %)
+                 :maxMenuHeight 200
+                 :noOptionsMessage #(text :t.dropdown/no-results)
+                 :options (into-array items)
+                 :value (into-array (filter item-selected? items))
+                 :onChange #(on-change %)
+                 :placeholder (text :t.dropdown/placeholder)}])
 
 (defn guide
   []


### PR DESCRIPTION
Dropdown was misbehaving and selecting all items in the single case. This is due to mixing up JS and CLJS values. This is a fix that simplifies the situation.

The real problem is shown e.g. in create catalogue item page where you can select something from a dropdown. Then see that if you expand the same dropdown again you will see that all rows are rendered selected.

The examples also referred to `:userid` as id but obviously the example is meant to show `:id` as the id.