### PR TITLE
fix: don't try to emit deprecated :organizations key in /api/config

### DIFF
--- a/src/clj/rems/api/public.clj
+++ b/src/clj/rems/api/public.clj
@@ -60,8 +60,7 @@
                             :default-language
                             :dev
                             :extra-pages
-                            :languages
-                            :organizations])))
+                            :languages])))
 
     (GET "/full" []
       :summary "Get (almost) full configuration"


### PR DESCRIPTION
follow-up for #2039

see also rems-deploy#179

# Definition of Done / Review checklist

## Reviewability
- [x] link to issue
- [x] note if related change in rems-deploy repo

## API
- [x] API is documented and shows up in Swagger UI
- [ ] API is backwards compatible or completely new

## Documentation
- [x] update changelog if necessary
  - #2039 is already mentioned there

## Different installations
- [ ] new configuration options added to rems-deploy repository
  - should remove old ones at some point :)

## Follow-up
- [ ] new tasks are created for pending or remaining tasks