### PR TITLE
Caching improvements

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -47,7 +47,7 @@
                  [org.apache.lucene/lucene-queryparser "8.2.0"]
                  [org.clojure/clojure "1.10.0"]
                  [org.clojure/clojurescript "1.10.520" :exclusions [com.fasterxml.jackson.core/jackson-core]]
-                 [org.clojure/core.cache "0.7.2"]
+                 [org.clojure/core.cache "0.8.2"]
                  [org.clojure/core.memoize "0.7.2"]
                  [org.clojure/tools.cli "0.4.2"]
                  [org.clojure/tools.logging "0.5.0"]

--- a/src/clj/rems/db/applications.clj
+++ b/src/clj/rems/db/applications.clj
@@ -74,29 +74,14 @@
    :get-workflow workflow/get-workflow
    :blacklisted? blacklist/blacklisted?})
 
-;; short-lived cache to speed up pollers which get the application
-;; repeatedly for each event instead of building their own projection
-(mount/defstate application-cache
-  :start (atom (cache/ttl-cache-factory {} :ttl 10000)))
-
-;; TODO combine with reload-cache!?
-(defn- reset-application-cache! []
-  (swap! application-cache empty))
-
 (defn get-unrestricted-application
   "Returns the full application state without any user permission
    checks and filtering of sensitive information. Don't expose via APIs."
   [application-id]
-  (let [events (events/get-application-events application-id)
-        cache-key [application-id (count events)]
-        build-app (fn [_] (model/build-application-view events fetcher-injections))]
+  (let [events (events/get-application-events application-id)]
     (if (empty? events)
       nil ; application not found
-      ;; TODO: this caching could be removed by refactoring the pollers to build their own projection
-      (if (atom? application-cache) ; guard against not started cache
-        (-> (swap! application-cache cache/through-cache cache-key build-app)
-            (getx cache-key))
-        (build-app nil)))))
+      (model/build-application-view events fetcher-injections))))
 
 (defn get-application
   "Returns the part of application state which the specified user
@@ -253,7 +238,6 @@
 
 (defn reload-cache! []
   ;; TODO: Here is a small chance that a user will experience a cache miss. Consider rebuilding the cache asynchronously and then `reset!` the cache.
-  (reset-application-cache!)
   (events-cache/empty! all-applications-cache)
   (refresh-all-applications-cache!))
 

--- a/test/clj/rems/db/testing.clj
+++ b/test/clj/rems/db/testing.clj
@@ -31,8 +31,7 @@
 
 (defn caches-fixture [f]
   ;; no specific teardown. relies on the teardown of test-db-fixture.
-  (mount/start #'rems.db.applications/application-cache
-               #'rems.db.applications/all-applications-cache)
+  (mount/start #'rems.db.applications/all-applications-cache)
   (f))
 
 (defn test-data-fixture [f]

--- a/test/clj/rems/db/testing.clj
+++ b/test/clj/rems/db/testing.clj
@@ -21,6 +21,7 @@
                          #'rems.db.core/*db*)
   (db/assert-test-database!)
   (migrations/migrate ["reset"] {:database-url (:test-database-url env)})
+  (rems.db.applications/empty-injections-cache!)
   (f)
   (mount/stop))
 

--- a/test/clj/rems/test_performance.clj
+++ b/test/clj/rems/test_performance.clj
@@ -79,20 +79,9 @@
     (println "cache size" (mm/measure applications/all-applications-cache))))
 
 (defn benchmark-get-application []
-  (let [test-get-application #(applications/get-application "developer" 12)
-        no-cache (fn []
-                   (mount/stop #'applications/application-cache))
-        cached (fn []
-                 (mount/stop #'applications/application-cache)
-                 (mount/start #'applications/application-cache)
-                 (test-get-application))]
-    (run-benchmarks [{:name "get-application, no cache"
-                      :benchmark test-get-application
-                      :setup no-cache}
-                     {:name "get-application, cached"
-                      :benchmark test-get-application
-                      :setup cached}])
-    (println "cache size" (mm/measure applications/application-cache))))
+  (let [test-get-application #(applications/get-application "developer" 12)]
+    (run-benchmarks [{:name "get-application"
+                      :benchmark test-get-application}])))
 
 (comment
   ;; Note: If clj-memory-meter throws InaccessibleObjectException on Java 9+,


### PR DESCRIPTION
This does some improvements to the application caching. Instead of caching the applications, it caches the injections (workflows, resources etc.) which are less often changed. The performance is comparable to the old caching, except that the time for creating test-data dropped from 228s to 176s.

Further ideas to explore:
- The ttl-cache-factory defaults to 2s timeout, but it could be configured with a longer timeout or lru-cache-factory.
- The caches state could be managed with mount.


Performance measurements with the unix time command:

no cache
lein run test-data  231.63s user 23.76s system 167% cpu 2:32.09 total
lein kaocha integration  210.77s user 25.39s system 55% cpu 7:01.77 total
lein run  114.06s user 9.75s system 163% cpu 1:15.60 total

application cache
lein run test-data  228.88s user 24.11s system 162% cpu 2:35.81 total
lein kaocha integration  193.27s user 20.32s system 71% cpu 4:58.67 total
lein run  111.08s user 10.06s system 161% cpu 1:15.16 total

injections cache
lein run test-data  176.02s user 15.43s system 227% cpu 1:24.14 total
lein kaocha integration  191.41s user 30.84s system 87% cpu 4:14.95 total
lein run  116.78s user 9.68s system 179% cpu 1:10.26 total

\* "lein run" was timed until no more logs (about sending emails) were being printed.
