### PR TITLE
fix: empty search-index on startup by removing files

### DIFF
--- a/src/clj/rems/application/search.clj
+++ b/src/clj/rems/application/search.clj
@@ -9,6 +9,7 @@
             [rems.db.events :as events]
             [rems.text :as text])
   (:import [com.google.common.io MoreFiles RecursiveDeleteOption]
+           [java.nio.file Files]
            [org.apache.lucene.analysis Analyzer]
            [org.apache.lucene.analysis.standard StandardAnalyzer]
            [org.apache.lucene.document Document StringField Field$Store TextField]
@@ -30,7 +31,8 @@
   :start (let [index-dir (.toPath (io/file (:search-index-path env)))]
            (locking index-lock
              ;; delete old index
-             (MoreFiles/deleteDirectoryContents index-dir (into-array [RecursiveDeleteOption/ALLOW_INSECURE]))
+             (when (.exists (.toFile index-dir))
+               (MoreFiles/deleteDirectoryContents index-dir (into-array [RecursiveDeleteOption/ALLOW_INSECURE])))
              (let [directory (NIOFSDirectory. index-dir)]
                ;; create new empty index by creating and closing an indexwriter, otehrwise SearcherManager will fail
                (.close (IndexWriter. directory (IndexWriterConfig. analyzer)))

--- a/src/clj/rems/application/search.clj
+++ b/src/clj/rems/application/search.clj
@@ -34,7 +34,7 @@
              (when (.exists (.toFile index-dir))
                (MoreFiles/deleteDirectoryContents index-dir (into-array [RecursiveDeleteOption/ALLOW_INSECURE])))
              (let [directory (NIOFSDirectory. index-dir)]
-               ;; create new empty index by creating and closing an indexwriter, otehrwise SearcherManager will fail
+               ;; create a new empty index by creating and closing an IndexWriter, otehrwise SearcherManager will fail
                (.close (IndexWriter. directory (IndexWriterConfig. analyzer)))
                (atom {::directory directory
                       ::searcher-manager (SearcherManager. directory (SearcherFactory.))


### PR DESCRIPTION
instead of via lucene api

this helps with the situation where the index was created with a
previous version of lucene, and might also help with #1890


# Definition of Done / Review checklist

## Reviewability
- [x] link to issue

## Testing
- [x] valuable features are integration / browser / acceptance tested automatically