### PR TITLE
fix: remove self-refer from rems.browser-test-util

### DIFF
--- a/test/clj/rems/browser_test_util.clj
+++ b/test/clj/rems/browser_test_util.clj
@@ -10,8 +10,7 @@
             [medley.core :refer [assoc-some]]
             [rems.api.testing :refer [standalone-fixture]]
             [rems.config]
-            [rems.standalone]
-            [rems.browser-test-util :as btu])
+            [rems.standalone])
   (:import (java.net SocketException)))
 
 ;;; test setup


### PR DESCRIPTION
it's not needed and it breaks (reload)