### PR TITLE
fix: code examples for rems.fields/guide

### DIFF
--- a/src/cljs/rems/fields.cljs
+++ b/src/cljs/rems/fields.cljs
@@ -340,254 +340,220 @@
   [:div
    (component-info field)
    (example "field of type \"text\""
-            [:form
-             [field {:field/type :text
-                     :field/title {:en "Title"}
-                     :field/placeholder {:en "placeholder"}}]])
+            [field {:field/type :text
+                    :field/title {:en "Title"}
+                    :field/placeholder {:en "placeholder"}}])
    (example "field of type \"text\" with maximum length"
-            [:form
-             [field {:field/type :text
-                     :field/title {:en "Title"}
-                     :field/placeholder {:en "placeholder"}
-                     :field/max-length 10}]])
+            [field {:field/type :text
+                    :field/title {:en "Title"}
+                    :field/placeholder {:en "placeholder"}
+                    :field/max-length 10}])
    (example "field of type \"text\" with validation error"
-            [:form
-             [field {:field/type :text
-                     :field/title {:en "Title"}
-                     :field/placeholder {:en "placeholder"}
-                     :validation {:type :t.form.validation/required}}]])
+            [field {:field/type :text
+                    :field/title {:en "Title"}
+                    :field/placeholder {:en "placeholder"}
+                    :validation {:type :t.form.validation/required}}])
    (example "non-editable field of type \"text\" without text"
-            [:form
-             [field {:field/type :text
-                     :field/title {:en "Title"}
-                     :field/placeholder {:en "placeholder"}
-                     :readonly true}]])
+            [field {:field/type :text
+                    :field/title {:en "Title"}
+                    :field/placeholder {:en "placeholder"}
+                    :readonly true}])
    (example "non-editable field of type \"text\" with text"
-            [:form
-             [field {:field/type :text
-                     :field/title {:en "Title"}
-                     :field/placeholder {:en "placeholder"}
-                     :readonly true
-                     :field/value lipsum-short}]])
+            [field {:field/type :text
+                    :field/title {:en "Title"}
+                    :field/placeholder {:en "placeholder"}
+                    :readonly true
+                    :field/value lipsum-short}])
    (example "field of type \"texta\""
-            [:form
-             [field {:field/type :texta
-                     :field/title {:en "Title"}
-                     :field/placeholder {:en "placeholder"}}]])
+            [field {:field/type :texta
+                    :field/title {:en "Title"}
+                    :field/placeholder {:en "placeholder"}}])
    (example "field of type \"texta\" with maximum length"
-            [:form
-             [field {:field/type :texta
-                     :field/title {:en "Title"}
-                     :field/placeholder {:en "placeholder"}
-                     :field/max-length 10}]])
+            [field {:field/type :texta
+                    :field/title {:en "Title"}
+                    :field/placeholder {:en "placeholder"}
+                    :field/max-length 10}])
    (example "field of type \"texta\" with validation error"
-            [:form
-             [field {:field/type :texta
-                     :field/title {:en "Title"}
-                     :field/placeholder {:en "placeholder"}
-                     :validation {:type :t.form.validation/required}}]])
+            [field {:field/type :texta
+                    :field/title {:en "Title"}
+                    :field/placeholder {:en "placeholder"}
+                    :validation {:type :t.form.validation/required}}])
    (example "non-editable field of type \"texta\""
-            [:form
-             [field {:field/type :texta
-                     :field/title {:en "Title"}
-                     :field/placeholder {:en "placeholder"}
-                     :readonly true
-                     :field/value lipsum-paragraphs}]])
+            [field {:field/type :texta
+                    :field/title {:en "Title"}
+                    :field/placeholder {:en "placeholder"}
+                    :readonly true
+                    :field/value lipsum-paragraphs}])
    (let [previous-lipsum-paragraphs (-> lipsum-paragraphs
                                         (str/replace "ipsum primis in faucibus orci luctus" "eu mattis purus mi eu turpis")
                                         (str/replace "per inceptos himenaeos" "justo erat hendrerit magna"))]
      [:div
       (example "editable field of type \"texta\" with previous value, diff hidden"
-               [:form
-                [field {:field/type :texta
-                        :field/title {:en "Title"}
-                        :field/placeholder {:en "placeholder"}
-                        :field/value lipsum-paragraphs
-                        :field/previous-value previous-lipsum-paragraphs}]])
+               [field {:field/type :texta
+                       :field/title {:en "Title"}
+                       :field/placeholder {:en "placeholder"}
+                       :field/value lipsum-paragraphs
+                       :field/previous-value previous-lipsum-paragraphs}])
       (example "editable field of type \"texta\" with previous value, diff shown"
-               [:form
-                [field {:field/type :texta
-                        :field/title {:en "Title"}
-                        :field/placeholder {:en "placeholder"}
-                        :field/value lipsum-paragraphs
-                        :field/previous-value previous-lipsum-paragraphs
-                        :diff true}]])
+               [field {:field/type :texta
+                       :field/title {:en "Title"}
+                       :field/placeholder {:en "placeholder"}
+                       :field/value lipsum-paragraphs
+                       :field/previous-value previous-lipsum-paragraphs
+                       :diff true}])
       (example "non-editable field of type \"texta\" with previous value, diff hidden"
-               [:form
-                [field {:field/type :texta
-                        :field/title {:en "Title"}
-                        :field/placeholder {:en "placeholder"}
-                        :readonly true
-                        :field/value lipsum-paragraphs
-                        :field/previous-value previous-lipsum-paragraphs}]])
+               [field {:field/type :texta
+                       :field/title {:en "Title"}
+                       :field/placeholder {:en "placeholder"}
+                       :readonly true
+                       :field/value lipsum-paragraphs
+                       :field/previous-value previous-lipsum-paragraphs}])
       (example "non-editable field of type \"texta\" with previous value, diff shown"
-               [:form
-                [field {:field/type :texta
-                        :field/title {:en "Title"}
-                        :field/placeholder {:en "placeholder"}
-                        :readonly true
-                        :field/value lipsum-paragraphs
-                        :field/previous-value previous-lipsum-paragraphs
-                        :diff true}]])
+               [field {:field/type :texta
+                       :field/title {:en "Title"}
+                       :field/placeholder {:en "placeholder"}
+                       :readonly true
+                       :field/value lipsum-paragraphs
+                       :field/previous-value previous-lipsum-paragraphs
+                       :diff true}])
       (example "non-editable field of type \"texta\" with previous value equal to current value"
-               [:form
-                [field {:field/type :texta
-                        :field/title {:en "Title"}
-                        :field/placeholder {:en "placeholder"}
-                        :readonly true
-                        :field/value lipsum-paragraphs
-                        :field/previous-value lipsum-paragraphs}]])])
+               [field {:field/type :texta
+                       :field/title {:en "Title"}
+                       :field/placeholder {:en "placeholder"}
+                       :readonly true
+                       :field/value lipsum-paragraphs
+                       :field/previous-value lipsum-paragraphs}])])
    (example "field of type \"attachment\""
-            [:form
-             [field {:app-id 5
-                     :field/id 6
-                     :field/type :attachment
-                     :field/title {:en "Title"}}]])
+            [field {:app-id 5
+                    :field/id 6
+                    :field/type :attachment
+                    :field/title {:en "Title"}}])
    (example "field of type \"attachment\", file uploaded"
-            [:form
-             [field {:app-id 5
-                     :field/id 6
-                     :field/type :attachment
-                     :field/title {:en "Title"}
-                     :field/value "123"
-                     :field/attachment {:attachment/id 123
-                                        :attachment/filename "test.txt"}}]])
+            [field {:app-id 5
+                    :field/id 6
+                    :field/type :attachment
+                    :field/title {:en "Title"}
+                    :field/value "123"
+                    :field/attachment {:attachment/id 123
+                                       :attachment/filename "test.txt"}}])
    (example "field of type \"attachment\", file uploaded, success indicator"
-            [:form
-             [field {:app-id 5
-                     :field/id 6
-                     :field/type :attachment
-                     :field/title {:en "Title"}
-                     :field/value "123"
-                     :field/attachment {:attachment/id 123
-                                        :attachment/filename "test.txt"}
-                     :success true}]])
+            [field {:app-id 5
+                    :field/id 6
+                    :field/type :attachment
+                    :field/title {:en "Title"}
+                    :field/value "123"
+                    :field/attachment {:attachment/id 123
+                                       :attachment/filename "test.txt"}
+                    :success true}])
    (example "field of type \"attachment\", previous and new file uploaded, diff shown"
-            [:form
-             [field {:app-id 5
-                     :field/id 6
-                     :field/type :attachment
-                     :field/title {:en "Title"}
-                     :field/value "123"
-                     :field/previous-value "456"
-                     :field/attachment {:attachment/id 123
-                                        :attachment/filename "new.txt"}
-                     :field/previous-attachment {:attachment/id 456
-                                                 :attachment/filename "old.txt"}
-                     :diff true}]])
+            [field {:app-id 5
+                    :field/id 6
+                    :field/type :attachment
+                    :field/title {:en "Title"}
+                    :field/value "123"
+                    :field/previous-value "456"
+                    :field/attachment {:attachment/id 123
+                                       :attachment/filename "new.txt"}
+                    :field/previous-attachment {:attachment/id 456
+                                                :attachment/filename "old.txt"}
+                    :diff true}])
    (example "field of type \"attachment\", previous and new file uploaded, diff hidden"
-            [:form
-             [field {:app-id 5
-                     :field/id 6
-                     :field/type :attachment
-                     :field/title {:en "Title"}
-                     :field/value "123"
-                     :field/previous-value "456"
-                     :field/attachment {:attachment/id 123
-                                        :attachment/filename "new.txt"}
-                     :field/previous-attachment {:attachment/id 456
-                                                 :attachment/filename "old.txt"}}]])
+            [field {:app-id 5
+                    :field/id 6
+                    :field/type :attachment
+                    :field/title {:en "Title"}
+                    :field/value "123"
+                    :field/previous-value "456"
+                    :field/attachment {:attachment/id 123
+                                       :attachment/filename "new.txt"}
+                    :field/previous-attachment {:attachment/id 456
+                                                :attachment/filename "old.txt"}}])
    (example "field of type \"attachment\", previous file uploaded, new deleted, diff shown"
-            [:form
-             [field {:app-id 5
-                     :field/id 6
-                     :field/type :attachment
-                     :field/title {:en "Title"}
-                     :field/previous-value "456"
-                     :field/previous-attachment {:attachment/id 456
-                                                 :attachment/filename "old.txt"}
-                     :diff true}]])
+            [field {:app-id 5
+                    :field/id 6
+                    :field/type :attachment
+                    :field/title {:en "Title"}
+                    :field/previous-value "456"
+                    :field/previous-attachment {:attachment/id 456
+                                                :attachment/filename "old.txt"}
+                    :diff true}])
    (example "field of type \"attachment\", previous file uploaded, new deleted, diff hidden"
-            [:form
-             [field {:app-id 5
-                     :field/id 6
-                     :field/type :attachment
-                     :field/title {:en "Title"}
-                     :field/previous-value "456"
-                     :field/previous-attachment {:attachment/id 456
-                                                 :attachment/filename "old.txt"}}]])
+            [field {:app-id 5
+                    :field/id 6
+                    :field/type :attachment
+                    :field/title {:en "Title"}
+                    :field/previous-value "456"
+                    :field/previous-attachment {:attachment/id 456
+                                                :attachment/filename "old.txt"}}])
    (example "non-editable field of type \"attachment\""
-            [:form
-             [field {:app-id 5
-                     :field/id 6
-                     :field/type :attachment
-                     :field/title {:en "Title"}
-                     :readonly true}]])
+            [field {:app-id 5
+                    :field/id 6
+                    :field/type :attachment
+                    :field/title {:en "Title"}
+                    :readonly true}])
    (example "non-editable field of type \"attachment\", file uploaded"
-            [:form
-             [field {:app-id 5
-                     :field/id 6
-                     :field/type :attachment
-                     :field/title {:en "Title"}
-                     :readonly true
-                     :field/value "123"
-                     :field/attachment {:attachment/id 123
-                                        :attachment/filename "test.txt"}}]])
+            [field {:app-id 5
+                    :field/id 6
+                    :field/type :attachment
+                    :field/title {:en "Title"}
+                    :readonly true
+                    :field/value "123"
+                    :field/attachment {:attachment/id 123
+                                       :attachment/filename "test.txt"}}])
    (example "field of type \"date\""
-            [:form
-             [field {:field/type :date
-                     :field/title {:en "Title"}}]])
+            [field {:field/type :date
+                    :field/title {:en "Title"}}])
    (example "field of type \"date\" with value"
-            [:form
-             [field {:field/type :date
-                     :field/title {:en "Title"}
-                     :field/value "2000-12-31"}]])
+            [field {:field/type :date
+                    :field/title {:en "Title"}
+                    :field/value "2000-12-31"}])
    (example "non-editable field of type \"date\""
-            [:form
-             [field {:field/type :date
-                     :field/title {:en "Title"}
-                     :readonly true
-                     :field/value ""}]])
+            [field {:field/type :date
+                    :field/title {:en "Title"}
+                    :readonly true
+                    :field/value ""}])
    (example "non-editable field of type \"date\" with value"
-            [:form
-             [field {:field/type :date
-                     :field/title {:en "Title"}
-                     :readonly true
-                     :field/value "2000-12-31"}]])
+            [field {:field/type :date
+                    :field/title {:en "Title"}
+                    :readonly true
+                    :field/value "2000-12-31"}])
    (example "field of type \"option\""
-            [:form
-             [field {:field/type :option
-                     :field/title {:en "Title"}
-                     :field/value "y"
-                     :field/options [{:key "y" :label {:en "Yes" :fi "Kyllä"}}
-                                     {:key "n" :label {:en "No" :fi "Ei"}}]}]])
+            [field {:field/type :option
+                    :field/title {:en "Title"}
+                    :field/value "y"
+                    :field/options [{:key "y" :label {:en "Yes" :fi "Kyllä"}}
+                                    {:key "n" :label {:en "No" :fi "Ei"}}]}])
    (example "non-editable field of type \"option\""
-            [:form
-             [field {:field/type :option
-                     :field/title {:en "Title"}
-                     :field/value "y"
-                     :readonly true
-                     :field/options [{:key "y" :label {:en "Yes" :fi "Kyllä"}}
-                                     {:key "n" :label {:en "No" :fi "Ei"}}]}]])
+            [field {:field/type :option
+                    :field/title {:en "Title"}
+                    :field/value "y"
+                    :readonly true
+                    :field/options [{:key "y" :label {:en "Yes" :fi "Kyllä"}}
+                                    {:key "n" :label {:en "No" :fi "Ei"}}]}])
    (example "field of type \"multiselect\""
-            [:form
-             [field {:field/type :multiselect
-                     :field/title {:en "Title"}
-                     :field/value "egg bacon"
-                     :field/options [{:key "egg" :label {:en "Egg" :fi "Munaa"}}
-                                     {:key "bacon" :label {:en "Bacon" :fi "Pekonia"}}
-                                     {:key "spam" :label {:en "Spam" :fi "Lihasäilykettä"}}]}]])
+            [field {:field/type :multiselect
+                    :field/title {:en "Title"}
+                    :field/value "egg bacon"
+                    :field/options [{:key "egg" :label {:en "Egg" :fi "Munaa"}}
+                                    {:key "bacon" :label {:en "Bacon" :fi "Pekonia"}}
+                                    {:key "spam" :label {:en "Spam" :fi "Lihasäilykettä"}}]}])
    (example "non-editable field of type \"multiselect\""
-            [:form
-             [field {:field/type :multiselect
-                     :field/title {:en "Title"}
-                     :field/value "egg bacon"
-                     :readonly true
-                     :field/options [{:key "egg" :label {:en "Egg" :fi "Munaa"}}
-                                     {:key "bacon" :label {:en "Bacon" :fi "Pekonia"}}
-                                     {:key "spam" :label {:en "Spam" :fi "Lihasäilykettä"}}]}]])
+            [field {:field/type :multiselect
+                    :field/title {:en "Title"}
+                    :field/value "egg bacon"
+                    :readonly true
+                    :field/options [{:key "egg" :label {:en "Egg" :fi "Munaa"}}
+                                    {:key "bacon" :label {:en "Bacon" :fi "Pekonia"}}
+                                    {:key "spam" :label {:en "Spam" :fi "Lihasäilykettä"}}]}])
    (example "optional field"
-            [:form
-             [field {:field/type :texta
-                     :field/optional true
-                     :field/title {:en "Title"}
-                     :field/placeholder {:en "placeholder"}}]])
+            [field {:field/type :texta
+                    :field/optional true
+                    :field/title {:en "Title"}
+                    :field/placeholder {:en "placeholder"}}])
    (example "field of type \"label\""
-            [:form
-             [field {:field/type :label
-                     :field/title {:en "Lorem ipsum dolor sit amet"}}]])
+            [field {:field/type :label
+                    :field/title {:en "Lorem ipsum dolor sit amet"}}])
    (example "field of type \"description\""
-            [:form
-             [field {:field/type :description
-                     :field/title {:en "Title"}
-                     :field/placeholder {:en "placeholder"}}]])])
+            [field {:field/type :description
+                    :field/title {:en "Title"}
+                    :field/placeholder {:en "placeholder"}}])])


### PR DESCRIPTION
They were not rendering as code because of the wrapping form tag. I
checked that removing the form tag doesn't affect appearance.