### PR TITLE
fix: don't render broken more info links in application

### DIFF
--- a/src/cljc/rems/catalogue_util.cljc
+++ b/src/cljc/rems/catalogue_util.cljc
@@ -1,9 +1,9 @@
 (ns rems.catalogue-util
   (:require [clojure.string :as str]))
 
-(defn urn-catalogue-item? [{:keys [resid]}]
+(defn urn? [resid]
   (and resid (str/starts-with? resid "urn:")))
 
 (defn urn-catalogue-item-link [{:keys [resid]} {:keys [urn-organization]}]
-  (when resid
+  (when (urn? resid)
     (str (or urn-organization "http://urn.fi/") resid)))

--- a/src/cljs/rems/catalogue.cljs
+++ b/src/cljs/rems/catalogue.cljs
@@ -4,7 +4,7 @@
             [rems.application-util :refer [form-fields-editable?]]
             [rems.atoms :refer [external-link document-title document-title]]
             [rems.cart :as cart]
-            [rems.catalogue-util :refer [urn-catalogue-item-link urn-catalogue-item?]]
+            [rems.catalogue-util :refer [urn-catalogue-item-link]]
             [rems.flash-message :as flash-message]
             [rems.guide-functions]
             [rems.roles :as roles]
@@ -81,8 +81,7 @@
 ;;;; UI
 
 (defn- catalogue-item-more-info [item language config]
-  (let [urn-link (when (urn-catalogue-item? item)
-                   (urn-catalogue-item-link item config))
+  (let [urn-link (urn-catalogue-item-link item config)
         more-info-link (get-in item [:localizations language :infourl])
         link (or more-info-link
                  urn-link)]


### PR DESCRIPTION
... by making urn-catalogue-item-link check that the resid is a urn.

fixes #1872