### PR TITLE
Show version info in console instead of page footer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Changes since v2.6
 - Redirect to login page when accessing an attachment link when logged out (#1590)
 - Form editor: add new field between fields (#1812)
 - Entitlements appear immediately instead of after a delay (#1784)
+- Show version information in console instead of the page footer (#1785)
 
 ### Fixes
 - More robust email resending (#1750)

--- a/src/cljs/rems/spa.cljs
+++ b/src/cljs/rems/spa.cljs
@@ -142,6 +142,12 @@
    (println "Received not-found from" current-url)
    {:dispatch [:set-active-page :not-found]}))
 
+(defn version-info []
+  (if-let [{:keys [version revision]} (read-current-version)]
+    (do (println "Version: " version)
+        (println (str git/+commits-url+ revision)))
+    (println "Version information not available")))
+
 (rf/reg-event-fx
  :landing-page-redirect!
  (fn [{:keys [db]}]
@@ -260,11 +266,7 @@
      [:div.navbar-text (text :t/footer)]
      (when (config/dev-environment?)
        [:div.dev-only
-        [dev-reload-button]])
-     (when-let [{:keys [version revision]} (read-current-version)]
-       [:div#footer-release-number
-        [:a {:href (str git/+commits-url+ revision)}
-         version]])]]])
+        [dev-reload-button]])]]])
 
 (defn logo []
   [:div.logo [:div.container.img]])
@@ -496,6 +498,7 @@
   (r/render [page] (.getElementById js/document "app")))
 
 (defn init! []
+  (version-info)
   (rf/dispatch-sync [:initialize-db])
   (load-interceptors!)
   (-> (p/all [(fetch-translations!)


### PR DESCRIPTION
Closes #1785 

Prints version info twice, first when the page is opened and
again when the user logs in.

# Definition of Done / Review checklist

## Documentation
- [x] update changelog if necessary
