### PR TITLE
maintenance commands: add-api-key, fix demo-data and test-data

### DIFF
--- a/src/clj/rems/standalone.clj
+++ b/src/clj/rems/standalone.clj
@@ -66,12 +66,13 @@
      \"demo-data\" -- insert data for demoing purposes into database
      \"validate\" -- validate data in db"
   [& args]
-  (cond
-    (#{"migrate" "rollback"} (first args))
+  (case (first args)
+    ("migrate" "rollback")
     (do
       (mount/start #'rems.config/env)
       (migrations/migrate args (select-keys env [:database-url])))
-    (= "reset" (first args))
+
+    "reset"
     (do
       (println "\n\n*** Are you absolutely sure??? Reset empties the whole database and runs migrations to empty db.***\nType 'YES' to proceed")
       (when (= "YES" (read-line))
@@ -79,21 +80,25 @@
           (println "Running reset")
           (mount/start #'rems.config/env)
           (migrations/migrate args (select-keys env [:database-url])))))
-    (= "test-data" (first args))
+
+    "test-data"
     (do
       (mount/start #'rems.config/env #'rems.db.core/*db*)
       (log/info "Creating test data")
       (test-data/create-test-data!)
       (test-data/create-performance-test-data!)
       (log/info "Test data created"))
-    (= "demo-data" (first args))
+
+    "demo-data"
     (do
       (mount/start #'rems.config/env #'rems.db.core/*db*)
       (test-data/create-demo-data!))
-    (= "validate" (first args))
+
+    "validate"
     (do
       (mount/start #'rems.config/env #'rems.db.core/*db*)
       (when-not (validate/validate)
         (System/exit 2)))
-    :else
+
+    ;; default
     (apply start-app args)))

--- a/src/clj/rems/standalone.clj
+++ b/src/clj/rems/standalone.clj
@@ -9,6 +9,7 @@
             [rems.application.search :as search]
             [rems.config :refer [env]]
             [rems.db.applications :as applications]
+            [rems.db.core :as db]
             [rems.db.test-data :as test-data]
             [rems.handler :as handler]
             [rems.validate :as validate])
@@ -64,7 +65,8 @@
      \"reset\" -- empties database and runs migrations to empty db
      \"test-data\" -- insert test data into database
      \"demo-data\" -- insert data for demoing purposes into database
-     \"validate\" -- validate data in db"
+     \"validate\" -- validate data in db
+     \"add-api-key <api-key> [<description>]\" -- add api key to db"
   [& args]
   (case (first args)
     ("migrate" "rollback")
@@ -93,6 +95,12 @@
     (do
       (mount/start #'rems.config/env #'rems.db.core/*db*)
       (test-data/create-demo-data!))
+
+    "add-api-key"
+    (let [[_ key comment] args]
+      (mount/start #'rems.config/env #'rems.db.core/*db*)
+      (db/add-api-key! {:apikey key :comment comment})
+      (log/info "Api key added"))
 
     "validate"
     (do

--- a/src/clj/rems/standalone.clj
+++ b/src/clj/rems/standalone.clj
@@ -85,7 +85,9 @@
 
     "test-data"
     (do
-      (mount/start #'rems.config/env #'rems.db.core/*db*)
+      (mount/start #'rems.config/env
+                   #'rems.db.core/*db*
+                   #'rems.locales/translations)
       (log/info "Creating test data")
       (test-data/create-test-data!)
       (test-data/create-performance-test-data!)
@@ -93,7 +95,9 @@
 
     "demo-data"
     (do
-      (mount/start #'rems.config/env #'rems.db.core/*db*)
+      (mount/start #'rems.config/env
+                   #'rems.db.core/*db*
+                   #'rems.locales/translations)
       (test-data/create-demo-data!))
 
     "add-api-key"


### PR DESCRIPTION
- Now you can add API keys from the command line:
  `lein run add-api-key 42 "an api key"`
- Generating test-data and demo-data got broken by #1775, fixed now