### PR TITLE
Rahti: add certificate to store

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,5 @@
+# For documentation see docs/docker.md
+
 FROM openjdk:11-jre-slim
 
 RUN mkdir /rems

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,3 +8,5 @@ ENTRYPOINT ["./docker-entrypoint.sh"]
 COPY empty-config.edn /rems/config/config.edn
 COPY target/uberjar/rems.jar /rems/rems.jar
 COPY docker-entrypoint.sh /rems/docker-entrypoint.sh
+
+RUN chmod 664 /usr/local/openjdk-11/lib/security/cacerts

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -4,6 +4,19 @@ cd rems
 
 [ -z "$COMMANDS" ] && COMMANDS="run"
 
+certfile=$(ls /rems/certs)
+
+if [ ! -z ${certfile} ] && [ "${certfile}" != "null" ] ; then
+    keytool -importcert -cacerts -noprompt \
+            -storepass changeit \
+            -file /rems/certs/${certfile} \
+            -alias ${certfile}
+
+    keytool -storepasswd -cacerts \
+            -storepass changeit  \
+            -new $(head /dev/urandom | tr -dc A-Za-z0-9 | head -c 20)
+fi
+
 for COMMAND in $COMMANDS
 do
     if [ "${COMMAND}" = "run" ] ; then

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -1,0 +1,8 @@
+# Deploy Rems in docker
+
+1. Build rems with lein or copy rems.jar to target/uberjar/rems.jar
+2. Build rems docker image. Use the docker file located in the root directory of rems git.
+Example command: `docker build /path/to/rems/git/root/dir/ -t rems:tag`
+2. Mount your config.edn file to /rems/config/config.edn in the container (Optional)
+3. Mount certificate to be added to rems certificate store to /rems/certs/.
+This process currecntly supports only one certificate. (Optional)


### PR DESCRIPTION
 - If certificate exists under /rems/certs/ add it to
   cacerts certificate store before starting rems

# Definition of Done / Review checklist

## Reviewability
- [ ] link to issue
- [ ] note if PR is on top of other PR
- [ ] note if related change in rems-deploy repo
- [ ] consider adding screenshots for ease of review

## API
- [ ] API is documented and shows up in Swagger UI
- [ ] API is backwards compatible or completely new
- [ ] Events are backwards compatible

## Documentation
- [ ] update changelog if necessary
- [ ] add or update docstrings for namespaces and functions
- [ ] components are added to guide page
- [ ] documentation _at least_ for config options (i.e. docs folder)
- [ ] ADR for major architectural decisions or experiments

## Different installations
- [ ] new configuration options added to rems-deploy repository
- [ ] instance specific translations (i.e. LBR kielivara)

## Testing
- [ ] complex logic is unit tested
- [ ] valuable features are integration / browser / acceptance tested automatically

## Accessibility
- [ ] all icons have the aria-label attribute
- [ ] all fields have a label
- [ ] errors are linked to fields with aria-describedby
- [ ] contrast is checked
- [ ] conscious decision about where to move focus after an action

## Follow-up
- [ ] new tasks are created for pending or remaining tasks
- [ ] no critical TODOs left to implement
