### PR TITLE
Event log text for revoked applications

### DIFF
--- a/resources/translations/en.edn
+++ b/resources/translations/en.edn
@@ -136,7 +136,7 @@
                           :remarked "%1 added a remark."
                           :resources-changed "%1 changed the resources. New resources: %2."
                           :returned "%1 requested changes to the application."
-                          :revoked "%1 revoked the application."
+                          :revoked "%1 revoked the entitlement."
                           :submitted "%1 submitted the application for review."
                           :unknown "Unknown"}
                  :id "Id"

--- a/resources/translations/en.edn
+++ b/resources/translations/en.edn
@@ -244,10 +244,10 @@
                                  :message-to-applicant "Dear %1,\n\nYour application %3 has been returned for your consideration. Please, amend according to requests and resubmit.\n\nYou can review the application at %6"
                                  :subject-to-handler "(%3) Application has been returned to applicant"
                                  :message-to-handler "Dear %1,\n\n%2 has returned the application %3 to the applicant %4 for modifications.\n\nYou can view the application at %6"}
-          :application-revoked {:subject-to-applicant "Your application %3 has been revoked"
-                                :message-to-applicant "Dear %1,\n\nYour application %3 has been revoked.\n\nYou can view the application at %6"
-                                :subject-to-handler "(%3) Application has been revoked"
-                                :message-to-handler "Dear %1,\n\n%2 has revoked the application %3 from %4.\n\nYou can view the application at %6"}
+          :application-revoked {:subject-to-applicant "Entitlements related to your application %3 have been revoked"
+                                :message-to-applicant "Dear %1,\n\nEntitlements related to your application %3 have been revoked.\n\nYou can view the application at %6"
+                                :subject-to-handler "(%3) Entitlements have been revoked"
+                                :message-to-handler "Dear %1,\n\n%2 has revoked the entitlements related to application %3 from %4.\n\nYou can view the application at %6"}
           :application-licenses-added {:subject "Your application's %3 terms of use have changed"
                                        :message "Dear %1,\n\n%2 has requested your approval for changed terms of use to application %3.\n\nYou can review the application and approve the changed the terms of use at %6"}
           :application-resubmitted {:subject "(%3) Application has been resubmitted"

--- a/resources/translations/fi.edn
+++ b/resources/translations/fi.edn
@@ -242,10 +242,10 @@
                                  :message-to-applicant "Hyvä %1,\n\nHakemuksesi %3 on palautettu muokattavaksesi. Ole hyvä ja täydennä hakemusta kommenttien mukaan.\n\nVoit tarkastella hakemusta osoitteessa %6"
                                  :subject-to-handler "(%3) Hakemus on palautettu"
                                  :message-to-handler "Hyvä %1,\n\n%2 on palauttanut käyttäjän %4 hakemuksen %3.\n\nVoit tarkastella hakemusta osoitteessa %6"}
-          :application-revoked {:subject-to-applicant "Hakemuksesi %3 on peruttu"
-                                :message-to-applicant "Hyvä %1,\n\nHakemuksesi %3 on peruttu.\n\nVoit tarkastella hakemusta: %6"
-                                :subject-to-handler "(%3) Hakemus on peruttu"
-                                :message-to-handler "Hyvä %1,\n\n%2 on perunut käyttäjän %4 hakemuksen %3.\n\nVoit tarkastella hakemusta: %6"}
+          :application-revoked {:subject-to-applicant "Hakemukseesi %3 liittyvät käyttöoikeudet on peruttu"
+                                :message-to-applicant "Hyvä %1,\n\nHakemukseesi %3 liittyvät käyttöoikeudet on peruttu.\n\nVoit tarkastella hakemusta: %6"
+                                :subject-to-handler "(%3) Käyttöoikeudet on peruttu"
+                                :message-to-handler "Hyvä %1,\n\n%2 on perunut käyttäjän %4 hakemukseen %3 liittyvät käyttöoikeudet.\n\nVoit tarkastella hakemusta: %6"}
           :application-licenses-added {:subject "Hakemuksen %3 käyttöehdot ovat muuttuneet"
                                        :message "Hyvä %1,\n\n%2 pyytää hyväksyntääsi muuttuneille käyttöehdoille hakemukseen %3.\n\nVoit tarkastella hakemusta ja hyväksyä muuttuneet käyttöehdot osoitteessa %6"}
           :application-resubmitted {:subject "(%3) Hakemus lähetetty uudelleen"

--- a/resources/translations/fi.edn
+++ b/resources/translations/fi.edn
@@ -134,7 +134,7 @@
                           :remarked "%1 kirjasi huomion."
                           :resources-changed "%1 muutti haettavia resursseja. Uudet resurssit: %2."
                           :returned "%1 palautti hakemuksen muokattavaksi."
-                          :revoked "%1 perui hakemuksen."
+                          :revoked "%1 perui käyttöoikeuden."
                           :submitted "%1 lähetti hakemuksen käsiteltäväksi."
                           :unknown "Tuntematon"}
                  :id "Tunniste"

--- a/test/clj/rems/email/test_template.clj
+++ b/test/clj/rems/email/test_template.clj
@@ -275,11 +275,11 @@
 
 (deftest test-revoked
   (is (= [{:to-user "applicant"
-           :subject "Your application 2001/3, \"Application title\" has been revoked",
-           :body "Dear Alice Applicant,\n\nYour application 2001/3, \"Application title\" has been revoked.\n\nYou can view the application at http://example.com/application/7"}
+           :subject "Entitlements related to your application 2001/3, \"Application title\" have been revoked"
+           :body "Dear Alice Applicant,\n\nEntitlements related to your application 2001/3, \"Application title\" have been revoked.\n\nYou can view the application at http://example.com/application/7"}
           {:to-user "assistant"
-           :subject "(2001/3, \"Application title\") Application has been revoked",
-           :body "Dear Amber Assistant,\n\nHannah Handler has revoked the application 2001/3, \"Application title\" from Alice Applicant.\n\nYou can view the application at http://example.com/application/7"}]
+           :subject "(2001/3, \"Application title\") Entitlements have been revoked"
+           :body "Dear Amber Assistant,\n\nHannah Handler has revoked the entitlements related to application 2001/3, \"Application title\" from Alice Applicant.\n\nYou can view the application at http://example.com/application/7"}]
          (emails base-events {:application/id 7
                               :event/type :application.event/revoked
                               :event/actor "handler"}))))


### PR DESCRIPTION
Closes #1777

The emails still talk about revoking the application instead of the entitlement. Should those too be changed?