### PR TITLE
Rahti dev to restart each time new image is pushed to rahti

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -115,9 +115,8 @@ jobs:
       - restore_cache:
           keys:
             - v2-dependencies-{{ checksum "project.clj" }}
-      - run:
-        - >
-          NAME=$(curl -k -s \
+      - run: |
+          DEV_CONTAINER_NAME=$(curl -k -s \
             -H "Authorization: Bearer $rahti_dev_pod_delete_token" \
             -H 'Accept: application/json' \
             https://rahti.csc.fi:8443/api/v1/namespaces/rems-dev/pods | \
@@ -126,7 +125,7 @@ jobs:
             -X DELETE \
             -H "Authorization: Bearer $rahti_dev_pod_delete_token" \
             -H 'Accept: application/json' \
-            https://rahti.csc.fi:8443/api/v1/namespaces/rems-dev/pods/${NAME} > /dev/null
+            https://rahti.csc.fi:8443/api/v1/namespaces/rems-dev/pods/${DEV_CONTAINER_NAME}
 
   # pseudo job to post a single ok status to github after all the tests
   ok:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -154,7 +154,7 @@ workflows:
           filters:
             branches:
               only:
-                - master
+                - rahti-dev
       - rahti:
           requires:
             - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -157,7 +157,7 @@ workflows:
           filters:
             branches:
               only:
-                - rahti-dev
+                - master
       - rahti:
           requires:
             - build
@@ -165,7 +165,7 @@ workflows:
           filters:
             branches:
               only:
-                - rahti-dev
+                - master
       - ok:
           requires:
             - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -122,7 +122,7 @@ jobs:
       - run: docker push docker-registry.rahti.csc.fi/rems/rems:circle
       - run: docker push docker-registry.rahti.csc.fi/rems/rems:circle-$(git rev-parse HEAD)
       - run: |
-          DEV_CONTAINER_NAME=$(curl -k -s \
+          DEV_POD_NAME=$(curl -k -s \
             -H "Authorization: Bearer $rahti_dev_pod_delete_token" \
             -H 'Accept: application/json' \
             https://rahti.csc.fi:8443/api/v1/namespaces/rems-dev/pods | \
@@ -131,8 +131,26 @@ jobs:
             -X DELETE \
             -H "Authorization: Bearer $rahti_dev_pod_delete_token" \
             -H 'Accept: application/json' \
-            https://rahti.csc.fi:8443/api/v1/namespaces/rems-dev/pods/${DEV_CONTAINER_NAME}
-
+            https://rahti.csc.fi:8443/api/v1/namespaces/rems-dev/pods/${DEV_POD_NAME}
+      - run: |
+          RELEASE=$(git tag -l --points-at HEAD | grep "v[0-9]\.[0-9]")
+          if [ ! -z ${RELEASE} ] ; then
+            docker tag docker-registry.rahti.csc.fi/rems/rems:circle docker-registry.rahti.csc.fi/rems/rems:release
+            docker tag docker-registry.rahti.csc.fi/rems/rems:circle docker-registry.rahti.csc.fi/rems/rems:${RELEASE}
+            docker push docker-registry.rahti.csc.fi/rems/rems:release
+            docker push docker-registry.rahti.csc.fi/rems/rems:${RELEASE}
+      - run: |
+            DEMO_POD_NAME=$(curl -k -s \
+              -H "Authorization: Bearer $rahti_demo_pod_delete_token" \
+              -H 'Accept: application/json' \
+              https://rahti.csc.fi:8443/api/v1/namespaces/rems-demo/pods | \
+              jq '.items | .[].metadata.name' | grep rems-demo | tr -d \")
+            curl -k -s \
+              -X DELETE \
+              -H "Authorization: Bearer $rahti_demo_pod_delete_token" \
+              -H 'Accept: application/json' \
+              https://rahti.csc.fi:8443/api/v1/namespaces/rems-demo/pods/${DEMO_POD_NAME}
+          fi
   # pseudo job to post a single ok status to github after all the tests
   ok:
     executor: docker

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -104,19 +104,16 @@ jobs:
       - store_artifacts:
           path: target/uberjar/rems.jar
       - persist_to_workspace:
-          root: target/uberjar
+          root: .
           paths:
-            - rems.jar
+            - target/uberjar/rems.jar
 
   rahti:
     <<: *defaults
     steps:
       - checkout
-      - restore_cache:
-          keys:
-            - v2-dependencies-{{ checksum "project.clj" }}
       - attach_workspace:
-          at: target/uberjar
+          at: .
       - run: docker build --pull --tag docker-registry.rahti.csc.fi/rems/rems:circle --tag docker-registry.rahti.csc.fi/rems/rems:circle-$(git rev-parse HEAD) .
       - run: docker login -p $rahtitoken -u unused docker-registry.rahti.csc.fi
       - run: docker push docker-registry.rahti.csc.fi/rems/rems:circle
@@ -160,7 +157,7 @@ workflows:
           filters:
             branches:
               only:
-                - master
+                - rahti-dev
       - rahti:
           requires:
             - build
@@ -168,7 +165,7 @@ workflows:
           filters:
             branches:
               only:
-                - master
+                - rahti-dev
       - ok:
           requires:
             - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -111,12 +111,6 @@ jobs:
       - restore_cache:
           keys:
             - v2-dependencies-{{ checksum "project.clj" }}
-      - run: |
-          war_job=$(curl -s https://circleci.com/api/v1.1/project/github/CSCfi/rems/tree/master \
-            | jq 'map(select(.workflows.job_name == "war"))[0].build_num // error("no build")')
-          urls=$(curl -s https://circleci.com/api/v1.1/project/github/CSCfi/rems/${war_job}/artifacts \
-            | jq -r '.[].url // error("no artifact")' | grep rems.jar)
-          curl -s --show-error --remote-name-all $urls
       - run: docker build --pull --tag docker-registry.rahti.csc.fi/rems/rems:circle --tag docker-registry.rahti.csc.fi/rems/rems:circle-$(git rev-parse HEAD) .
       - run: docker login -p $rahtitoken -u unused docker-registry.rahti.csc.fi
       - run: docker push docker-registry.rahti.csc.fi/rems/rems:circle

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -122,7 +122,7 @@ jobs:
       - run: docker push docker-registry.rahti.csc.fi/rems/rems:circle
       - run: docker push docker-registry.rahti.csc.fi/rems/rems:circle-$(git rev-parse HEAD)
       - run: |
-          DEV_POD_NAME=$(curl -k -s \
+          DEV_CONTAINER_NAME=$(curl -k -s \
             -H "Authorization: Bearer $rahti_dev_pod_delete_token" \
             -H 'Accept: application/json' \
             https://rahti.csc.fi:8443/api/v1/namespaces/rems-dev/pods | \
@@ -131,25 +131,8 @@ jobs:
             -X DELETE \
             -H "Authorization: Bearer $rahti_dev_pod_delete_token" \
             -H 'Accept: application/json' \
-            https://rahti.csc.fi:8443/api/v1/namespaces/rems-dev/pods/${DEV_POD_NAME}
-      - run: |
-          RELEASE=$(git tag -l --points-at HEAD | grep "v[0-9]\.[0-9]")
-          if [ ! -z ${RELEASE} ] ; then
-            #docker tag docker-registry.rahti.csc.fi/rems/rems:circle docker-registry.rahti.csc.fi/rems/rems:release
-            docker tag docker-registry.rahti.csc.fi/rems/rems:circle docker-registry.rahti.csc.fi/rems/rems:${RELEASE}
-            docker push docker-registry.rahti.csc.fi/rems/rems:release
-            docker push docker-registry.rahti.csc.fi/rems/rems:${RELEASE}
-            DEMO_POD_NAME=$(curl -k -s \
-              -H "Authorization: Bearer $rahti_demo_pod_delete_token" \
-              -H 'Accept: application/json' \
-              https://rahti.csc.fi:8443/api/v1/namespaces/rems-demo/pods | \
-              jq '.items | .[].metadata.name' | grep rems-demo | tr -d \")
-            curl -k -s \
-              -X DELETE \
-              -H "Authorization: Bearer $rahti_demo_pod_delete_token" \
-              -H 'Accept: application/json' \
-              https://rahti.csc.fi:8443/api/v1/namespaces/rems-demo/pods/${DEMO_POD_NAME}
-          fi
+            https://rahti.csc.fi:8443/api/v1/namespaces/rems-dev/pods/${DEV_CONTAINER_NAME}
+
   # pseudo job to post a single ok status to github after all the tests
   ok:
     executor: docker
@@ -177,7 +160,7 @@ workflows:
           filters:
             branches:
               only:
-                - rahti-dev
+                - master
       - rahti:
           requires:
             - build
@@ -185,7 +168,7 @@ workflows:
           filters:
             branches:
               only:
-                - rahti-dev
+                - master
       - ok:
           requires:
             - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -160,7 +160,7 @@ workflows:
           filters:
             branches:
               only:
-                - rahti-dev
+                - master
       - rahti:
           requires:
             - build
@@ -168,7 +168,7 @@ workflows:
           filters:
             branches:
               only:
-                - rahti-dev
+                - master
       - ok:
           requires:
             - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -139,7 +139,6 @@ jobs:
             docker tag docker-registry.rahti.csc.fi/rems/rems:circle docker-registry.rahti.csc.fi/rems/rems:${RELEASE}
             docker push docker-registry.rahti.csc.fi/rems/rems:release
             docker push docker-registry.rahti.csc.fi/rems/rems:${RELEASE}
-      - run: |
             DEMO_POD_NAME=$(curl -k -s \
               -H "Authorization: Bearer $rahti_demo_pod_delete_token" \
               -H 'Accept: application/json' \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -108,6 +108,26 @@ jobs:
       - run: docker push docker-registry.rahti.csc.fi/rems/rems:circle
       - run: docker push docker-registry.rahti.csc.fi/rems/rems:circle-$(git rev-parse HEAD)
 
+  dev:
+    <<: *defaults
+    steps:
+      - checkout
+      - restore_cache:
+          keys:
+            - v2-dependencies-{{ checksum "project.clj" }}
+      - run:
+        - >
+          NAME=$(curl -k -s \
+            -H "Authorization: Bearer $rahti_dev_pod_delete_token" \
+            -H 'Accept: application/json' \
+            https://rahti.csc.fi:8443/api/v1/namespaces/rems-dev/pods | \
+            jq '.items | .[].metadata.name' | grep rems-dev | tr -d \")
+          curl -k -s \
+            -X DELETE \
+            -H "Authorization: Bearer $rahti_dev_pod_delete_token" \
+            -H 'Accept: application/json' \
+            https://rahti.csc.fi:8443/api/v1/namespaces/rems-dev/pods/${NAME} > /dev/null
+
   # pseudo job to post a single ok status to github after all the tests
   ok:
     executor: docker
@@ -136,6 +156,14 @@ workflows:
             branches:
               only:
                 - master
+      - dev:
+          requires:
+            - build
+          #  - war
+          filters:
+            branches:
+              only:
+                - rahti-dev
       - ok:
           requires:
             - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -158,11 +158,11 @@ workflows:
       - dev:
           requires:
             - build
-          #  - war
+            - war
           filters:
             branches:
               only:
-                - rahti-dev
+                - master
       - ok:
           requires:
             - build
@@ -170,3 +170,4 @@ workflows:
             - test
             - doo
             - war
+            - dev

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -135,7 +135,7 @@ jobs:
       - run: |
           RELEASE=$(git tag -l --points-at HEAD | grep "v[0-9]\.[0-9]")
           if [ ! -z ${RELEASE} ] ; then
-            docker tag docker-registry.rahti.csc.fi/rems/rems:circle docker-registry.rahti.csc.fi/rems/rems:release
+            #docker tag docker-registry.rahti.csc.fi/rems/rems:circle docker-registry.rahti.csc.fi/rems/rems:release
             docker tag docker-registry.rahti.csc.fi/rems/rems:circle docker-registry.rahti.csc.fi/rems/rems:${RELEASE}
             docker push docker-registry.rahti.csc.fi/rems/rems:release
             docker push docker-registry.rahti.csc.fi/rems/rems:${RELEASE}
@@ -178,7 +178,7 @@ workflows:
           filters:
             branches:
               only:
-                - master
+                - rahti-dev
       - rahti:
           requires:
             - build
@@ -186,7 +186,7 @@ workflows:
           filters:
             branches:
               only:
-                - master
+                - rahti-dev
       - ok:
           requires:
             - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -111,6 +111,12 @@ jobs:
       - restore_cache:
           keys:
             - v2-dependencies-{{ checksum "project.clj" }}
+      - run: |
+          war_job=$(curl -s https://circleci.com/api/v1.1/project/github/CSCfi/rems/tree/master \
+            | jq 'map(select(.workflows.job_name == "war"))[0].build_num // error("no build")')
+          urls=$(curl -s https://circleci.com/api/v1.1/project/github/CSCfi/rems/${war_job}/artifacts \
+            | jq -r '.[].url // error("no artifact")' | grep rems.jar)
+          curl -s --show-error --remote-name-all $urls
       - run: docker build --pull --tag docker-registry.rahti.csc.fi/rems/rems:circle --tag docker-registry.rahti.csc.fi/rems/rems:circle-$(git rev-parse HEAD) .
       - run: docker login -p $rahtitoken -u unused docker-registry.rahti.csc.fi
       - run: docker push docker-registry.rahti.csc.fi/rems/rems:circle

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -103,18 +103,18 @@ jobs:
       - run: lein uberjar
       - store_artifacts:
           path: target/uberjar/rems.jar
-      - run: docker build --pull --tag docker-registry.rahti.csc.fi/rems/rems:circle --tag docker-registry.rahti.csc.fi/rems/rems:circle-$(git rev-parse HEAD) .
-      - run: docker login -p $rahtitoken -u unused docker-registry.rahti.csc.fi
-      - run: docker push docker-registry.rahti.csc.fi/rems/rems:circle
-      - run: docker push docker-registry.rahti.csc.fi/rems/rems:circle-$(git rev-parse HEAD)
 
-  dev:
+  rahti:
     <<: *defaults
     steps:
       - checkout
       - restore_cache:
           keys:
             - v2-dependencies-{{ checksum "project.clj" }}
+      - run: docker build --pull --tag docker-registry.rahti.csc.fi/rems/rems:circle --tag docker-registry.rahti.csc.fi/rems/rems:circle-$(git rev-parse HEAD) .
+      - run: docker login -p $rahtitoken -u unused docker-registry.rahti.csc.fi
+      - run: docker push docker-registry.rahti.csc.fi/rems/rems:circle
+      - run: docker push docker-registry.rahti.csc.fi/rems/rems:circle-$(git rev-parse HEAD)
       - run: |
           DEV_CONTAINER_NAME=$(curl -k -s \
             -H "Authorization: Bearer $rahti_dev_pod_delete_token" \
@@ -155,14 +155,14 @@ workflows:
             branches:
               only:
                 - master
-      - dev:
+      - rahti:
           requires:
             - build
             - war
           filters:
             branches:
               only:
-                - master
+                - rahti-dev
       - ok:
           requires:
             - build
@@ -170,4 +170,4 @@ workflows:
             - test
             - doo
             - war
-            - dev
+            - rahti

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -103,6 +103,10 @@ jobs:
       - run: lein uberjar
       - store_artifacts:
           path: target/uberjar/rems.jar
+      - persist_to_workspace:
+          root: target/uberjar
+          paths:
+            - rems.jar
 
   rahti:
     <<: *defaults
@@ -111,6 +115,8 @@ jobs:
       - restore_cache:
           keys:
             - v2-dependencies-{{ checksum "project.clj" }}
+      - attach_workspace:
+          at: target/uberjar
       - run: docker build --pull --tag docker-registry.rahti.csc.fi/rems/rems:circle --tag docker-registry.rahti.csc.fi/rems/rems:circle-$(git rev-parse HEAD) .
       - run: docker login -p $rahtitoken -u unused docker-registry.rahti.csc.fi
       - run: docker push docker-registry.rahti.csc.fi/rems/rems:circle

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,4 +6,5 @@ WORKDIR /rems
 ENTRYPOINT ["./docker-entrypoint.sh"]
 
 COPY empty-config.edn /rems/config/config.edn
+COPY target/uberjar/rems.jar /rems/rems.jar
 COPY docker-entrypoint.sh /rems/docker-entrypoint.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,5 +6,4 @@ WORKDIR /rems
 ENTRYPOINT ["./docker-entrypoint.sh"]
 
 COPY empty-config.edn /rems/config/config.edn
-COPY target/uberjar/rems.jar /rems/rems.jar
 COPY docker-entrypoint.sh /rems/docker-entrypoint.sh


### PR DESCRIPTION
Circleci to restart rems dev container running in rahti each time after a new image is pushed to rahti
https://github.com/CSCfi/rems/issues/1236

# Definition of Done / Review checklist

## Reviewability
- [ ] link to issue
- [ ] note if PR is on top of other PR
- [ ] note if related change in rems-deploy repo
- [ ] consider adding screenshots for ease of review

## API
- [ ] API is documented and shows up in Swagger UI
- [ ] API is backwards compatible or completely new
- [ ] Events are backwards compatible

## Documentation
- [ ] update changelog if necessary
- [ ] add or update docstrings for namespaces and functions
- [ ] components are added to guide page
- [ ] documentation _at least_ for config options (i.e. docs folder)
- [ ] ADR for major architectural decisions or experiments

## Different installations
- [ ] new configuration options added to rems-deploy repository
- [ ] instance specific translations (i.e. LBR kielivara)

## Testing
- [ ] complex logic is unit tested
- [ ] valuable features are integration / browser / acceptance tested automatically

## Accessibility
- [ ] all icons have the aria-label attribute
- [ ] all fields have a label
- [ ] errors are linked to fields with aria-describedby
- [ ] contrast is checked
- [ ] conscious decision about where to move focus after an action

## Follow-up
- [ ] new tasks are created for pending or remaining tasks
- [ ] no critical TODOs left to implement
