### PR TITLE
Some changes to linkifying text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ Changes since v2.6
 - Allow users to change their email address, in case the identity provider
   doesn't provide an email address or the users want to use a different one (#1884)
 - Healthcheck api `/api/health` (#1902)
+- Support www links in form field titles (#1864)
 
 ### Enhancements
 - Application search tips hidden behind question mark icon (#1767)

--- a/src/cljs/rems/fields.cljs
+++ b/src/cljs/rems/fields.cljs
@@ -64,7 +64,7 @@
   editor-component - HTML, form component for editing the field"
   [{:keys [readonly readonly-component diff diff-component validation on-toggle-diff fieldset] :as opts} editor-component]
   (let [id (:field/id opts)
-        title (localized (:field/title opts))
+        title (linkify (localized (:field/title opts)))
         optional (:field/optional opts)
         value (:field/value opts)
         previous-value (:field/previous-value opts)

--- a/src/cljs/rems/util.cljs
+++ b/src/cljs/rems/util.cljs
@@ -158,14 +158,25 @@
       set
       (disj "")))
 
+(def ^:private link-regex #"(?:http://|https://|www\.\w).*?(?=[^a-zA-Z0-9_/]*(?: |$))")
+
 (defn linkify
   "Given a string, return a vector that, when concatenated, forms the
-  original string, except that all whitespace-separated substrings that
-  resemble a link have been changed to hiccup links."
+  original string, except that all substrings that resemble a link have
+  been changed to hiccup links."
   [s]
-  (let [link? (fn [s] (re-matches #"^http[s]?://.*" s))]
-    (map #(if (link? %) [:a {:href %} %] %)
-         (interpose " " (str/split s " ")))))
+  (when s
+    (let [splitted (-> s
+                       (str/replace link-regex #(str "\t" %1 "\t"))
+                       (str/split "\t"))
+          link? (fn [s] (re-matches link-regex s))
+          text-to-url (fn [s] (if (re-matches #"^(http://|https://).*" s)
+                                s
+                                (str "http://" s)))]
+      (map #(if (link? %)
+              [:a {:target :_blank :href (text-to-url %)} %]
+              %)
+           splitted))))
 
 (defn focus-input-field [id]
   (fn [event]

--- a/test/clj/rems/test_browser.clj
+++ b/test/clj/rems/test_browser.clj
@@ -126,7 +126,7 @@
 
 (defn fill-form-field [label text]
   (let [id (get-element-attr *driver* [:application-fields
-                                       {:tag :label, :fn/text label}]
+                                       {:tag :label, :fn/has-text label}]
                              :for)]
     ;; XXX: need to use `fill-human`, because `fill` is so quick that the form drops characters here and there
     (fill-human *driver* {:id id} text)))
@@ -215,14 +215,14 @@
     (fill-form-field "10. Place/plces of research, including place of sample and/or data analysis." "Test")
     (fill-form-field "11. Description of other research group members and their role in the applied project." "Test")
     (fill-form-field "12. Specify selection criteria of study participants (if applicable)" "Test")
-    (fill-form-field "13. Specify requested phenotype data (information on variables is found at https://kite.fimm.fi)" "Test")
+    (fill-form-field "13. Specify requested phenotype data" "Test")
     (select-option "16. Are biological samples requested?" "n")
     (fill-form-field "17. What study results will be returned to THL Biobank (if any)?" "Test")
     (fill-form-field "18. Ethical aspects of the project" "Test")
     (fill-form-field "19. Project keywords (max 5)" "Test")
     (fill-form-field "20. Planned publications (max 3)" "Test")
     (fill-form-field "21. Funding information" "Test")
-    (fill-form-field "22. Invoice address (Service prices: www.thl.fi/biobank/researchers)" "Test")
+    (fill-form-field "22. Invoice address" "Test")
     (check-box "disease_prevention")
 
     (accept-licenses)

--- a/test/cljs/rems/test_util.cljs
+++ b/test/cljs/rems/test_util.cljs
@@ -44,11 +44,35 @@
     (is (= #{"foo" "bar"} (decode-option-keys (encode-option-keys #{"foo" "bar"}))))))
 
 (deftest test-linkify
-  (testing "retain original string"
-    (is (= (apply str (linkify "a b c") "a b c"))))
-  (testing "change link strings to hiccup links"
-    (is (= (linkify "a http://www.abc.com c")
-        ["a" " " [:a {:href "http://www.abc.com"} "http://www.abc.com"] " " "c"]))))
+  (let [link [:a {:target :_blank :href "http://www.abc.com"} "http://www.abc.com"]]
+    (testing "retain original string"
+      (is (= (apply str (linkify "a b c") "a b c"))))
+    (testing "change link strings to hiccup links"
+      (is (= (linkify "See http://www.abc.com")
+             ["See " link]))
+      (is (= (linkify "See https://www.abc.com")
+             ["See " [:a {:target :_blank :href "https://www.abc.com"} "https://www.abc.com"]])))
+    (testing "do not include subsequent punctuation marks in the link"
+      (is (= (linkify "See http://www.abc.com.")
+             ["See " link "."]))
+      (is (= (linkify "See http://www.abc.com, please.")
+             ["See " link ", please."]))
+      (is (= (linkify "See http://www.abc.com?")
+             ["See " link "?"]))
+      (is (= (linkify "See http://www.abc.com...")
+             ["See " link "..."]))
+      (is (= (linkify "See http://www.abc.com!")
+             ["See " link "!"])))
+    (testing "do not include subsequent parentheses in the link"
+      (is (= (linkify "(See http://www.abc.com.)")
+             ["(See " link ".)"]))
+      (is (= (linkify "(See http://www.abc.com?)")
+             ["(See " link "?)"])))
+    (testing "a link without http-prefix"
+      (is (= (linkify "(See www-page at www.abc.com.)")
+             ["(See www-page at "
+              [:a {:target :_blank :href "http://www.abc.com"} "www.abc.com"]
+              ".)"])))))
 
 (deftest test-remove-empty-keys
   (is (= (remove-empty-keys {}) {}))


### PR DESCRIPTION
- Linkify form field titles

- Open links in a new tab

- Support links without http-prefix, e.g., www.example.com.

- Do not include subsequent punctuation marks or parentheses in the link.

Closes #1864 

# Definition of Done / Review checklist

## Reviewability
- [x] link to issue

## Documentation
- [x] update changelog if necessary
- [x] add or update docstrings for namespaces and functions

## Testing
- [x] complex logic is unit tested