### PR TITLE
fix redirects to relative urls

### DIFF
--- a/src/clj/rems/auth/fake_shibboleth.clj
+++ b/src/clj/rems/auth/fake_shibboleth.clj
@@ -46,7 +46,7 @@ a:visited { color: #fff; }
 ")
 
 (defn- fake-login [session username]
-  (assoc (redirect (str (:public-url env) "redirect"))
+  (assoc (redirect "/redirect")
          :session (assoc session :identity (users/get-raw-user-attributes username))))
 
 (defn- user-selection [username]

--- a/src/clj/rems/auth/fake_shibboleth.clj
+++ b/src/clj/rems/auth/fake_shibboleth.clj
@@ -3,7 +3,6 @@
             [compojure.core :refer [GET defroutes]]
             [hiccup.page :refer [html5]]
             [hiccup.util :refer [url]]
-            [rems.config :refer [env]]
             [rems.db.core :as db]
             [rems.db.users :as users]
             [rems.json :as json]

--- a/src/clj/rems/auth/fake_shibboleth.clj
+++ b/src/clj/rems/auth/fake_shibboleth.clj
@@ -3,6 +3,7 @@
             [compojure.core :refer [GET defroutes]]
             [hiccup.page :refer [html5]]
             [hiccup.util :refer [url]]
+            [rems.config :refer [env]]
             [rems.db.core :as db]
             [rems.db.users :as users]
             [rems.json :as json]
@@ -45,7 +46,7 @@ a:visited { color: #fff; }
 ")
 
 (defn- fake-login [session username]
-  (assoc (redirect "/redirect")
+  (assoc (redirect (str (:public-url env) "redirect"))
          :session (assoc session :identity (users/get-raw-user-attributes username))))
 
 (defn- user-selection [username]

--- a/src/clj/rems/middleware.clj
+++ b/src/clj/rems/middleware.clj
@@ -185,6 +185,12 @@
     (str (:public-url env) (.substring url 1))
     url))
 
+(deftest test-unrelativize-url
+  (with-redefs [env {:public-url "http://public.url/"}]
+    (is (= "http://public.url/" (unrelativize-url "/")))
+    (is (= "http://public.url/foo/bar" (unrelativize-url "/foo/bar")))
+    (is (= "http://example.com/foo/bar" (unrelativize-url "http://example.com/foo/bar")))))
+
 (defn- wrap-fix-location-header
   "When we try to redirect to a relative url, prefix the url with (:public-url env).
    If we don't do this, Jetty does it for us but uses the request url instead of :public-url."


### PR DESCRIPTION
we need to prefix relative redirects with :public-url instead of
letting jetty prefix them with the request url

related to #1236