### PR TITLE
feat: use enabled and archived without organization ns

### DIFF
--- a/src/clj/rems/api/schema.clj
+++ b/src/clj/rems/api/schema.clj
@@ -45,8 +45,8 @@
           (s/optional-key :organization/owners) [User]
           (s/optional-key :organization/review-emails) [{:name LocalizedString
                                                          :email s/Str}]
-          (s/optional-key :organization/enabled) s/Bool
-          (s/optional-key :organization/archived) s/Bool}))
+          (s/optional-key :enabled) s/Bool
+          (s/optional-key :archived) s/Bool}))
 
 (s/defschema CatalogueItemLocalizations
   {s/Keyword {;; TODO :id (it's the catalogue item id) and :langcode
@@ -125,11 +125,11 @@
 
 (s/defschema OrganizationEnabledCommand
   (merge OrganizationId
-         {:organization/enabled s/Bool}))
+         {:enabled s/Bool}))
 
 (s/defschema OrganizationArchivedCommand
   (merge OrganizationId
-         {:organization/archived s/Bool}))
+         {:archived s/Bool}))
 
 (s/defschema SuccessResponse
   {:success s/Bool

--- a/src/clj/rems/api/services/dependencies.clj
+++ b/src/clj/rems/api/services/dependencies.clj
@@ -51,7 +51,7 @@
 
 (defn- add-status-bits [dep]
   (merge dep
-         (select-keys (enrich-dependency dep) [:archived :enabled :organization/archived :organization/enabled])))
+         (select-keys (enrich-dependency dep) [:archived :enabled])))
 
 (defn- only-id [item]
   (select-keys item [:resource/id :license/id :catalogue-item/id :form/id :workflow/id]))
@@ -111,7 +111,6 @@
   (when-let [users (->> (get-in (dependencies) [:reverse-dependencies item])
                         (mapv add-status-bits)
                         (remove :archived)
-                        (remove :organization/archived)
                         seq)]
     {:success false
      :errors [(merge {:type :t.administration.errors/in-use-by}
@@ -122,7 +121,7 @@
   [item]
   (when-let [used (->> (get-in (dependencies) [:dependencies item])
                        (mapv add-status-bits)
-                       (filter #(or (:archived %) (:organization/archived %)))
+                       (filter :archived)
                        seq)]
     {:success false
      :errors [(merge {:type :t.administration.errors/dependencies-archived}

--- a/src/clj/rems/api/services/organizations.clj
+++ b/src/clj/rems/api/services/organizations.clj
@@ -42,11 +42,11 @@
   (organizations/add-organization! userid org))
 
 (defn set-organization-enabled! [{:keys [id enabled]}]
-  (organizations/update-organization! id (fn [organization] (assoc organization :organization/enabled enabled)))
+  (organizations/update-organization! id (fn [organization] (assoc organization :enabled enabled)))
   {:success true})
 
 (defn set-organization-archived! [{:keys [id archived]}]
   (or (dependencies/change-archive-status-error archived  {:organization/id id})
       (do
-        (organizations/update-organization! id (fn [organization] (assoc organization :organization/archived archived)))
+        (organizations/update-organization! id (fn [organization] (assoc organization :archived archived)))
         {:success true})))

--- a/src/clj/rems/db/organizations.clj
+++ b/src/clj/rems/db/organizations.clj
@@ -13,8 +13,8 @@
                          :user userid
                          :time (DateTime.)
                          :data (json/generate-string (-> org
-                                                         (assoc :organization/enabled true
-                                                                :organization/archived false)
+                                                         (assoc :enabled true
+                                                                :archived false)
                                                          (dissoc :organization/id)))})
   {:success true
    :organization/id (:organization/id org)})

--- a/test/clj/rems/api/services/test_organizations.clj
+++ b/test/clj/rems/api/services/test_organizations.clj
@@ -11,7 +11,7 @@
 (defn- status-flags [id]
   (with-user "owner"
     (-> (organizations/get-organization {:organization/id id})
-        (select-keys [:organization/enabled :organization/archived]))))
+        (select-keys [:enabled :archived]))))
 
 (deftest organization-enabled-archived-test
   (test-data/create-user! {:eppn "owner"} :owner)
@@ -20,8 +20,8 @@
           org-id2 (test-data/create-organization! {:organization/id "test-org-2"})]
 
       (testing "new organizations are enabled and not archived"
-        (is (= {:organization/enabled true
-                :organization/archived false}
+        (is (= {:enabled true
+                :archived false}
                (status-flags org-id1))))
 
       ;; reset all to false for the following tests
@@ -33,29 +33,29 @@
       (testing "enable"
         (organizations/set-organization-enabled! {:id org-id1
                                                   :enabled true})
-        (is (= {:organization/enabled true
-                :organization/archived false}
+        (is (= {:enabled true
+                :archived false}
                (status-flags org-id1))))
 
       (testing "disable"
         (organizations/set-organization-enabled! {:id org-id1
                                                   :enabled false})
-        (is (= {:organization/enabled false
-                :organization/archived false}
+        (is (= {:enabled false
+                :archived false}
                (status-flags org-id1))))
 
       (testing "archive"
         (organizations/set-organization-archived! {:id org-id1
                                                    :archived true})
-        (is (= {:organization/enabled false
-                :organization/archived true}
+        (is (= {:enabled false
+                :archived true}
                (status-flags org-id1))))
 
       (testing "unarchive"
         (organizations/set-organization-archived! {:id org-id1
                                                    :archived false})
-        (is (= {:organization/enabled false
-                :organization/archived false}
+        (is (= {:enabled false
+                :archived false}
                (status-flags org-id1))))
 
       (testing "does not affect unrelated organizations"
@@ -67,11 +67,11 @@
                                                   :enabled false})
         (organizations/set-organization-archived! {:id org-id2
                                                    :archived false})
-        (is (= {:organization/enabled true
-                :organization/archived true}
+        (is (= {:enabled true
+                :archived true}
                (status-flags org-id1)))
-        (is (= {:organization/enabled false
-                :organization/archived false}
+        (is (= {:enabled false
+                :archived false}
                (status-flags org-id2)))
 
         (is (:success (organizations/set-organization-archived! {:id org-id1
@@ -79,9 +79,9 @@
         (is (:success (organizations/set-organization-archived! {:id org-id2
                                                                  :archived true})))
 
-        (is (= {:organization/enabled true
-                :organization/archived false}
+        (is (= {:enabled true
+                :archived false}
                (status-flags org-id1)))
-        (is (= {:organization/enabled false
-                :organization/archived true}
+        (is (= {:enabled false
+                :archived true}
                (status-flags org-id2)))))))

--- a/test/clj/rems/api/test_organizations.clj
+++ b/test/clj/rems/api/test_organizations.clj
@@ -51,8 +51,8 @@
                     :organization/review-emails [{:email "test@organization.test.org"
                                                   :name {:fi "Organisaatiot API Test ORG Katselmoijat"
                                                          :en "Organizations API Test ORG Reviewers"}}]
-                    :organization/enabled true
-                    :organization/archived false}
+                    :enabled true
+                    :archived false}
                    (-> (find-first (comp #{"organizations-api-test-org"} :organization/id) data)
                        (update :organization/last-modified parse-date))))))
 


### PR DESCRIPTION
Technical change to rename `:organization/enabled` to `:enabled` and `:organization/archived` to `:archived`. Afterwards they are in line with other items and the state-flags -concept and don't complicate it.