### PR TITLE
Catalogue item change form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ have notable changes.
 
 Changes since v2.6
 
+### Additions
+- Catalogue item form can be changed for one or more items at a time. 
+  New items will be created that use the new form while the old items
+  are disabled and archived. The name of the new item will be exactly
+  the same as before. See #837
+
 ### Enhancements
 - Application search tips hidden behind question mark icon (#1767)
 - Redirect to login page when accessing an attachment link when logged out (#1590)

--- a/resources/translations/en.edn
+++ b/resources/translations/en.edn
@@ -49,7 +49,6 @@
                    :back "Back"
                    :blacklist "Blacklist"
                    :change-form "Change form"
-                   :change-form-intro "You are about to change the form of the following catalogue items. The changes will be made one at a time, so that each old item is terminated and a new copy with the chosen form will be activated."
                    :cancel "Cancel"
                    :catalogue-item "Catalogue item"
                    :catalogue-items "Catalogue items"
@@ -189,7 +188,8 @@
              :show "Show"
              :show-less "Show less"
              :show-more "Show more"}
-  :change-form {:form-selection "Form"}
+  :change-form {:change-form-intro "You are about to change the form of the following catalogue items. The changes will be made one at a time, so that each old item is terminated and a new copy with the chosen form will be activated."
+                :form-selection "Form"}
   :create-catalogue-item {:form-selection "Form"
                           :infourl "More info URL (optional, defaults to resource URN)"
                           :resource-selection "Resource"

--- a/resources/translations/en.edn
+++ b/resources/translations/en.edn
@@ -188,7 +188,7 @@
              :show "Show"
              :show-less "Show less"
              :show-more "Show more"}
-  :change-form {:change-form-intro "You are about to change the form of the following catalogue items. The changes will be made one at a time, so that each old item is terminated and a new copy with the chosen form will be activated."
+  :change-form {:change-form-intro "You are about to change the form of the following catalogue items. The changes will be made one at a time, so that each old item is terminated and a new copy will use the chosen form." 
                 :form-selection "Form"}
   :create-catalogue-item {:form-selection "Form"
                           :infourl "More info URL (optional, defaults to resource URN)"

--- a/resources/translations/en.edn
+++ b/resources/translations/en.edn
@@ -359,6 +359,9 @@
            :search "Search"}
   :table {:ascending-order "Ascending order"
           :descending-order "Descending order"
+          :all-rows-selected "All rows selected"
+          :no-rows-selected "No rows selected"
+          :some-rows-selected "Some rows selected"
           :show-all-n-rows "Show all %1 rows"}
   :unauthorized-page {:unauthorized "Unauthorized"
                       :you-are-unauthorized "You're unauthorized to access this page."}

--- a/resources/translations/en.edn
+++ b/resources/translations/en.edn
@@ -48,9 +48,13 @@
                    :archive "Archive"
                    :back "Back"
                    :blacklist "Blacklist"
+                   :change-form "Change form"
+                   :change-form-intro "You are about to change the form of the following catalogue items. The changes will be made one at a time, so that each old item is terminated and a new copy with the chosen form will be activated."
                    :cancel "Cancel"
                    :catalogue-item "Catalogue item"
                    :catalogue-items "Catalogue items"
+                   :change "Change"
+                   :changed "Changed"
                    :comment "Comment"
                    :copy-as-new "Copy as new"
                    :create-catalogue-item "Create catalogue item"
@@ -186,6 +190,7 @@
              :show "Show"
              :show-less "Show less"
              :show-more "Show more"}
+  :change-form {:form-selection "Form"}
   :create-catalogue-item {:form-selection "Form"
                           :infourl "More info URL (optional, defaults to resource URN)"
                           :resource-selection "Resource"

--- a/resources/translations/en.edn
+++ b/resources/translations/en.edn
@@ -54,7 +54,6 @@
                    :catalogue-item "Catalogue item"
                    :catalogue-items "Catalogue items"
                    :change "Change"
-                   :changed "Changed"
                    :comment "Comment"
                    :copy-as-new "Copy as new"
                    :create-catalogue-item "Create catalogue item"

--- a/resources/translations/fi.edn
+++ b/resources/translations/fi.edn
@@ -186,7 +186,7 @@
              :show "Näytä"
              :show-less "Näytä vähemmän"
              :show-more "Näytä lisää"}
-  :change-form {:change-form-intro "Olet muuttamassa seuraavien aineistojen lomaketta. Muutokset tehdään yksi kerrallaan siten, että vanha aineisto lopetetaan ja uuteen aktivoitavaan kopioon laitetaan valitsemasi lomake."
+  :change-form {:change-form-intro "Olet muuttamassa seuraavien aineistojen lomaketta. Muutokset tehdään yksi kerrallaan siten, että vanha aineisto poistetaan käytöstä ja uusi kopio käyttää valitsemaasi lomaketta."
                 :form-selection "Lomake"}
   :create-catalogue-item {:form-selection "Lomake"
                           :infourl "Lisätietoja-URL (vapaaehtoinen, puuttuessa käytetään resurssin URN:ää)"

--- a/resources/translations/fi.edn
+++ b/resources/translations/fi.edn
@@ -48,9 +48,13 @@
                    :archive "Arkistoi"
                    :back "Takaisin"
                    :blacklist "Kieltolista"
+                   :change-form "Vaihda lomaketta"
+                   :change-form-intro "Olet muuttamassa seuraavien aineistojen lomaketta. Muutokset tehdään yksi kerrallaan siten, että vanha aineisto lopetetaan ja uuteen aktivoitavaan kopioon laitetaan valitsemasi lomake."
                    :cancel "Peruuta"
                    :catalogue-item "Aineisto"
                    :catalogue-items "Aineistot"
+                   :change "Vaihda"
+                   :changed "Vaihdettu"
                    :comment "Kommentti"
                    :copy-as-new "Kopioi uudeksi"
                    :create-catalogue-item "Uusi aineisto"
@@ -184,6 +188,7 @@
              :show "Näytä"
              :show-less "Näytä vähemmän"
              :show-more "Näytä lisää"}
+  :change-form {:form-selection "Lomake"}
   :create-catalogue-item {:form-selection "Lomake"
                           :infourl "Lisätietoja-URL (vapaaehtoinen, puuttuessa käytetään resurssin URN:ää)"
                           :resource-selection "Resurssi"

--- a/resources/translations/fi.edn
+++ b/resources/translations/fi.edn
@@ -49,7 +49,6 @@
                    :back "Takaisin"
                    :blacklist "Kieltolista"
                    :change-form "Vaihda lomaketta"
-                   :change-form-intro "Olet muuttamassa seuraavien aineistojen lomaketta. Muutokset tehdään yksi kerrallaan siten, että vanha aineisto lopetetaan ja uuteen aktivoitavaan kopioon laitetaan valitsemasi lomake."
                    :cancel "Peruuta"
                    :catalogue-item "Aineisto"
                    :catalogue-items "Aineistot"
@@ -187,7 +186,8 @@
              :show "Näytä"
              :show-less "Näytä vähemmän"
              :show-more "Näytä lisää"}
-  :change-form {:form-selection "Lomake"}
+  :change-form {:change-form-intro "Olet muuttamassa seuraavien aineistojen lomaketta. Muutokset tehdään yksi kerrallaan siten, että vanha aineisto lopetetaan ja uuteen aktivoitavaan kopioon laitetaan valitsemasi lomake."
+                :form-selection "Lomake"}
   :create-catalogue-item {:form-selection "Lomake"
                           :infourl "Lisätietoja-URL (vapaaehtoinen, puuttuessa käytetään resurssin URN:ää)"
                           :resource-selection "Resurssi"

--- a/resources/translations/fi.edn
+++ b/resources/translations/fi.edn
@@ -54,7 +54,6 @@
                    :catalogue-item "Aineisto"
                    :catalogue-items "Aineistot"
                    :change "Vaihda"
-                   :changed "Vaihdettu"
                    :comment "Kommentti"
                    :copy-as-new "Kopioi uudeksi"
                    :create-catalogue-item "Uusi aineisto"

--- a/resources/translations/fi.edn
+++ b/resources/translations/fi.edn
@@ -357,6 +357,9 @@
            :search "Etsi"} ; "Hae" would be more natural, but the catalogue page uses the same word for another meaning
   :table {:ascending-order "Nouseva järjestys"
           :descending-order "Laskeva järjestys"
+          :all-rows-selected "Kaikki rivit valittuna"
+          :no-rows-selected "Ei yhtään riviä valittuna"
+          :some-rows-selected "Joitain rivejä valittuna"
           :show-all-n-rows "Näytä kaikki %1 riviä"}
   :unauthorized-page {:unauthorized "Ei käyttöoikeutta"
                       :you-are-unauthorized "Sinulla ei ole tämän sivun käyttöoikeutta."}

--- a/src/clj/rems/api/catalogue_items.clj
+++ b/src/clj/rems/api/catalogue_items.clj
@@ -48,7 +48,7 @@
 
 (s/defschema ChangeFormResponse
   {:success s/Bool
-   :new-catalogue-item-id s/Int})
+   :catalogue-item-id s/Int})
 
 ;; TODO use declarative roles everywhere
 (def catalogue-items-api

--- a/src/clj/rems/api/services/catalogue.clj
+++ b/src/clj/rems/api/services/catalogue.clj
@@ -74,25 +74,27 @@
   Since we don't want to modify the old item we must create
   a new item that is the copy of the old item except for the changed form."
   [item form-id]
-  ;; create a new item with the new form
-  (let [new-item (db/create-catalogue-item! {:enabled true
-                                             :archived false
-                                             :form form-id
-                                             :resid (:resource-id item)
-                                             :wfid (:wfid item)})]
+  (if (= (:formid item) form-id)
+    {:success true :catalogue-item-id (:id item)}
+    ;; create a new item with the new form
+    (let [new-item (db/create-catalogue-item! {:enabled true
+                                               :archived false
+                                               :form form-id
+                                               :resid (:resource-id item)
+                                               :wfid (:wfid item)})]
 
-    ;; copy localizations
-    (doseq [[langcode localization] (:localizations item)]
-      (db/upsert-catalogue-item-localization! {:id (:id new-item)
-                                               :langcode (name langcode)
-                                               :title (:title localization)
-                                               :infourl (:infourl localization)}))
-    ;; Reset cache so that next call to get localizations will get these ones.
-    (catalogue/reset-cache!)
+      ;; copy localizations
+      (doseq [[langcode localization] (:localizations item)]
+        (db/upsert-catalogue-item-localization! {:id (:id new-item)
+                                                 :langcode (name langcode)
+                                                 :title (:title localization)
+                                                 :infourl (:infourl localization)}))
+      ;; Reset cache so that next call to get localizations will get these ones.
+      (catalogue/reset-cache!)
 
-    ;; end the old catalogue item
-    (db/set-catalogue-item-enabled! {:id (:id item) :enabled false})
-    (db/set-catalogue-item-archived! {:id (:id item) :archived true})
-    (db/set-catalogue-item-endt! {:id (:id item) :end (:start new-item)})
+      ;; end the old catalogue item
+      (db/set-catalogue-item-enabled! {:id (:id item) :enabled false})
+      (db/set-catalogue-item-archived! {:id (:id item) :archived true})
+      (db/set-catalogue-item-endt! {:id (:id item) :end (:start new-item)})
 
-    {:success true :new-catalogue-item-id (:id new-item)}))
+      {:success true :catalogue-item-id (:id new-item)})))

--- a/src/clj/rems/css/styles.clj
+++ b/src/clj/rems/css/styles.clj
@@ -597,7 +597,8 @@
      :form)
     {:margin-left (u/rem 0.5)}]
    [:.commands {:text-align "right"
-                :padding "0 1rem"}]
+                :padding "0 1rem"
+                :cursor :auto}]
    [".spaced-horizontally > *:not(:first-child)" {:margin-left (u/rem 0.5)}]
    [".spaced-vertically > *:not(:first-child)" {:margin-top (u/rem 0.5)}]
    [".spaced-vertically-3 > *:not(:first-child)" {:margin-top (u/rem 1.5)}]

--- a/src/clj/rems/css/styles.clj
+++ b/src/clj/rems/css/styles.clj
@@ -301,6 +301,8 @@
     {:cursor :pointer
      :color (util/get-theme-attribute :link-color "#007bff")}
     [:&:hover {:color (util/get-theme-attribute :link-hover-color :color4)}]]
+   [:.pointer {:cursor :pointer}
+    [:label.form-check-label {:cursor :pointer}]]
    [:html {:position :relative
            :min-width (u/px 320)
            :height (u/percent 100)}]

--- a/src/cljs/rems/administration/catalogue_items.cljs
+++ b/src/cljs/rems/administration/catalogue_items.cljs
@@ -169,7 +169,7 @@
           [[spinner/big]]
           [[roles/when roles/show-admin-edit-buttons?
             [:div.commands.text-left.pl-0
-             [ create-catalogue-item-button]
+             [create-catalogue-item-button]
              [change-form-button (items-by-id @(rf/subscribe [::catalogue]) @(rf/subscribe [::selected-items]))]]
             [status-flags/display-archived-toggle #(do (rf/dispatch [::fetch-catalogue])
                                                        (rf/dispatch [:rems.table/set-selected-rows {:id ::catalogue} nil]))]

--- a/src/cljs/rems/administration/catalogue_items.cljs
+++ b/src/cljs/rems/administration/catalogue_items.cljs
@@ -157,7 +157,7 @@
      [table/search catalogue-table]
      [table/table catalogue-table]]))
 
-(defn- items-by-id [items ids]
+(defn- items-by-ids [items ids]
   (filter (comp ids :id) items))
 
 (defn catalogue-items-page []
@@ -170,7 +170,7 @@
           [[roles/when roles/show-admin-edit-buttons?
             [:div.commands.text-left.pl-0
              [create-catalogue-item-button]
-             [change-form-button (items-by-id @(rf/subscribe [::catalogue]) @(rf/subscribe [::selected-items]))]]
+             [change-form-button (items-by-ids @(rf/subscribe [::catalogue]) @(rf/subscribe [::selected-items]))]]
             [status-flags/display-archived-toggle #(do (rf/dispatch [::fetch-catalogue])
                                                        (rf/dispatch [:rems.table/set-selected-rows {:id ::catalogue} nil]))]
             [status-flags/disabled-and-archived-explanation]]

--- a/src/cljs/rems/administration/catalogue_items.cljs
+++ b/src/cljs/rems/administration/catalogue_items.cljs
@@ -123,7 +123,7 @@
                      {:td [:td.active
                            [readonly-checkbox {:value checked?}]]
                       :sort-value (if checked? 1 2)})
-           :commands {:td [:td.commands {:on-click #(.stopPropagation %)}
+           :commands {:td [:td.commands
                            [view-button (:id item)]
                            [roles/when roles/show-admin-edit-buttons?
                             [catalogue-item/edit-button (:id item)]

--- a/src/cljs/rems/administration/catalogue_items.cljs
+++ b/src/cljs/rems/administration/catalogue_items.cljs
@@ -1,5 +1,6 @@
 (ns rems.administration.catalogue-items
-  (:require [re-frame.core :as rf]
+  (:require [cljs-time.coerce :as time-coerce]
+            [re-frame.core :as rf]
             [rems.administration.administration :refer [administration-navigator-container]]
             [rems.administration.catalogue-item :as catalogue-item]
             [rems.administration.status-flags :as status-flags]
@@ -97,7 +98,9 @@
  (fn [[catalogue language] _]
    (map (fn [item]
           {:key (:id item)
-           :name {:value (get-localized-title item language)}
+           :name {:value (get-localized-title item language)
+                  :sort-value [(get-localized-title item language)
+                               (- (time-coerce/to-long (:start item)))]} ; secondary sort by created, reverse
            :resource (let [value (:resource-name item)]
                        {:value value
                         :td [:td.resource

--- a/src/cljs/rems/administration/catalogue_items.cljs
+++ b/src/cljs/rems/administration/catalogue_items.cljs
@@ -171,6 +171,7 @@
             [:div.commands.text-left.pl-0
              [ create-catalogue-item-button]
              [change-form-button (items-by-id @(rf/subscribe [::catalogue]) @(rf/subscribe [::selected-items]))]]
-            [status-flags/display-archived-toggle #(rf/dispatch [::fetch-catalogue])]
+            [status-flags/display-archived-toggle #(do (rf/dispatch [::fetch-catalogue])
+                                                       (rf/dispatch [:rems.table/set-selected-rows {:id ::catalogue} nil]))]
             [status-flags/disabled-and-archived-explanation]]
            [catalogue-list]])))

--- a/src/cljs/rems/administration/catalogue_items.cljs
+++ b/src/cljs/rems/administration/catalogue_items.cljs
@@ -71,12 +71,12 @@
  (fn [db _]
    (::selected-items db)))
 
-(defn- to-create-catalogue-item []
+(defn- create-catalogue-item-button []
   [atoms/link {:class "btn btn-primary"}
    "/administration/catalogue-items/create"
    (text :t.administration/create-catalogue-item)])
 
-(defn- to-change-form [items]
+(defn- change-form-button [items]
   [:button.btn.btn-primary
    {:disabled (when (empty? items) :disabled)
     :on-click (fn []
@@ -84,7 +84,7 @@
                 (navigate! "/administration/catalogue-items/change-form") )}
    (text :t.administration/change-form)])
 
-(defn- to-catalogue-item [catalogue-item-id]
+(defn- view-button [catalogue-item-id]
   [atoms/link {:class "btn btn-primary"}
    (str "/administration/catalogue-items/" catalogue-item-id)
    (text :t.administration/view)])
@@ -124,7 +124,7 @@
                            [readonly-checkbox {:value checked?}]]
                       :sort-value (if checked? 1 2)})
            :commands {:td [:td.commands {:on-click #(.stopPropagation %)}
-                           [to-catalogue-item (:id item)]
+                           [view-button (:id item)]
                            [roles/when roles/show-admin-edit-buttons?
                             [catalogue-item/edit-button (:id item)]
                             [status-flags/enabled-toggle item #(rf/dispatch [::set-catalogue-item-enabled %1 %2 [::fetch-catalogue]])]
@@ -169,8 +169,8 @@
           [[spinner/big]]
           [[roles/when roles/show-admin-edit-buttons?
             [:div.commands.text-left.pl-0
-             [to-create-catalogue-item]
-             [to-change-form (items-by-id @(rf/subscribe [::catalogue]) @(rf/subscribe [::selected-items]))]]
+             [ create-catalogue-item-button]
+             [change-form-button (items-by-id @(rf/subscribe [::catalogue]) @(rf/subscribe [::selected-items]))]]
             [status-flags/display-archived-toggle #(rf/dispatch [::fetch-catalogue])]
             [status-flags/disabled-and-archived-explanation]]
            [catalogue-list]])))

--- a/src/cljs/rems/administration/catalogue_items.cljs
+++ b/src/cljs/rems/administration/catalogue_items.cljs
@@ -62,7 +62,7 @@
    {}))
 
 (rf/reg-event-db
- ::set-selected-items!
+ ::set-selected-items
  (fn [db [_ items]]
    (assoc db ::selected-items items)))
 
@@ -152,7 +152,7 @@
                          :rows [::catalogue-table-rows]
                          :default-sort-column :name
                          :selectable? true
-                         :on-select #(rf/dispatch [::set-selected-items! %])}]
+                         :on-select #(rf/dispatch [::set-selected-items %])}]
     [:div.mt-3
      [table/search catalogue-table]
      [table/table catalogue-table]]))

--- a/src/cljs/rems/administration/change_catalogue_item_form.cljs
+++ b/src/cljs/rems/administration/change_catalogue_item_form.cljs
@@ -56,9 +56,14 @@
 (rf/reg-sub ::forms (fn [db _] (::forms db)))
 
 (defn- form-change-loop [items form]
-  (if (empty? items)
-    (flash-message/show-default-success! :top [text :t.administration/change-form])
-    (rf/dispatch [::change-catalogue-item-form! (:id (first items)) form (partial form-change-loop (rest items) form)])))
+  (let [item (first items)]
+    (cond (empty? items)
+          (flash-message/show-default-success! :top [text :t.administration/change-form])
+
+          (not= (:formid item) (:form/id form))
+          (rf/dispatch [::change-catalogue-item-form! (:id item) form (partial form-change-loop (rest items) form)])
+
+          :else (recur (rest items) form))))
 
 (defn- all-items-have-the-form-already? [items form]
   (every? (comp #{(:form/id form)} :formid) items))

--- a/src/cljs/rems/administration/change_catalogue_item_form.cljs
+++ b/src/cljs/rems/administration/change_catalogue_item_form.cljs
@@ -61,7 +61,7 @@
           (flash-message/show-default-success! :top [text :t.administration/change-form])
 
           (not= (:formid item) (:form/id form))
-          (rf/dispatch [::change-catalogue-item-form! (:id item) form (partial form-change-loop (rest items) form)])
+          (rf/dispatch [::change-catalogue-item-form! (:id item) form #(form-change-loop (rest items) form)])
 
           :else (recur (rest items) form))))
 

--- a/src/cljs/rems/administration/change_catalogue_item_form.cljs
+++ b/src/cljs/rems/administration/change_catalogue_item_form.cljs
@@ -133,7 +133,7 @@
      [document-title (text :t.administration/change-form)]
      [flash-message/component :top]
      [:div
-      [:p (text :t.administration/change-form-intro)]
+      [:p (text :t.change-form/change-form-intro)]
       [catalogue-items-table]
       [form-select]
       [:div.col.commands

--- a/src/cljs/rems/administration/change_catalogue_item_form.cljs
+++ b/src/cljs/rems/administration/change_catalogue_item_form.cljs
@@ -22,12 +22,12 @@
 (rf/reg-event-db ::set-form (fn [db [_ form]] (assoc-in db [::form] form)))
 
 (rf/reg-event-db
- ::set-catalogue-item-form
- (fn [db [_ catalogue-item-id form]]
+ ::update-catalogue-item
+ (fn [db [_ old-catalogue-item-id new-catalogue-item-id new-form]]
    (update db ::catalogue-items (fn [items]
                                   (for [item items]
-                                    (if (= (:id item) catalogue-item-id)
-                                      (assoc item :formid (:form/id form) :form-name (:form/title form))
+                                    (if (= (:id item) old-catalogue-item-id)
+                                      (assoc item :id new-catalogue-item-id :formid (:form/id new-form) :form-name (:form/title new-form))
                                       item))))))
 
 (defn- change-catalogue-item-form! [{:keys [db]} [_ catalogue-item-id form on-success]]
@@ -35,7 +35,7 @@
     (post! (str  "/api/catalogue-items/" catalogue-item-id "/change-form")
            {:params {:form (:form/id form)}
             :handler (fn [result]
-                       (rf/dispatch [::set-catalogue-item-form catalogue-item-id form])
+                       (rf/dispatch [::update-catalogue-item catalogue-item-id (:catalogue-item-id result) form])
                        (rf/dispatch [:rems.table/toggle-row-selection {:id :rems.administration.catalogue-items/catalogue} catalogue-item-id])
                        (rf/dispatch [:rems.table/toggle-row-selection {:id :rems.administration.catalogue-items/catalogue} (:catalogue-item-id result)])
                        (on-success))

--- a/src/cljs/rems/administration/change_catalogue_item_form.cljs
+++ b/src/cljs/rems/administration/change_catalogue_item_form.cljs
@@ -32,7 +32,7 @@
 
 
 (rf/reg-event-fx
- ::change-catalogue-item-form!
+ ::change-catalogue-item-form
  (fn [{:keys [db]} [_ catalogue-item-id form on-success]]
    (post! (str  "/api/catalogue-items/" catalogue-item-id "/change-form")
           {:params {:form (:form/id form)}
@@ -61,7 +61,7 @@
           (flash-message/show-default-success! :top [text :t.administration/change-form])
 
           (not= (:formid item) (:form/id form))
-          (rf/dispatch [::change-catalogue-item-form! (:id item) form #(form-change-loop (rest items) form)])
+          (rf/dispatch [::change-catalogue-item-form (:id item) form #(form-change-loop (rest items) form)])
 
           :else (recur (rest items) form))))
 

--- a/src/cljs/rems/administration/change_catalogue_item_form.cljs
+++ b/src/cljs/rems/administration/change_catalogue_item_form.cljs
@@ -37,7 +37,7 @@
             :handler (fn [result]
                        (rf/dispatch [::set-catalogue-item-form catalogue-item-id form])
                        (rf/dispatch [:rems.table/toggle-row-selection {:id :rems.administration.catalogue-items/catalogue} catalogue-item-id])
-                       (rf/dispatch [:rems.table/toggle-row-selection {:id :rems.administration.catalogue-items/catalogue} (:new-catalogue-item-id result)])
+                       (rf/dispatch [:rems.table/toggle-row-selection {:id :rems.administration.catalogue-items/catalogue} (:catalogue-item-id result)])
                        (on-success))
             :error-handler (flash-message/default-error-handler :top description)}))
   {})

--- a/src/cljs/rems/administration/change_catalogue_item_form.cljs
+++ b/src/cljs/rems/administration/change_catalogue_item_form.cljs
@@ -30,19 +30,20 @@
                                       (assoc item :id new-catalogue-item-id :formid (:form/id new-form) :form-name (:form/title new-form))
                                       item))))))
 
-(defn- change-catalogue-item-form! [{:keys [db]} [_ catalogue-item-id form on-success]]
-  (let [description [text :t.administration/change-form]]
-    (post! (str  "/api/catalogue-items/" catalogue-item-id "/change-form")
-           {:params {:form (:form/id form)}
-            :handler (fn [result]
-                       (rf/dispatch [::update-catalogue-item catalogue-item-id (:catalogue-item-id result) form])
-                       (rf/dispatch [:rems.table/toggle-row-selection {:id :rems.administration.catalogue-items/catalogue} catalogue-item-id])
-                       (rf/dispatch [:rems.table/toggle-row-selection {:id :rems.administration.catalogue-items/catalogue} (:catalogue-item-id result)])
-                       (on-success))
-            :error-handler (flash-message/default-error-handler :top description)}))
-  {})
 
-(rf/reg-event-fx ::change-catalogue-item-form! change-catalogue-item-form!)
+(rf/reg-event-fx
+ ::change-catalogue-item-form!
+ (fn [{:keys [db]} [_ catalogue-item-id form on-success]]
+   (let [description [text :t.administration/change-form]]
+     (post! (str  "/api/catalogue-items/" catalogue-item-id "/change-form")
+            {:params {:form (:form/id form)}
+             :handler (fn [result]
+                        (rf/dispatch [::update-catalogue-item catalogue-item-id (:catalogue-item-id result) form])
+                        (rf/dispatch [:rems.table/toggle-row-selection {:id :rems.administration.catalogue-items/catalogue} catalogue-item-id])
+                        (rf/dispatch [:rems.table/toggle-row-selection {:id :rems.administration.catalogue-items/catalogue} (:catalogue-item-id result)])
+                        (on-success))
+             :error-handler (flash-message/default-error-handler :top description)}))
+   {}))
 
 (defn- fetch-forms []
   (fetch "/api/forms"

--- a/src/cljs/rems/administration/change_catalogue_item_form.cljs
+++ b/src/cljs/rems/administration/change_catalogue_item_form.cljs
@@ -77,6 +77,11 @@
                   (all-items-have-the-form-already? items form))}
    (text :t.administration/change)])
 
+(defn- back-button []
+  [atoms/link {:class "btn btn-primary"}
+   (str "/administration/catalogue-items")
+   (text :t.administration/back)])
+
 (defn- to-catalogue-item [catalogue-item-id]
   [atoms/link {:class "btn btn-primary"}
    (str "/administration/catalogue-items/" catalogue-item-id)
@@ -137,4 +142,5 @@
       [catalogue-items-table]
       [form-select]
       [:div.col.commands
+       [back-button]
        [change-catalogue-item-form-button catalogue-items @(rf/subscribe [::form])]]]]))

--- a/src/cljs/rems/administration/change_catalogue_item_form.cljs
+++ b/src/cljs/rems/administration/change_catalogue_item_form.cljs
@@ -27,7 +27,7 @@
    (update db ::catalogue-items (fn [items]
                                   (for [item items]
                                     (if (= (:id item) catalogue-item-id)
-                                      (assoc item :form-id (:form/id form) :form-name (:form/title form))
+                                      (assoc item :formid (:form/id form) :form-name (:form/title form))
                                       item))))))
 
 (defn- change-catalogue-item-form! [{:keys [db]} [_ catalogue-item-id form on-success]]

--- a/src/cljs/rems/administration/change_catalogue_item_form.cljs
+++ b/src/cljs/rems/administration/change_catalogue_item_form.cljs
@@ -34,15 +34,14 @@
 (rf/reg-event-fx
  ::change-catalogue-item-form!
  (fn [{:keys [db]} [_ catalogue-item-id form on-success]]
-   (let [description [text :t.administration/change-form]]
-     (post! (str  "/api/catalogue-items/" catalogue-item-id "/change-form")
-            {:params {:form (:form/id form)}
-             :handler (fn [result]
-                        (rf/dispatch [::update-catalogue-item catalogue-item-id (:catalogue-item-id result) form])
-                        (rf/dispatch [:rems.table/toggle-row-selection {:id :rems.administration.catalogue-items/catalogue} catalogue-item-id])
-                        (rf/dispatch [:rems.table/toggle-row-selection {:id :rems.administration.catalogue-items/catalogue} (:catalogue-item-id result)])
-                        (on-success))
-             :error-handler (flash-message/default-error-handler :top description)}))
+   (post! (str  "/api/catalogue-items/" catalogue-item-id "/change-form")
+          {:params {:form (:form/id form)}
+           :handler (fn [result]
+                      (rf/dispatch [::update-catalogue-item catalogue-item-id (:catalogue-item-id result) form])
+                      (rf/dispatch [:rems.table/toggle-row-selection {:id :rems.administration.catalogue-items/catalogue} catalogue-item-id])
+                      (rf/dispatch [:rems.table/toggle-row-selection {:id :rems.administration.catalogue-items/catalogue} (:catalogue-item-id result)])
+                      (on-success))
+           :error-handler (flash-message/default-error-handler :top [text :t.administration/change-form])})
    {}))
 
 (defn- fetch-forms []

--- a/src/cljs/rems/administration/change_catalogue_item_form.cljs
+++ b/src/cljs/rems/administration/change_catalogue_item_form.cljs
@@ -66,7 +66,7 @@
           :else (recur (rest items) form))))
 
 (defn- all-items-have-the-form-already? [items form]
-  (every? (comp #{(:form/id form)} :formid) items))
+  (every? #(= (:form/id form) (:formid %)) items))
 
 (defn- change-catalogue-item-form-button [items form]
   [:button.btn.btn-primary

--- a/src/cljs/rems/administration/change_catalogue_item_form.cljs
+++ b/src/cljs/rems/administration/change_catalogue_item_form.cljs
@@ -1,0 +1,124 @@
+(ns rems.administration.change-catalogue-item-form
+  (:require [re-frame.core :as rf]
+            [rems.administration.administration :refer [administration-navigator-container]]
+            [rems.administration.status-flags :as status-flags]
+            [rems.atoms :as atoms :refer [readonly-checkbox document-title]]
+            [rems.collapsible :as collapsible]
+            [rems.dropdown :as dropdown]
+            [rems.flash-message :as flash-message]
+            [rems.table :as table]
+            [rems.text :refer [localize-time text get-localized-title]]
+            [rems.util :refer [navigate! fetch post!]]))
+
+(rf/reg-event-fx
+ ::enter-page
+ (fn [{:keys [db]} [_ catalogue-items]]
+   {:db (-> (dissoc db ::form)
+            (assoc ::catalogue-items catalogue-items))
+    ::fetch-forms nil}))
+
+(rf/reg-sub ::catalogue-items (fn [db _] (::catalogue-items db)))
+(rf/reg-sub ::form (fn [db _] (::form db)))
+(rf/reg-event-db ::set-form (fn [db [_ form]] (assoc-in db [::form] form)))
+
+(rf/reg-event-db
+ ::set-catalogue-item-form
+ (fn [db [_ catalogue-item-id form]]
+   (update db ::catalogue-items (fn [items]
+                                  (for [item items]
+                                    (if (= (:id item) catalogue-item-id)
+                                      (assoc item :form-id (:form/id form) :form-name (:form/title form))
+                                      item))))))
+
+(defn- change-catalogue-item-form! [{:keys [db]} [_ catalogue-item-id form on-success]]
+  (let [description [text :t.administration/change-form]]
+    (post! (str  "/api/catalogue-items/" catalogue-item-id "/change-form")
+           {:params {:form (:form/id form)}
+            :handler (fn [result]
+                       (rf/dispatch [::set-catalogue-item-form catalogue-item-id form])
+                       (rf/dispatch [:rems.table/toggle-row-selection {:id :rems.administration.catalogue-items/catalogue} catalogue-item-id])
+                       (rf/dispatch [:rems.table/toggle-row-selection {:id :rems.administration.catalogue-items/catalogue} (:new-catalogue-item-id result)])
+                       (on-success))
+            :error-handler (flash-message/default-error-handler :top description)}))
+  {})
+
+(rf/reg-event-fx ::change-catalogue-item-form! change-catalogue-item-form!)
+
+(defn- fetch-forms []
+  (fetch "/api/forms"
+         {:handler #(rf/dispatch [::fetch-forms-result %])
+          :error-handler (flash-message/default-error-handler :top "Fetch forms")}))
+
+(rf/reg-fx ::fetch-forms fetch-forms)
+
+(rf/reg-event-db ::fetch-forms-result (fn [db [_ forms]] (assoc db ::forms forms)))
+
+(rf/reg-sub ::forms (fn [db _] (::forms db)))
+
+(defn- form-change-loop [items form]
+  (if (empty? items)
+    (flash-message/show-default-success! :top [text :t.administration/change-form])
+    (rf/dispatch [::change-catalogue-item-form! (:id (first items)) form (partial form-change-loop (rest items) form)])))
+
+(defn- change-catalogue-item-form-button [items form]
+  [:button.btn.btn-primary
+   {:type :button
+    :on-click (fn [] (form-change-loop items form))
+    :disabled (or (nil? (:form/id form)) (empty? items))}
+   (text :t.administration/change)])
+
+(defn- to-catalogue-item [catalogue-item-id]
+  [atoms/link {:class "btn btn-primary"}
+   (str "/administration/catalogue-items/" catalogue-item-id)
+   (text :t.administration/view)])
+
+(rf/reg-sub
+ ::catalogue-items-table-rows
+ (fn [_ _]
+   [(rf/subscribe [::catalogue-items])
+    (rf/subscribe [:language])])
+ (fn [[catalogue language] _]
+   (map (fn [item]
+          {:key (:id item)
+           :name {:value (get-localized-title item language)}
+           :form (let [value (:form-name item)]
+                   {:value value
+                    :td [:td.form
+                         [atoms/link nil
+                          (str "/administration/forms/" (:formid item))
+                          value]]})})
+        catalogue)))
+
+(defn catalogue-items-table []
+  [:div
+   [table/table {:id ::catalogue
+                 :columns [{:key :name
+                            :title (text :t.catalogue/header)}
+                           {:key :form
+                            :title (text :t.administration/form)}]
+                 :rows [::catalogue-items-table-rows]
+                 :default-sort-column :name}]])
+
+(defn form-select []
+  (let [form @(rf/subscribe [::form])
+        on-change #(rf/dispatch [::set-form %])]
+    [:div.form-group
+     [:label {:for :form-dropdown} (text :t.change-form/form-selection)]
+     [dropdown/dropdown {:id :form-dropdown
+                         :items @(rf/subscribe [::forms])
+                         :item-key :form/id
+                         :item-label :form/title
+                         :item-selected? #(= (:form/id %) (:form/id form))
+                         :on-change on-change}]]))
+
+(defn change-catalogue-item-form-page []
+  [:div
+   [administration-navigator-container]
+   [document-title (text :t.administration/change-form)]
+   [flash-message/component :top]
+   [:div
+    [:p (text :t.administration/change-form-intro)]
+    [catalogue-items-table]
+    [form-select]
+    [:div.col.commands
+     [change-catalogue-item-form-button @(rf/subscribe [::catalogue-items]) @(rf/subscribe [::form])]]]])

--- a/src/cljs/rems/administration/change_catalogue_item_form.cljs
+++ b/src/cljs/rems/administration/change_catalogue_item_form.cljs
@@ -112,13 +112,19 @@
                          :on-change on-change}]]))
 
 (defn change-catalogue-item-form-page []
-  [:div
-   [administration-navigator-container]
-   [document-title (text :t.administration/change-form)]
-   [flash-message/component :top]
-   [:div
-    [:p (text :t.administration/change-form-intro)]
-    [catalogue-items-table]
-    [form-select]
-    [:div.col.commands
-     [change-catalogue-item-form-button @(rf/subscribe [::catalogue-items]) @(rf/subscribe [::form])]]]])
+  ;; catalogue items must be setup in the previous page
+  ;; it can be empty when we reload or relogin
+  ;; then we can redirect back to the previous page
+  (let [catalogue-items @(rf/subscribe [::catalogue-items])]
+    (when (empty? catalogue-items)
+      (navigate! "/administration/catalogue-items"))
+    [:div
+     [administration-navigator-container]
+     [document-title (text :t.administration/change-form)]
+     [flash-message/component :top]
+     [:div
+      [:p (text :t.administration/change-form-intro)]
+      [catalogue-items-table]
+      [form-select]
+      [:div.col.commands
+       [change-catalogue-item-form-button catalogue-items @(rf/subscribe [::form])]]]]))

--- a/src/cljs/rems/administration/change_catalogue_item_form.cljs
+++ b/src/cljs/rems/administration/change_catalogue_item_form.cljs
@@ -60,11 +60,16 @@
     (flash-message/show-default-success! :top [text :t.administration/change-form])
     (rf/dispatch [::change-catalogue-item-form! (:id (first items)) form (partial form-change-loop (rest items) form)])))
 
+(defn- all-items-have-the-form-already? [items form]
+  (every? (comp #{(:form/id form)} :formid) items))
+
 (defn- change-catalogue-item-form-button [items form]
   [:button.btn.btn-primary
    {:type :button
     :on-click (fn [] (form-change-loop items form))
-    :disabled (or (nil? (:form/id form)) (empty? items))}
+    :disabled (or (nil? (:form/id form))
+                  (empty? items)
+                  (all-items-have-the-form-already? items form))}
    (text :t.administration/change)])
 
 (defn- to-catalogue-item [catalogue-item-id]

--- a/src/cljs/rems/administration/status_flags.cljs
+++ b/src/cljs/rems/administration/status_flags.cljs
@@ -15,6 +15,7 @@
     :on-click #(on-change (assoc item :enabled true) [text :t.administration/enable])}
    (text :t.administration/enable)])
 
+; TODO consider naming enabled-toggle-button
 (defn enabled-toggle [item on-change]
   (if (:enabled item)
     [disable-button item on-change]
@@ -33,6 +34,7 @@
     :on-click #(on-change (assoc item :archived false) [text :t.administration/unarchive])}
    (text :t.administration/unarchive)])
 
+;; TODO consider naming archived-toggle-button
 (defn archived-toggle [item on-change]
   (if (:archived item)
     [unarchive-button item on-change]

--- a/src/cljs/rems/administration/status_flags.cljs
+++ b/src/cljs/rems/administration/status_flags.cljs
@@ -56,7 +56,7 @@
         on-change (fn []
                     (rf/dispatch [::set-display-archived? (not display-archived?)])
                     (when on-change (on-change)))]
-    [:div.form-check.form-check-inline {:style {:float "right"}}
+    [:div.form-check.form-check-inline.pointer {:style {:float "right"}}
      [checkbox {:id :display-archived
                 :class :form-check-input
                 :value display-archived?

--- a/src/cljs/rems/atoms.cljs
+++ b/src/cljs/rems/atoms.cljs
@@ -69,7 +69,7 @@
                               (on-change value)))]
     [:i.far.fa-lg
      {:id id
-      :class [class (if value :fa-check-square :fa-square) (when-not on-change :readonly-checkbox)]
+      :class [:checkbox class (if value :fa-check-square :fa-square) (when-not on-change :readonly-checkbox)]
       :tabIndex 0
       :role :checkbox
       :aria-checked value

--- a/src/cljs/rems/spa.cljs
+++ b/src/cljs/rems/spa.cljs
@@ -10,6 +10,7 @@
             [rems.administration.blacklist :refer [blacklist-page]]
             [rems.administration.catalogue-item :refer [catalogue-item-page]]
             [rems.administration.catalogue-items :refer [catalogue-items-page]]
+            [rems.administration.change-catalogue-item-form :refer [change-catalogue-item-form-page]]
             [rems.administration.create-catalogue-item :refer [create-catalogue-item-page]]
             [rems.administration.create-form :refer [create-form-page]]
             [rems.administration.create-license :refer [create-license-page]]
@@ -223,6 +224,7 @@
    :rems.administration/blacklist blacklist-page
    :rems.administration/catalogue-item catalogue-item-page
    :rems.administration/catalogue-items catalogue-items-page
+   :rems.administration/change-catalogue-item-form change-catalogue-item-form-page
    :rems.administration/create-catalogue-item create-catalogue-item-page
    :rems.administration/create-form create-form-page
    :rems.administration/create-license create-license-page
@@ -347,6 +349,9 @@
 (secretary/defroute "/administration/blacklist" []
   (rf/dispatch [:rems.administration.blacklist/enter-page])
   (rf/dispatch [:set-active-page :rems.administration/blacklist]))
+
+(secretary/defroute "/administration/catalogue-items/change-form" []
+  (rf/dispatch [:set-active-page :rems.administration/change-catalogue-item-form]))
 
 (secretary/defroute "/administration/catalogue-items/create" []
   (rf/dispatch [:rems.administration.create-catalogue-item/enter-page])

--- a/src/cljs/rems/table.cljs
+++ b/src/cljs/rems/table.cljs
@@ -9,7 +9,7 @@
   - The `table` parameter is passed as a parameter to dynamic subscriptions,
     so that we can have multiple table components on the same page.
   - The rows are processed in stages by chaining subscriptions:
-      (:rows table) -> [::rows table] -> [::sorted-rows table] -> [::sorted-and-filtered-rows table]
+      (:rows table) -> [::rows table] -> [::sorted-rows table] -> [::sorted-and-filtered-rows table] -> [::displayed-rows table]
     This way only the last subscription, which does the filtering,
     needs to be recalculated when the user types the search parameters.
     Likewise, changing sorting only recalculates the last two subscriptions.
@@ -22,7 +22,7 @@
             [rems.atoms :refer [checkbox close-symbol search-symbol sort-symbol]]
             [rems.focus :as focus]
             [rems.search :as search]
-            [rems.text :refer [text-format]]
+            [rems.text :refer [text text-format]]
             [schema.core :as s])
   (:require-macros [rems.guide-macros :refer [component-info example namespace-info]]))
 
@@ -226,6 +226,14 @@
                  ;; performance optimization: hide DOM nodes instead of destroying them
                  (assoc row ::display-row? (display-row? row columns search-terms))))))))
 
+(rf/reg-sub
+ ::displayed-rows
+ (fn [db [_ table]]
+   (let [rows @(rf/subscribe [::sorted-and-filtered-rows table])
+         max-rows @(rf/subscribe [::max-rows table])
+         rows (filter ::display-row? rows)]
+     (take max-rows rows))))
+
 (defn search
   "Search field component for filtering a `rems.table/table` instance
   which takes the same `table` parameter as this component.
@@ -259,9 +267,63 @@
  (fn [db [_ table key]]
    (contains? (get-in db [::selected-rows (:id table)]) key)))
 
+(rf/reg-sub
+ ::selected-rows
+ (fn [db [_ table]]
+   (get-in db [::selected-rows (:id table)])))
+
+(rf/reg-event-db
+ ::set-selected-rows
+ (fn [db [_ table rows]]
+   (let [new-db (assoc-in db [::selected-rows (:id table)] (set (map :key rows)))]
+     (when-let [on-select (:on-select table)]
+       (on-select (get-in new-db [::selected-rows (:id table)])))
+     new-db)))
+
+(rf/reg-sub
+ ::row-selection-state
+ (fn [db [_ table]]
+   (let [selected-rows @(rf/subscribe [::selected-rows table])
+         all-visible-rows (set (map :key @(rf/subscribe [::displayed-rows table])))
+         all-selected?  (= all-visible-rows selected-rows)
+         some-selected? (seq selected-rows)]
+     (cond all-selected? :all
+           some-selected? :some
+           :else :none))))
+
+(defn- selection-toggle-all
+  "A checkbox-like component useful for a selection toggle in the table header."
+  [table]
+  (let [selection-state @(rf/subscribe [::row-selection-state table])
+        visible-rows @(rf/subscribe [::displayed-rows table])
+        on-change (case selection-state
+                    :all #(rf/dispatch [::set-selected-rows table []])
+                    :some #(rf/dispatch [::set-selected-rows table []])
+                    :none #(rf/dispatch [::set-selected-rows table visible-rows]))]
+    [:th.selection
+     [:i.far.fa-lg
+      {:id (str (:id table) "-selection-toggle-all")
+       :class (case selection-state
+                :all :fa-check-square
+                :some :fa-minus-square
+                :none :fa-square)
+       :tabIndex 0
+       :role :checkbox
+       :aria-checked (case selection-state
+                       :all true
+                       :some :mixed
+                       :none false)
+       :aria-label (case selection-state
+                     :all (text :t.table/all-rows-selected)
+                     :some (text :t.table/some-rows-selected)
+                     :none (text :t.table/no-rows-selected))
+       :on-click on-change
+       :on-key-press #(when (= (.-key %) " ")
+                        (on-change))}]]))
+
 (defn- table-header [table]
-  (let [sorting @(rf/subscribe [::sorting table])]
-    (into [:tr (when (:selectable? table) [:th.selection])]
+  (let [sorting @(rf/subscribe [::sorting (:id table)])]
+    (into [:tr (when (:selectable? table) [selection-toggle-all table])]
           (for [column (:columns table)]
             [:th
              (when (sortable? column)
@@ -301,7 +363,7 @@
   See `rems.table/Table` for the `table` parameter schema."
   [table]
   (s/validate Table table)
-  (let [rows @(rf/subscribe [::sorted-and-filtered-rows table])
+  (let [rows @(rf/subscribe [::sorted-and-filtered-rows table]) ; TODO refactor to use ::displayed-rows
         language @(rf/subscribe [:language])
         max-rows @(rf/subscribe [::max-rows table])
         ;; When showing all rows, table-row is responsible for filtering displayed rows,

--- a/src/cljs/rems/table.cljs
+++ b/src/cljs/rems/table.cljs
@@ -345,7 +345,8 @@
                                  "table-row"
                                  "none")}
               :on-click (when (:selectable? table)
-                          #(rf/dispatch [::toggle-row-selection table (:key row)]))}
+                          #(when (contains? #{"TR" "TD" "TH"} (.. % -target -tagName)) ; selection is the default action
+                             (rf/dispatch [::toggle-row-selection table (:key row)])))}
          (when (:selectable? table)
            [:td.selection
             [checkbox {:value @(rf/subscribe [::selected-row table (:key row)])

--- a/src/cljs/rems/table.cljs
+++ b/src/cljs/rems/table.cljs
@@ -275,9 +275,10 @@
 (rf/reg-event-db
  ::set-selected-rows
  (fn [db [_ table rows]]
-   (let [new-db (assoc-in db [::selected-rows (:id table)] (set (map :key rows)))]
+   (let [selected-rows (set (map :key rows))
+         new-db (assoc-in db [::selected-rows (:id table)] selected-rows)]
      (when-let [on-select (:on-select table)]
-       (on-select (get-in new-db [::selected-rows (:id table)])))
+       (on-select selected-rows))
      new-db)))
 
 (rf/reg-sub

--- a/src/cljs/rems/table.cljs
+++ b/src/cljs/rems/table.cljs
@@ -301,7 +301,7 @@
                     :some #(rf/dispatch [::set-selected-rows table []])
                     :none #(rf/dispatch [::set-selected-rows table visible-rows]))]
     [:th.selection
-     [:i.far.fa-lg
+     [:i.far.fa-lg.pointer
       {:id (str (:id table) "-selection-toggle-all")
        :class (case selection-state
                 :all :fa-check-square

--- a/src/cljs/rems/table.cljs
+++ b/src/cljs/rems/table.cljs
@@ -286,7 +286,7 @@
  (fn [db [_ table]]
    (let [selected-rows @(rf/subscribe [::selected-rows table])
          all-visible-rows (set (map :key @(rf/subscribe [::displayed-rows table])))
-         all-selected?  (= all-visible-rows selected-rows)
+         all-selected?  (and (= all-visible-rows selected-rows) (seq all-visible-rows))
          some-selected? (seq selected-rows)]
      (cond all-selected? :all
            some-selected? :some

--- a/src/cljs/rems/table.cljs
+++ b/src/cljs/rems/table.cljs
@@ -382,7 +382,8 @@
          ^{:key (:key row)} [table-row row table])]
       (when (< max-rows (count rows))
         [:tfoot
-         [:tr [:td {:col-span (count (:columns table))
+         [:tr [:td {:col-span (+ (count (:columns table))
+                                 (if (:selectable? table) 1 0))
                     :style {:text-align :center}}
                [:button.btn.btn-primary {:type :button
                                          :on-click (fn []

--- a/test/clj/rems/api/test_catalogue_items.clj
+++ b/test/clj/rems/api/test_catalogue_items.clj
@@ -173,7 +173,7 @@
                                       (json-body {:form new-form-id})
                                       handler
                                       read-ok-body
-                                      :new-catalogue-item-id)
+                                      :catalogue-item-id)
             new-catalogue-item (-> (request :get (str "/api/catalogue-items/" new-catalogue-item-id))
                                    (authenticate api-key "owner")
                                    handler


### PR DESCRIPTION
This implements a first (maybe rough) version of #837 and closes it.

The looping is done in the UI so that if there is a problem, it's stopped, but the user can opt to rerun the loop again. Also the new table select with filter options can be used creatively to select the forms to change e.g. by filtering to existing use of some form.

There can be some confusion for users which functions are "bulk edits" and which affect only one item. However re-rendering the buttons on the table is too slow and "jumpy". We could perhaps have an area for only bulk operations, but that we can decide based on feedback. At least it is possible to go to view an item and back, and not lose the selection.

Since this is a "power tool", we should spend extra time making sure this is properly tested and does not cause loss of work / ops work.

![Screenshot_2019-11-25_13-01-49](https://user-images.githubusercontent.com/823661/69535294-466efd00-0f84-11ea-9f8b-7beb1a98b8b1.png)
![Screenshot_2019-11-25_13-02-16](https://user-images.githubusercontent.com/823661/69535302-4969ed80-0f84-11ea-9823-6166d028d4db.png)
![Screenshot_2019-11-25_13-02-31](https://user-images.githubusercontent.com/823661/69535304-4bcc4780-0f84-11ea-83bd-2ff9dab86722.png)

# Definition of Done / Review checklist

## Reviewability
- [x] link to issue
- ~[ ] note if PR is on top of other PR~
- ~[ ] note if related change in rems-deploy repo~
- [x] consider adding screenshots for ease of review

## API
- [x] API is documented and shows up in Swagger UI
- [x] API is backwards compatible or completely new
- ~[ ] Events are backwards compatible~

## Documentation
- [x] update changelog if necessary
- [x] add or update docstrings for namespaces and functions
- [x] components are added to guide page
- ~[ ] documentation _at least_ for config options (i.e. docs folder)~
- ~[ ] ADR for major architectural decisions or experiments~

## ~Different installations~

## Testing
- [x] complex logic is unit tested
- [x] valuable features are integration / browser / acceptance tested automatically

## ~Accessibility~
Note, the accessibility is based on existing table, dropdown and table selection features so there is no change.

## Follow-up
- ~[ ] new tasks are created for pending or remaining tasks~
- [x] no critical TODOs left to implement
