### PR TITLE
feat: don't set a transaction timeout for dev

### DIFF
--- a/dev-config.edn
+++ b/dev-config.edn
@@ -1,8 +1,6 @@
 {:dev true
  :nrepl-port 7000
  :database-url "postgresql://localhost/rems?user=rems"
- :database-lock-timeout "4s"
- :database-idle-in-transaction-session-timeout "8s"
  :test-database-url "postgresql://localhost/rems_test?user=rems_test"
  :search-index-path "target/search-index-dev"
  :theme-path "example-theme/theme.edn"

--- a/src/clj/rems/db/core.clj
+++ b/src/clj/rems/db/core.clj
@@ -6,14 +6,18 @@
             [clojure.set :refer [superset?]]
             [conman.core :as conman]
             [mount.core :refer [defstate] :as mount]
-            [rems.config :refer [env]]))
+            [rems.config :refer [env]]
+            [clojure.string :as str]))
 
 ;; See docs/architecture/010-transactions.md
 (defn- hikaricp-settings []
   ;; HikariConfig wants an actual String, no support for parameterized queries...
   {:connection-init-sql
-   (str "SET lock_timeout TO '" (:database-lock-timeout env) "'; "
-        "SET idle_in_transaction_session_timeout TO '" (:database-idle-in-transaction-session-timeout env) "';")})
+   (str/join [(when (:database-lock-timeout env)
+                (str "SET lock_timeout TO '" (:database-lock-timeout env) "';"))
+              (when (:database-idle-in-transaction-session-timeout env)
+                (str "SET idle_in_transaction_session_timeout TO '" (:database-idle-in-transaction-session-timeout env) "';"))])})
+        
 
 (defstate ^:dynamic *db*
   :start (try (let [db (cond (:test (mount/args)) (conman/connect! (merge (hikaricp-settings)

--- a/test/clj/rems/db/test_transactions.clj
+++ b/test/clj/rems/db/test_transactions.clj
@@ -69,7 +69,10 @@
         wrapped-handle-command (fn [cmd application injections]
                                  (mark-observed-app-version (old-handle-command cmd application injections)
                                                             application))]
-    (with-redefs [commands/handle-command wrapped-handle-command]
+    (with-redefs [commands/handle-command wrapped-handle-command
+                  rems.config/env (assoc rems.config/env
+                                         :database-lock-timeout "4s"
+                                          :database-idle-in-transaction-session-timeout "8s")]
       (let [write-event (fn [app-id]
                           (try
                             (conman/with-transaction [db/*db* {:isolation :serializable}]


### PR DESCRIPTION
Don't set a transaction timeout for development use so that you can single-step while debugging.