### PR TITLE
Fix a typo and slight modifications to emails

### DIFF
--- a/resources/translations/en.edn
+++ b/resources/translations/en.edn
@@ -263,11 +263,11 @@
                                  :subject-to-handler "(%3) Application has been rejected"
                                  :message-to-handler "Dear %1,\n\n%2 has rejected the application %3 from %4.\n\nYou can view the application and the decision at %6"}
           :application-closed {:subject-to-applicant "Your application %3 has been closed"
-                               :message-to-applicant "Dear %1,\n\nYour application %3 has been closed.\n\nYou can view the application at %6"
+                               :message-to-applicant "Dear %1,\n\nYour application %3 has been closed.\n\nYou can still view the application at %6"
                                :subject-to-handler "(%3) Application has been closed"
                                :message-to-handler "Dear %1,\n\n%2 has closed the application %3 from %4.\n\nYou can view the application at %6"}
           :application-returned {:subject-to-applicant "Your application %3 needs to be amended"
-                                 :message-to-applicant "Dear %1,\n\nYour application %3 has been returned for your consideration. Please, amend according to requests and resubmit.\n\nYou can review the application at %6"
+                                 :message-to-applicant "Dear %1,\n\nYour application %3 has been returned for your consideration. Please, amend according to requests and resubmit.\n\nYou can view and edit the application at %6"
                                  :subject-to-handler "(%3) Application has been returned to applicant"
                                  :message-to-handler "Dear %1,\n\n%2 has returned the application %3 to the applicant %4 for modifications.\n\nYou can view the application at %6"}
           :application-revoked {:subject-to-applicant "Entitlements related to your application %3 have been revoked"
@@ -275,7 +275,7 @@
                                 :subject-to-handler "(%3) Entitlements have been revoked"
                                 :message-to-handler "Dear %1,\n\n%2 has revoked the entitlements related to application %3 from %4.\n\nYou can view the application at %6"}
           :application-licenses-added {:subject "Your application's %3 terms of use have changed"
-                                       :message "Dear %1,\n\n%2 has requested your approval for changed terms of use to application %3.\n\nYou can review the application and approve the changed the terms of use at %6"}
+                                       :message "Dear %1,\n\n%2 has requested your approval for changed terms of use to application %3.\n\nYou can view the application and approve the changed terms of use at %6"}
           :application-resubmitted {:subject "(%3) Application has been resubmitted"
                                     :message "Dear %1,\n\nApplication %3 has been resubmitted by %4.\n\nYou can review the application at %6"}
           :application-submitted {:subject "(%3) A new application has been submitted"
@@ -294,7 +294,7 @@
                            :message "Dear %1,\n\nYou have been invited to participate in application %3, by %2.\n\nYou can view the application and accept the terms of use at %4"}
           :regards "\n\nKind regards,\n\nREMS\n"
           :remarked {:subject "(%3) Application has been commented"
-                     :message "Dear %1,\n\n%2 has commented on the application %3, submitted by %4.\n\nYou can view the comment and the application at %6"}
+                     :message "Dear %1,\n\n%2 has commented your application %3, submitted by %4.\n\nYou can view the application and the comment at %6"}
           :review-requested {:subject "(%3) Review request"
                              :message "Dear %1,\n\n%2 has requested your review on application %3, submitted by %4.\n\nYou can review the application at %6"}
           :reviewed {:subject "(%3) Application has been reviewed"

--- a/resources/translations/fi.edn
+++ b/resources/translations/fi.edn
@@ -261,11 +261,11 @@
                                  :subject-to-handler "(%3) Hakemus on hylätty"
                                  :message-to-handler "Hyvä %1,\n\n%2 on hylännyt käyttäjän %4 hakemuksen %3.\n\nVoit tarkastella hakemusta ja päätöstä osoitteessa %6"}
           :application-closed {:subject-to-applicant "Hakemuksesi %3 on suljettu"
-                               :message-to-applicant "Hyvä %1,\n\nHakemuksesi %3 on suljettu.\n\nVoit tarkastella hakemusta: %6"
+                               :message-to-applicant "Hyvä %1,\n\nHakemuksesi %3 on suljettu.\n\nVoit yhä tarkastella hakemusta: %6"
                                :subject-to-handler "(%3) Hakemus on suljettu"
                                :message-to-handler "Hyvä %1,\n\n%2 on sulkenut käyttäjän %4 hakemuksen %3.\n\nVoit tarkastella hakemusta: %6"}
           :application-returned {:subject-to-applicant "Hakemuksesi %3 vaatii täydentämistä"
-                                 :message-to-applicant "Hyvä %1,\n\nHakemuksesi %3 on palautettu muokattavaksesi. Ole hyvä ja täydennä hakemusta kommenttien mukaan.\n\nVoit tarkastella hakemusta osoitteessa %6"
+                                 :message-to-applicant "Hyvä %1,\n\nHakemuksesi %3 on palautettu muokattavaksesi. Ole hyvä ja täydennä hakemusta kommenttien mukaan.\n\nVoit tarkastella ja muokata hakemusta osoitteessa %6"
                                  :subject-to-handler "(%3) Hakemus on palautettu"
                                  :message-to-handler "Hyvä %1,\n\n%2 on palauttanut käyttäjän %4 hakemuksen %3.\n\nVoit tarkastella hakemusta osoitteessa %6"}
           :application-revoked {:subject-to-applicant "Hakemukseesi %3 liittyvät käyttöoikeudet on peruttu"

--- a/test/clj/rems/email/test_template.clj
+++ b/test/clj/rems/email/test_template.clj
@@ -189,7 +189,7 @@
     (is (= #{"assistant" "handler"} (email-recipients mails)))
     (is (= {:to-user "assistant"
             :subject "(2001/3, \"Application title\") Application has been commented"
-            :body "Dear Amber Assistant,\n\nRandom Remarker has commented on the application 2001/3, \"Application title\", submitted by Alice Applicant.\n\nYou can view the comment and the application at http://example.com/application/7"}
+            :body "Dear Amber Assistant,\n\nRandom Remarker has commented your application 2001/3, \"Application title\", submitted by Alice Applicant.\n\nYou can view the application and the comment at http://example.com/application/7"}
            (email-to "assistant" mails))))
   (let [mails (emails base-events {:application/id 7
                                    :event/type :application.event/remarked
@@ -199,7 +199,7 @@
     (is (= #{"assistant" "handler" "applicant"} (email-recipients mails)))
     (is (= {:to-user "applicant"
             :subject "(2001/3, \"Application title\") Application has been commented"
-            :body "Dear Alice Applicant,\n\nRandom Remarker has commented on the application 2001/3, \"Application title\", submitted by Alice Applicant.\n\nYou can view the comment and the application at http://example.com/application/7"}
+            :body "Dear Alice Applicant,\n\nRandom Remarker has commented your application 2001/3, \"Application title\", submitted by Alice Applicant.\n\nYou can view the application and the comment at http://example.com/application/7"}
            (email-to "applicant" mails)))))
 
 (deftest test-members-licenses-approved-closed
@@ -224,7 +224,7 @@
         (is (= #{"applicant" "member" "somebody"} (email-recipients mails)))
         (is (= {:to-user "applicant"
                 :subject "Your application's 2001/3, \"Application title\" terms of use have changed"
-                :body "Dear Alice Applicant,\n\nHannah Handler has requested your approval for changed terms of use to application 2001/3, \"Application title\".\n\nYou can review the application and approve the changed the terms of use at http://example.com/application/7"}
+                :body "Dear Alice Applicant,\n\nHannah Handler has requested your approval for changed terms of use to application 2001/3, \"Application title\".\n\nYou can view the application and approve the changed terms of use at http://example.com/application/7"}
                (email-to "applicant" mails)))))
     (testing "approved"
       (let [mails (emails member-events {:application/id 7
@@ -250,7 +250,7 @@
         (is (= #{"applicant" "member" "somebody" "handler"} (email-recipients mails)))
         (is (= {:to-user "applicant"
                 :subject "Your application 2001/3, \"Application title\" has been closed"
-                :body "Dear Alice Applicant,\n\nYour application 2001/3, \"Application title\" has been closed.\n\nYou can view the application at http://example.com/application/7"}
+                :body "Dear Alice Applicant,\n\nYour application 2001/3, \"Application title\" has been closed.\n\nYou can still view the application at http://example.com/application/7"}
                (email-to "applicant" mails)))
         (is (= {:to-user "handler"
                 :subject "(2001/3, \"Application title\") Application has been closed"
@@ -356,7 +356,7 @@
                   :event/actor "applicant"}]
     (is (= [{:to-user "applicant"
              :subject "Your application 2001/3, \"Application title\" needs to be amended"
-             :body "Dear Alice Applicant,\n\nYour application 2001/3, \"Application title\" has been returned for your consideration. Please, amend according to requests and resubmit.\n\nYou can review the application at http://example.com/application/7"}
+             :body "Dear Alice Applicant,\n\nYour application 2001/3, \"Application title\" has been returned for your consideration. Please, amend according to requests and resubmit.\n\nYou can view and edit the application at http://example.com/application/7"}
             {:to-user "assistant"
              :subject "(2001/3, \"Application title\") Application has been returned to applicant"
              :body "Dear Amber Assistant,\n\nHannah Handler has returned the application 2001/3, \"Application title\" to the applicant Alice Applicant for modifications.\n\nYou can view the application at http://example.com/application/7"}]


### PR DESCRIPTION
Fixed a typo in :application-licenses-added email message.
Also make some slight modifications to :application-closed and
:application-returned and :remarked.

https://github.com/CSCfi/rems/issues/2235

# Definition of Done / Review checklist

## Reviewability
- [ ] link to issue
- [ ] note if PR is on top of other PR
- [ ] note if related change in rems-deploy repo
- [ ] consider adding screenshots for ease of review

## API
- [ ] API is documented and shows up in Swagger UI
- [ ] API is backwards compatible or completely new
- [ ] Events are backwards compatible

## Documentation
- [ ] update changelog if necessary
- [ ] add or update docstrings for namespaces and functions
- [ ] components are added to guide page
- [ ] documentation _at least_ for config options (i.e. docs folder)
- [ ] ADR for major architectural decisions or experiments

## Different installations
- [ ] new configuration options added to rems-deploy repository
- [ ] instance specific translations (i.e. LBR kielivara)

## Testing
- [ ] complex logic is unit tested
- [ ] valuable features are integration / browser / acceptance tested automatically

## Accessibility
- [ ] all icons have the aria-label attribute
- [ ] all fields have a label
- [ ] errors are linked to fields with aria-describedby
- [ ] contrast is checked
- [ ] conscious decision about where to move focus after an action

## Follow-up
- [ ] new tasks are created for pending or remaining tasks
- [ ] no critical TODOs left to implement
