### PR TITLE
fix: make enrich-dependency public

### DIFF
--- a/src/clj/rems/api/services/dependencies.clj
+++ b/src/clj/rems/api/services/dependencies.clj
@@ -7,7 +7,7 @@
             [rems.db.resource :as resource]
             [rems.db.workflow :as workflow]))
 
-(defn- enrich-dependency [dep]
+(defn enrich-dependency [dep]
   (cond
     (:license/id dep) (licenses/get-license (:license/id dep))
     (:resource/id dep) (resource/get-resource (:resource/id dep))


### PR DESCRIPTION
it's used by rems.api.services.workflow