### PR TITLE
Fix build

### DIFF
--- a/test/clj/rems/api/test_workflows.clj
+++ b/test/clj/rems/api/test_workflows.clj
@@ -12,7 +12,7 @@
             [ring.mock.request :refer :all]))
 
 (use-fixtures
-  :once
+  :each
   api-fixture)
 
 ;; this is a subset of what we expect to get from the api


### PR DESCRIPTION
workflows-edit-test sets alice as handler, but workflows-api-security-test assumes that alice is not a handler