### PR TITLE
refactor: move some cljc namespaces under rems.common

### DIFF
--- a/src/clj/rems/api/extra_pages.clj
+++ b/src/clj/rems/api/extra_pages.clj
@@ -4,7 +4,7 @@
             [rems.api.schema :refer :all]
             [rems.api.util :as api-util]
             [rems.config :refer [env]]
-            [rems.common-util :refer [index-by]]
+            [rems.common.util :refer [index-by]]
             [ring.util.http-response :refer :all]
             [schema.core :as s])
   (:import (java.io FileNotFoundException)))

--- a/src/clj/rems/api/services/attachment.clj
+++ b/src/clj/rems/api/services/attachment.clj
@@ -1,5 +1,5 @@
 (ns rems.api.services.attachment
-  (:require [rems.application-util :as application-util]
+  (:require [rems.common.application-util :as application-util]
             [rems.auth.util :refer [throw-forbidden]]
             [rems.db.applications :as applications]
             [rems.db.attachments :as attachments]

--- a/src/clj/rems/api/services/catalogue.clj
+++ b/src/clj/rems/api/services/catalogue.clj
@@ -1,6 +1,6 @@
 (ns rems.api.services.catalogue
   (:require [rems.api.services.util :as util]
-            [rems.common-util :refer [index-by]]
+            [rems.common.util :refer [index-by]]
             [rems.db.applications :as applications]
             [rems.db.core :as db]
             [rems.db.catalogue :as catalogue]

--- a/src/clj/rems/api/services/command.clj
+++ b/src/clj/rems/api/services/command.clj
@@ -5,7 +5,7 @@
             [rems.application.approver-bot :as approver-bot]
             [rems.application.commands :as commands]
             [rems.application.rejecter-bot :as rejecter-bot]
-            [rems.application-util :as application-util]
+            [rems.common.application-util :as application-util]
             [rems.db.applications :as applications]
             [rems.db.catalogue :as catalogue]
             [rems.db.core :as db]

--- a/src/clj/rems/api/services/licenses.clj
+++ b/src/clj/rems/api/services/licenses.clj
@@ -1,7 +1,7 @@
 (ns rems.api.services.licenses
   "Serving licenses for API."
   (:require [rems.api.services.util :as util]
-            [rems.common-util :refer [distinct-by]]
+            [rems.common.util :refer [distinct-by]]
             [rems.db.applications :as applications]
             [rems.db.attachments :as attachments]
             [rems.db.core :as db]

--- a/src/clj/rems/application/approver_bot.clj
+++ b/src/clj/rems/application/approver_bot.clj
@@ -1,6 +1,6 @@
 (ns rems.application.approver-bot
   (:require [clj-time.core :as time]
-            [rems.application-util :as application-util]
+            [rems.common.application-util :as application-util]
             [rems.db.applications :as applications]))
 
 (def bot-userid "approver-bot")

--- a/src/clj/rems/application/commands.clj
+++ b/src/clj/rems/application/commands.clj
@@ -1,6 +1,6 @@
 (ns rems.application.commands
   (:require [clojure.test :refer [deftest is testing]]
-            [rems.application-util :as application-util]
+            [rems.common.application-util :as application-util]
             [rems.permissions :as permissions]
             [rems.util :refer [getx getx-in assert-ex try-catch-ex update-present]]
             [schema-refined.core :as r]

--- a/src/clj/rems/application/model.clj
+++ b/src/clj/rems/application/model.clj
@@ -1,7 +1,7 @@
 (ns rems.application.model
   (:require [clojure.test :refer [deftest is testing]]
             [medley.core :refer [map-vals update-existing]]
-            [rems.application-util :as application-util]
+            [rems.common.application-util :as application-util]
             [rems.application.events :as events]
             [rems.application.master-workflow :as master-workflow]
             [rems.common.form :refer [field-visible?]]

--- a/src/clj/rems/application/rejecter_bot.clj
+++ b/src/clj/rems/application/rejecter_bot.clj
@@ -1,6 +1,6 @@
 (ns rems.application.rejecter-bot
   (:require [clj-time.core :as time]
-            [rems.application-util :as application-util]
+            [rems.common.application-util :as application-util]
             [rems.db.applications :as applications]))
 
 (def bot-userid "rejecter-bot")

--- a/src/clj/rems/application/search.clj
+++ b/src/clj/rems/application/search.clj
@@ -3,7 +3,7 @@
             [clojure.string :as str]
             [clojure.tools.logging :as log]
             [mount.core :as mount]
-            [rems.application-util :as application-util]
+            [rems.common.application-util :as application-util]
             [rems.config :refer [env]]
             [rems.db.applications :as applications]
             [rems.db.events :as events]

--- a/src/clj/rems/db/attachments.clj
+++ b/src/clj/rems/db/attachments.clj
@@ -1,5 +1,5 @@
 (ns rems.db.attachments
-  (:require [rems.application-util :refer [form-fields-editable?]]
+  (:require [rems.common.application-util :refer [form-fields-editable?]]
             [rems.auth.util :refer [throw-forbidden]]
             [rems.db.core :as db]
             [rems.util :refer [file-to-bytes]])

--- a/src/clj/rems/db/catalogue.clj
+++ b/src/clj/rems/db/catalogue.clj
@@ -1,6 +1,6 @@
 (ns rems.db.catalogue
   (:require [clojure.core.memoize :as memo]
-            [rems.common-util :refer [index-by]]
+            [rems.common.util :refer [index-by]]
             [rems.db.core :as db]))
 
 (def ^:private +localizations-cache-time-ms+ (* 5 60 1000))

--- a/src/clj/rems/db/entitlements.clj
+++ b/src/clj/rems/db/entitlements.clj
@@ -5,7 +5,7 @@
             [clojure.set :refer [union]]
             [clojure.tools.logging :as log]
             [mount.core :as mount]
-            [rems.application-util :as application-util]
+            [rems.common.application-util :as application-util]
             [rems.auth.util :refer [throw-forbidden]]
             [rems.config :refer [env]]
             [rems.db.applications :as applications]

--- a/src/clj/rems/db/licenses.clj
+++ b/src/clj/rems/db/licenses.clj
@@ -1,6 +1,6 @@
 (ns rems.db.licenses
   "querying localized licenses"
-  (:require [rems.common-util :refer [distinct-by]]
+  (:require [rems.common.util :refer [distinct-by]]
             [rems.db.core :as db]))
 
 (defn- format-license [license]

--- a/src/clj/rems/email/template.clj
+++ b/src/clj/rems/email/template.clj
@@ -1,6 +1,6 @@
 (ns rems.email.template
   (:require [clojure.string :as str]
-            [rems.application-util :as application-util]
+            [rems.common.application-util :as application-util]
             [rems.application.model]
             [rems.config :refer [env]]
             [rems.context :as context]

--- a/src/clj/rems/guide_macros.clj
+++ b/src/clj/rems/guide_macros.clj
@@ -2,7 +2,7 @@
   "Utilities for component guide."
   (:require [clojure.pprint :refer [code-dispatch write]]
             [clojure.string :as str]
-            [rems.common-util :as common-util]))
+            [rems.common.util :as common-util]))
 
 (defmacro namespace-info [ns-symbol]
   (let [ns (find-ns ns-symbol)

--- a/src/clj/rems/locales.clj
+++ b/src/clj/rems/locales.clj
@@ -5,7 +5,7 @@
             [clojure.tools.logging :as log]
             [medley.core :refer [deep-merge]]
             [mount.core :refer [defstate]]
-            [rems.common-util :refer [recursive-keys]]
+            [rems.common.util :refer [recursive-keys]]
             [rems.config :refer [env]])
   (:import (java.io FileNotFoundException)))
 

--- a/src/cljc/rems/common/application_util.cljc
+++ b/src/cljc/rems/common/application_util.cljc
@@ -1,4 +1,4 @@
-(ns rems.application-util)
+(ns rems.common.application-util)
 
 (defn accepted-licenses? [application userid]
   (let [application-licenses (map :license/id (:application/licenses application))

--- a/src/cljc/rems/common/catalogue_util.cljc
+++ b/src/cljc/rems/common/catalogue_util.cljc
@@ -1,4 +1,4 @@
-(ns rems.catalogue-util
+(ns rems.common.catalogue-util
   (:require [clojure.string :as str]))
 
 (defn urn? [resid]

--- a/src/cljc/rems/common/form.cljc
+++ b/src/cljc/rems/common/form.cljc
@@ -5,7 +5,7 @@
   (:require  [clojure.string :as str]
              [clojure.test :refer [deftest is testing]]
              [medley.core :refer [find-first]]
-             [rems.common-util :refer [getx-in parse-int remove-empty-keys]]))
+             [rems.common.util :refer [getx-in parse-int remove-empty-keys]]))
 
 (defn supports-optional? [field]
   (not (contains? #{:label :header} (:field/type field))))

--- a/src/cljc/rems/common/git.cljc
+++ b/src/cljc/rems/common/git.cljc
@@ -1,4 +1,4 @@
-(ns rems.git)
+(ns rems.common.git)
 
 (def +repo-url+ "https://github.com/CSCfi/rems/")
 (def +commits-url+ (str +repo-url+ "commits/"))

--- a/src/cljc/rems/common/util.cljc
+++ b/src/cljc/rems/common/util.cljc
@@ -1,4 +1,4 @@
-(ns rems.common-util
+(ns rems.common.util
   (:require [clojure.string :as str]
             [clojure.test :refer [deftest is testing]]))
 

--- a/src/cljc/rems/text.cljc
+++ b/src/cljc/rems/text.cljc
@@ -2,7 +2,7 @@
   #?(:clj (:require [clj-time.core :as time]
                     [clj-time.format :as format]
                     [clojure.string :as str]
-                    [rems.application-util :as application-util]
+                    [rems.common.application-util :as application-util]
                     [rems.context :as context]
                     [rems.locales :as locales]
                     [taoensso.tempura :refer [tr]])
@@ -10,7 +10,7 @@
                      [cljs-time.format :as format]
                      [clojure.string :as str]
                      [re-frame.core :as rf]
-                     [rems.application-util :as application-util]
+                     [rems.common.application-util :as application-util]
                      [taoensso.tempura :refer [tr]])))
 
 (defn with-language [lang f]

--- a/src/cljc/rems/validation.cljc
+++ b/src/cljc/rems/validation.cljc
@@ -1,2 +1,0 @@
-(ns rems.validation
-  #_(:require [struct.core :as st]))

--- a/src/cljs/rems/administration/blacklist.cljs
+++ b/src/cljs/rems/administration/blacklist.cljs
@@ -2,7 +2,7 @@
   "Implements both a blacklist component and the blacklist-page"
   (:require [re-frame.core :as rf]
             [rems.administration.administration :as administration]
-            [rems.application-util]
+            [rems.common.application-util]
             [rems.atoms :as atoms]
             [rems.dropdown :as dropdown]
             [rems.flash-message :as flash-message]
@@ -192,10 +192,10 @@
           comment :blacklist/comment} rows]
      {:key (str "blacklist-" resource (:userid user))
       :resource {:value (:resource/ext-id resource)}
-      :user {:value (rems.application-util/get-member-name user)}
+      :user {:value (rems.common.application-util/get-member-name user)}
       :userid {:value (:userid user)}
       :email {:value (:email user)}
-      :added-by {:value (rems.application-util/get-member-name added-by)}
+      :added-by {:value (rems.common.application-util/get-member-name added-by)}
       :added-at {:value added-at :display-value (localize-time added-at)}
       :comment {:value comment}
       :commands {:td [:td.commands

--- a/src/cljs/rems/administration/create_form.cljs
+++ b/src/cljs/rems/administration/create_form.cljs
@@ -9,7 +9,7 @@
             [rems.atoms :as atoms :refer [document-title]]
             [rems.collapsible :as collapsible]
             [rems.common.form :refer [field-visible? generate-field-id validate-form-template] :as common-form]
-            [rems.common-util :refer [parse-int]]
+            [rems.common.util :refer [parse-int]]
             [rems.dropdown :as dropdown]
             [rems.fields :as fields]
             [rems.flash-message :as flash-message]

--- a/src/cljs/rems/administration/form.cljs
+++ b/src/cljs/rems/administration/form.cljs
@@ -6,7 +6,7 @@
             [rems.administration.status-flags :as status-flags]
             [rems.atoms :as atoms :refer [readonly-checkbox document-title]]
             [rems.collapsible :as collapsible]
-            [rems.common-util :refer [andstr]]
+            [rems.common.util :refer [andstr]]
             [rems.flash-message :as flash-message]
             [rems.roles :as roles]
             [rems.spinner :as spinner]

--- a/src/cljs/rems/administration/resource.cljs
+++ b/src/cljs/rems/administration/resource.cljs
@@ -7,7 +7,7 @@
             [rems.administration.status-flags :as status-flags]
             [rems.atoms :as atoms :refer [readonly-checkbox document-title]]
             [rems.collapsible :as collapsible]
-            [rems.common-util :refer [andstr]]
+            [rems.common.util :refer [andstr]]
             [rems.flash-message :as flash-message]
             [rems.roles :as roles]
             [rems.spinner :as spinner]

--- a/src/cljs/rems/administration/workflow.cljs
+++ b/src/cljs/rems/administration/workflow.cljs
@@ -7,7 +7,7 @@
             [rems.administration.status-flags :as status-flags]
             [rems.atoms :as atoms :refer [attachment-link external-link info-field readonly-checkbox enrich-user document-title]]
             [rems.collapsible :as collapsible]
-            [rems.common-util :refer [andstr]]
+            [rems.common.util :refer [andstr]]
             [rems.flash-message :as flash-message]
             [rems.roles :as roles]
             [rems.spinner :as spinner]

--- a/src/cljs/rems/application.cljs
+++ b/src/cljs/rems/application.cljs
@@ -22,7 +22,7 @@
             [rems.actions.review :refer [review-action-button review-form]]
             [rems.actions.revoke :refer [revoke-action-button revoke-form]]
             [rems.application-list :as application-list]
-            [rems.application-util :refer [accepted-licenses? form-fields-editable? get-member-name]]
+            [rems.common.application-util :refer [accepted-licenses? form-fields-editable? get-member-name]]
             [rems.atoms :refer [external-link file-download info-field readonly-checkbox textarea document-title success-symbol empty-symbol]]
             [rems.catalogue-util :refer [urn-catalogue-item-link]]
             [rems.collapsible :as collapsible]

--- a/src/cljs/rems/application.cljs
+++ b/src/cljs/rems/application.cljs
@@ -27,7 +27,7 @@
             [rems.common.catalogue-util :refer [urn-catalogue-item-link]]
             [rems.collapsible :as collapsible]
             [rems.common.form :refer [field-visible?]]
-            [rems.common-util :refer [index-by parse-int]]
+            [rems.common.util :refer [index-by parse-int]]
             [rems.fetcher :as fetcher]
             [rems.fields :as fields]
             [rems.flash-message :as flash-message]

--- a/src/cljs/rems/application.cljs
+++ b/src/cljs/rems/application.cljs
@@ -24,7 +24,7 @@
             [rems.application-list :as application-list]
             [rems.common.application-util :refer [accepted-licenses? form-fields-editable? get-member-name]]
             [rems.atoms :refer [external-link file-download info-field readonly-checkbox textarea document-title success-symbol empty-symbol]]
-            [rems.catalogue-util :refer [urn-catalogue-item-link]]
+            [rems.common.catalogue-util :refer [urn-catalogue-item-link]]
             [rems.collapsible :as collapsible]
             [rems.common.form :refer [field-visible?]]
             [rems.common-util :refer [index-by parse-int]]

--- a/src/cljs/rems/application_list.cljs
+++ b/src/cljs/rems/application_list.cljs
@@ -4,7 +4,7 @@
             [clojure.set :as set]
             [clojure.string :as str]
             [re-frame.core :as rf]
-            [rems.application-util :as application-util]
+            [rems.common.application-util :as application-util]
             [rems.atoms :as atoms]
             [rems.guide-functions]
             [rems.spinner :as spinner]

--- a/src/cljs/rems/cart.cljs
+++ b/src/cljs/rems/cart.cljs
@@ -3,7 +3,7 @@
             [clojure.string :as str]
             [re-frame.core :as rf]
             [rems.atoms :as atoms]
-            [rems.common-util :refer [select-vals]]
+            [rems.common.util :refer [select-vals]]
             [rems.text :refer [text text-format get-localized-title]])
   (:require-macros [rems.guide-macros :refer [component-info example]]))
 

--- a/src/cljs/rems/catalogue.cljs
+++ b/src/cljs/rems/catalogue.cljs
@@ -4,7 +4,7 @@
             [rems.common.application-util :refer [form-fields-editable?]]
             [rems.atoms :refer [external-link document-title document-title]]
             [rems.cart :as cart]
-            [rems.catalogue-util :refer [urn-catalogue-item-link]]
+            [rems.common.catalogue-util :refer [urn-catalogue-item-link]]
             [rems.flash-message :as flash-message]
             [rems.guide-functions]
             [rems.roles :as roles]

--- a/src/cljs/rems/catalogue.cljs
+++ b/src/cljs/rems/catalogue.cljs
@@ -1,7 +1,7 @@
 (ns rems.catalogue
   (:require [re-frame.core :as rf]
             [rems.application-list :as application-list]
-            [rems.application-util :refer [form-fields-editable?]]
+            [rems.common.application-util :refer [form-fields-editable?]]
             [rems.atoms :refer [external-link document-title document-title]]
             [rems.cart :as cart]
             [rems.catalogue-util :refer [urn-catalogue-item-link]]

--- a/src/cljs/rems/guide_functions.cljs
+++ b/src/cljs/rems/guide_functions.cljs
@@ -1,7 +1,7 @@
 (ns rems.guide-functions
   (:require [clojure.string :as str]
             [clojure.test :refer-macros [deftest is]]
-            [rems.common-util :as common-util]
+            [rems.common.util :as common-util]
             [rems.common.git :as git])
   (:require-macros [rems.read-gitlog :refer [read-current-version]]))
 

--- a/src/cljs/rems/guide_functions.cljs
+++ b/src/cljs/rems/guide_functions.cljs
@@ -2,7 +2,7 @@
   (:require [clojure.string :as str]
             [clojure.test :refer-macros [deftest is]]
             [rems.common-util :as common-util]
-            [rems.git :as git])
+            [rems.common.git :as git])
   (:require-macros [rems.read-gitlog :refer [read-current-version]]))
 
 (defn- remove-indentation [docstring]

--- a/src/cljs/rems/spa.cljs
+++ b/src/cljs/rems/spa.cljs
@@ -33,7 +33,7 @@
             [rems.auth.auth :as auth]
             [rems.cart :as cart]
             [rems.catalogue :refer [catalogue-page]]
-            [rems.common-util :refer [parse-int]]
+            [rems.common.util :refer [parse-int]]
             [rems.config :as config]
             [rems.extra-pages :refer [extra-pages]]
             [rems.flash-message :as flash-message]

--- a/src/cljs/rems/spa.cljs
+++ b/src/cljs/rems/spa.cljs
@@ -38,7 +38,7 @@
             [rems.extra-pages :refer [extra-pages]]
             [rems.flash-message :as flash-message]
             [rems.focus :as focus]
-            [rems.git :as git]
+            [rems.common.git :as git]
             [rems.guide-page :refer [guide-page]]
             [rems.navbar :as nav]
             [rems.new-application :refer [new-application-page]]

--- a/test/clj/rems/api/test_workflows.clj
+++ b/test/clj/rems/api/test_workflows.clj
@@ -3,7 +3,7 @@
             [rems.api.services.licenses :as licenses]
             [rems.api.services.workflow :as workflow]
             [rems.api.testing :refer :all]
-            [rems.common-util :refer [index-by]]
+            [rems.common.util :refer [index-by]]
             [rems.db.applications :as applications]
             [rems.db.core :as db]
             [rems.db.test-data :as test-data]

--- a/test/clj/rems/application/test_commands.clj
+++ b/test/clj/rems/application/test_commands.clj
@@ -3,7 +3,7 @@
             [rems.application.commands :as commands]
             [rems.application.events :as events]
             [rems.application.model :as model]
-            [rems.common-util :refer [distinct-by]]
+            [rems.common.util :refer [distinct-by]]
             [rems.form-validation :as form-validation]
             [rems.permissions :as permissions]
             [rems.util :refer [assert-ex getx]])

--- a/test/clj/rems/application/test_model.clj
+++ b/test/clj/rems/application/test_model.clj
@@ -8,7 +8,7 @@
             [rems.api.schema :as schema]
             [rems.application.events :as events]
             [rems.application.model :as model]
-            [rems.common-util :refer [deep-merge]]
+            [rems.common.util :refer [deep-merge]]
             [rems.permissions :as permissions]
             [schema.core :as s])
   (:import [java.util UUID]

--- a/test/clj/rems/test_locales.clj
+++ b/test/clj/rems/test_locales.clj
@@ -5,7 +5,7 @@
             [clojure.string :as str]
             [clojure.test :refer :all]
             [clojure.tools.logging]
-            [rems.common-util :refer [recursive-keys]]
+            [rems.common.util :refer [recursive-keys]]
             [rems.locales :as locales]
             [rems.testing-util :refer [create-temp-dir delete-recursively]]
             [rems.util :refer [getx-in]]

--- a/test/cljc/rems/common/test_util.cljc
+++ b/test/cljc/rems/common/test_util.cljc
@@ -1,6 +1,6 @@
-(ns rems.test-common-util
+(ns rems.common.test-util
   (:require #?(:clj [clojure.test :refer :all])
-            [rems.common-util :refer :all]))
+            [rems.common.util :refer :all]))
 
 (deftest select-vals-test
   (is (= [] (select-vals nil nil)))

--- a/test/cljc/rems/common/test_util.cljc
+++ b/test/cljc/rems/common/test_util.cljc
@@ -1,6 +1,7 @@
 (ns rems.common.test-util
-  (:require #?(:clj [clojure.test :refer :all])
-            [rems.common.util :refer :all]))
+  (:require #?(:clj [clojure.test :refer :all]
+               :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
+            [rems.common.util :refer [select-vals distinct-by]]))
 
 (deftest select-vals-test
   (is (= [] (select-vals nil nil)))

--- a/test/cljs/rems/cljs_tests.cljs
+++ b/test/cljs/rems/cljs_tests.cljs
@@ -7,6 +7,8 @@
             rems.administration.test-create-workflow
             rems.administration.test-items
             rems.common.form
+            rems.common.util
+            rems.common.test-util
             rems.flash-message
             rems.test-fields
             rems.test-table
@@ -19,6 +21,8 @@
            'rems.administration.test-create-workflow
            'rems.administration.test-items
            'rems.common.form
+           'rems.common.util
+           'rems.common.test-util
            'rems.flash-message
            'rems.test-fields
            'rems.test-table


### PR DESCRIPTION
to avoid conflicts with frontend or backend namespaces
