### PR TITLE
Automatically set organization in UI when logged in as organization-owner

### DIFF
--- a/src/cljs/rems/roles.cljs
+++ b/src/cljs/rems/roles.cljs
@@ -20,6 +20,9 @@
 (defn show-admin-edit-buttons? [roles]
   (some #{:organization-owner :owner} roles))
 
+(defn disallow-setting-organization? [roles]
+  (some #{:organization-owner} roles))
+
 (defn when [predicate & body]
   (clojure.core/when (predicate (:roles @(rf/subscribe [:identity])))
     (into [:<>] body)))

--- a/src/cljs/rems/roles.cljs
+++ b/src/cljs/rems/roles.cljs
@@ -21,7 +21,7 @@
   (some #{:organization-owner :owner} roles))
 
 (defn disallow-setting-organization? [roles]
-  (some #{:organization-owner} roles))
+  (not-any? #{:owner} roles))
 
 (defn when [predicate & body]
   (clojure.core/when (predicate (:roles @(rf/subscribe [:identity])))

--- a/test/cljs/rems/administration/test_create_form.cljs
+++ b/test/cljs/rems/administration/test_create_form.cljs
@@ -2,6 +2,7 @@
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [rems.administration.create-form :refer [build-request build-localized-string validate-form]]
+            [rems.identity :refer [set-roles!]]
             [rems.testing :refer [isolate-re-frame-state stub-re-frame-effect]]
             [rems.util :refer [getx-in]]))
 
@@ -19,6 +20,7 @@
   (rf/dispatch-sync [:rems.administration.create-form/enter-page]))
 
 (deftest add-form-field-test
+  (set-roles! [:owner])
   (let [form (rf/subscribe [:rems.administration.create-form/form])]
     (testing "adds fields"
       (reset-form)
@@ -48,6 +50,7 @@
           "after"))))
 
 (deftest remove-form-field-test
+  (set-roles! [:owner])
   (let [form (rf/subscribe [:rems.administration.create-form/form])]
     (testing "removes fields"
       (reset-form)
@@ -84,6 +87,7 @@
           "after"))))
 
 (deftest move-form-field-up-test
+  (set-roles! [:owner])
   (let [form (rf/subscribe [:rems.administration.create-form/form])]
     (testing "moves fields up"
       (reset-form)
@@ -125,6 +129,7 @@
             "after move 3")))))
 
 (deftest move-form-field-down-test
+  (set-roles! [:owner])
   (let [form (rf/subscribe [:rems.administration.create-form/form])]
     (testing "moves fields down"
       (reset-form)


### PR DESCRIPTION
Needs subsequent back-end changes to ensure that items are not
created with a different organization.

Part of #1893 

# Definition of Done / Review checklist

## Reviewability
- [x] link to issue
- [x] consider adding screenshots for ease of review

## Documentation
- [ ] update changelog if necessary
   - will do once all changes related to organizations are merged
