### PR TITLE
fix: unauthorized /catalogue if the user has not yet logged in

### DIFF
--- a/src/clj/rems/api/catalogue.clj
+++ b/src/clj/rems/api/catalogue.clj
@@ -3,7 +3,7 @@
             [rems.api.schema :refer :all]
             [rems.api.services.catalogue :as catalogue]
             [rems.api.util] ; required for route :roles
-            [rems.auth.util :refer [throw-forbidden]]
+            [rems.auth.util :refer [throw-forbidden throw-unauthorized]]
             [rems.config :refer [env]]
             [rems.roles :as roles]
             [ring.util.http-response :refer :all]
@@ -18,7 +18,13 @@
     (GET "/" []
       :summary "Get the catalogue of items for the UI (does not include archived items)"
       :return GetCatalogueResponse
-      (if (or (:catalogue-is-public env)
-              (roles/has-roles? :logged-in))
+      (cond
+        (or (:catalogue-is-public env)
+            (roles/has-roles? :logged-in))
         (ok (catalogue/get-localized-catalogue-items {:archived false}))
+
+        (not (roles/has-roles? :logged-in))
+        (throw-unauthorized)
+
+        :else
         (throw-forbidden)))))

--- a/test/clj/rems/api/test_catalogue.clj
+++ b/test/clj/rems/api/test_catalogue.clj
@@ -27,6 +27,6 @@
   (testing "catalogue-is-public false"
     (with-redefs [rems.config/env (assoc rems.config/env :catalogue-is-public false)]
       (is (api-call :get "/api/catalogue" nil "42" "alice") "should work for a regular user")
-      (is (= "forbidden" (read-body (api-response :get "/api/catalogue" nil nil nil))) "should be forbidden without authentication")
-      (is (= "forbidden" (read-body (api-response :get "/api/catalogue" nil "invalid-api-key" nil))) "should not work with wrong api key")
-      (is (= "forbidden" (read-body (api-response :get "/api/catalogue" nil "42" nil))) "should not work without a user"))))
+      (is (= "unauthorized" (read-body (api-response :get "/api/catalogue" nil nil nil))) "should be unauthorized without authentication")
+      (is (= "unauthorized" (read-body (api-response :get "/api/catalogue" nil "invalid-api-key" nil))) "should not work with wrong api key")
+      (is (= "unauthorized" (read-body (api-response :get "/api/catalogue" nil "42" nil))) "should not work without a user"))))


### PR DESCRIPTION
Previously if you go to `/catalogue` you will get a forbidden if the user
has not logged in. We want to give unauthorized here instead so the user
will be directed to log in. We give forbidden only if the user
actually doesn't have access rights to the catalogue and we know who
they are.