### PR TITLE
Call validate-fields explicitly instead of as an injection.

### DIFF
--- a/src/clj/rems/api/services/command.clj
+++ b/src/clj/rems/api/services/command.clj
@@ -47,7 +47,6 @@
 
 (def ^:private command-injections
   {:valid-user? users/user-exists?
-   :validate-fields form-validation/validate-fields
    :secure-token secure-token
    :get-catalogue-item catalogue/get-localized-catalogue-item
    :get-catalogue-item-licenses applications/get-catalogue-item-licenses

--- a/src/clj/rems/application/commands.clj
+++ b/src/clj/rems/application/commands.clj
@@ -3,6 +3,7 @@
             [medley.core :refer [assoc-some]]
             [rems.common.util :refer [build-index]]
             [rems.common.application-util :as application-util]
+            [rems.form-validation :as form-validation]
             [rems.permissions :as permissions]
             [rems.util :refer [assert-ex getx getx-in try-catch-ex update-present]]
             [schema-refined.core :as r]
@@ -236,9 +237,9 @@
   (when-not (application-util/is-handler? application actor)
     (unbundlable-catalogue-items catalogue-item-ids injections)))
 
-(defn- validation-error [application injections]
+(defn- validation-error [application]
   (let [errors (for [form (:application/forms application)
-                     error ((getx injections :validate-fields) (:form/fields form))]
+                     error (form-validation/validate-fields (:form/fields form))]
                  (assoc error :form-id (:form/id form)))]
     (when (seq errors)
       {:errors errors})))
@@ -355,7 +356,7 @@
   (or (merge-with concat
                   (disabled-catalogue-items-error application)
                   (licenses-not-accepted-error application (:actor cmd))
-                  (validation-error application injections))
+                  (validation-error application))
       (ok {:event/type :application.event/submitted})))
 
 (defmethod command-handler :application.command/approve

--- a/test/clj/rems/application/test_commands.clj
+++ b/test/clj/rems/application/test_commands.clj
@@ -601,8 +601,7 @@
                             :catalogue-item-ids []}))))))
 
 (deftest test-submit
-  (let [injections {:validate-fields form-validation/validate-fields
-                    :get-form-template dummy-get-form-template}
+  (let [injections {:get-form-template dummy-get-form-template}
         created-event {:event/type :application.event/created
                        :event/time test-time
                        :event/actor applicant-user-id
@@ -727,8 +726,7 @@
                                      {:type :application.command/return
                                       :actor handler-user-id
                                       :comment "ret"})
-          submit-injections {:validate-fields form-validation/validate-fields
-                             :get-form-template dummy-get-form-template}
+          submit-injections {:get-form-template dummy-get-form-template}
           submit-command {:type :application.command/submit
                           :actor applicant-user-id}]
       (is (= {:event/type :application.event/returned


### PR DESCRIPTION
Spinoff from #2117

# Definition of Done / Review checklist

## Reviewability
- [ ] link to issue
- [ ] note if PR is on top of other PR
- [ ] note if related change in rems-deploy repo
- [ ] consider adding screenshots for ease of review

## API
- [ ] API is documented and shows up in Swagger UI
- [ ] API is backwards compatible or completely new
- [ ] Events are backwards compatible

## Documentation
- [ ] update changelog if necessary
- [ ] add or update docstrings for namespaces and functions
- [ ] components are added to guide page
- [ ] documentation _at least_ for config options (i.e. docs folder)
- [ ] ADR for major architectural decisions or experiments

## Different installations
- [ ] new configuration options added to rems-deploy repository
- [ ] instance specific translations (i.e. LBR kielivara)

## Testing
- [ ] complex logic is unit tested
- [ ] valuable features are integration / browser / acceptance tested automatically

## Accessibility
- [ ] all icons have the aria-label attribute
- [ ] all fields have a label
- [ ] errors are linked to fields with aria-describedby
- [ ] contrast is checked
- [ ] conscious decision about where to move focus after an action

## Follow-up
- [ ] new tasks are created for pending or remaining tasks
- [ ] no critical TODOs left to implement
