### PR TITLE
fix: make dev_db.sh work with new versions of postgres docker image

### DIFF
--- a/dev_db.sh
+++ b/dev_db.sh
@@ -1,5 +1,5 @@
 #!/bin/bash -xeu
-docker run --rm --name rems_test -p 127.0.0.1:5432:5432 -d postgres:9.6
+docker run --rm --name rems_test -p 127.0.0.1:5432:5432 -d -e POSTGRES_HOST_AUTH_METHOD=trust postgres:9.6
 docker run --rm --link rems_test postgres:9.6 /bin/bash -c "while ! psql -h rems_test -U postgres -c 'select 1;' 2>/dev/null; do sleep 1; done"
 docker run -i --rm --link rems_test postgres:9.6 psql -h rems_test -U postgres < resources/sql/init.sql
 if [ -z "${FOR_TESTS:-}" ]; then


### PR DESCRIPTION
a password is now mandatory except if you specify POSTGRES_HOST_AUTH_METHOD=truest

https://github.com/docker-library/postgres/pull/658

fixes #2005