### PR TITLE
Rename organization fields

### DIFF
--- a/src/clj/rems/api/forms.clj
+++ b/src/clj/rems/api/forms.clj
@@ -11,10 +11,10 @@
 (defn- get-form-templates [filters]
   (doall
    (for [form (form/get-form-templates filters)]
-     (select-keys form [:form/id :form/organization :form/title :form/errors :enabled :archived]))))
+     (select-keys form [:form/id :organization :form/title :form/errors :enabled :archived]))))
 
 (s/defschema CreateFormCommand
-  {:form/organization OrganizationId
+  {:organization OrganizationId
    :form/title s/Str
    :form/fields [NewFieldTemplate]})
 

--- a/src/clj/rems/api/schema.clj
+++ b/src/clj/rems/api/schema.clj
@@ -205,10 +205,10 @@
 
 (s/defschema FormTemplate
   {:form/id s/Int
-   :form/organization OrganizationOverview
+   :organization OrganizationOverview
    :form/title s/Str
    :form/fields [FieldTemplate]
-   (s/optional-key :form/errors) (s/maybe {(s/optional-key :form/organization) s/Any
+   (s/optional-key :form/errors) (s/maybe {(s/optional-key :organization) s/Any
                                            (s/optional-key :form/title) s/Any
                                            (s/optional-key :form/fields) {s/Num s/Any}})
    ;; TODO: rename the following to use :status/ namespace (also in all other entities)

--- a/src/clj/rems/api/services/dependencies.clj
+++ b/src/clj/rems/api/services/dependencies.clj
@@ -26,7 +26,7 @@
      {:from {:license/id (:id lic)} :to dep})
 
    (for [form (form/get-form-templates nil)
-         dep [(:form/organization form)]]
+         dep [(:organization form)]]
      {:from {:form/id (:form/id form)} :to dep})
 
    (for [res (resource/get-resources {})

--- a/src/clj/rems/api/services/form.clj
+++ b/src/clj/rems/api/services/form.clj
@@ -83,7 +83,7 @@
      :errors [error-map]}))
 
 (defn create-form! [user-id form]
-  (let [organization (:form/organization form)]
+  (let [organization (:organization form)]
     (util/check-allowed-organization! organization)
     (or (validation-error form)
         (let [form-id (:id (db/save-form-template! {:organization (:organization/id organization)
@@ -110,9 +110,9 @@
 
 (defn edit-form! [user-id form]
   (let [form-id (:form/id form)
-        organization (:form/organization form)]
+        organization (:organization form)]
     ;; need to check both previous and new organization
-    (util/check-allowed-organization! (:form/organization (get-form-template form-id)))
+    (util/check-allowed-organization! (:organization (get-form-template form-id)))
     (util/check-allowed-organization! organization)
     (or (dependencies/in-use-error {:form/id form-id})
         (validation-error form)
@@ -124,12 +124,12 @@
             {:success true}))))
 
 (defn set-form-enabled! [{:keys [id enabled]}]
-  (util/check-allowed-organization! (:form/organization (get-form-template id)))
+  (util/check-allowed-organization! (:organization (get-form-template id)))
   (db/set-form-template-enabled! {:id id :enabled enabled})
   {:success true})
 
 (defn set-form-archived! [{:keys [id archived]}]
-  (util/check-allowed-organization! (:form/organization (get-form-template id)))
+  (util/check-allowed-organization! (:organization (get-form-template id)))
   (or (dependencies/change-archive-status-error archived {:form/id id})
       (do
         (db/set-form-template-archived! {:id id

--- a/src/clj/rems/db/form.clj
+++ b/src/clj/rems/db/form.clj
@@ -18,12 +18,12 @@
   (-> row
       (update :fields deserialize-fields)
       (->> (map-keys {:id :form/id
-                      :organization :form/organization
+                      :organization :organization
                       :title :form/title
                       :fields :form/fields
                       :enabled :enabled
                       :archived :archived}))
-      (update :form/organization (fn [o] {:organization/id o}))))
+      (update :organization (fn [o] {:organization/id o}))))
 
 (defn- add-validation-errors [template]
   (assoc template :form/errors (common-form/validate-form-template template (:languages env))))

--- a/src/clj/rems/db/licenses.clj
+++ b/src/clj/rems/db/licenses.clj
@@ -1,8 +1,7 @@
 (ns rems.db.licenses
   "querying localized licenses"
   (:require [rems.common.util :refer [distinct-by]]
-            [rems.db.core :as db]
-            [rems.db.organizations :as organizations]))
+            [rems.db.core :as db]))
 
 (defn- format-license [license]
   {:id (:id license)

--- a/src/clj/rems/db/organizations.clj
+++ b/src/clj/rems/db/organizations.clj
@@ -46,8 +46,7 @@
 (defn join-organization [x]
   ;; TODO alternatively we could pass in the organization key
   ;; TODO alternatively we could decide which layer transforms db string into {:organization/id "string"} and which layer joins the rest https://github.com/CSCfi/rems/issues/2179
-  (let [organization (or (:organization x)
-                         (:organization x))
+  (let [organization (:organization x)
         organization-id (if (string? organization) organization (:organization/id organization))
         organization-overview (-> organization-id
                                   getx-organization-by-id

--- a/src/clj/rems/db/organizations.clj
+++ b/src/clj/rems/db/organizations.clj
@@ -46,7 +46,7 @@
 (defn join-organization [x]
   ;; TODO alternatively we could pass in the organization key
   ;; TODO alternatively we could decide which layer transforms db string into {:organization/id "string"} and which layer joins the rest https://github.com/CSCfi/rems/issues/2179
-  (let [organization (or (:form/organization x)
+  (let [organization (or (:organization x)
                          (:organization x))
         organization-id (if (string? organization) organization (:organization/id organization))
         organization-overview (-> organization-id
@@ -54,7 +54,7 @@
                                   (select-keys [:organization/id :organization/name]))]
     (-> x
         (update-existing :organization (fn [_] organization-overview))
-        (update-existing :form/organization (fn [_] organization-overview)))))
+        (update-existing :organization (fn [_] organization-overview)))))
 
 (defn set-organization! [organization]
   (db/set-organization! {:id (:organization/id organization) :data (json/generate-string organization)}))

--- a/src/clj/rems/db/test_data.clj
+++ b/src/clj/rems/db/test_data.clj
@@ -194,13 +194,13 @@
                         :license/text {:fi "fi" :en "en"}
                         :license/attachment-id {:fi fi-attachment :en en-attachment}}))))
 
-(defn create-form! [{:keys [actor]
-                     :form/keys [organization title fields]
+(defn create-form! [{:keys [actor organization]
+                     :form/keys [title fields]
                      :as command}]
   (let [actor (or actor (create-owner!))
         result (with-user actor
                  (form/create-form! actor
-                                    {:form/organization (or organization (default-organization))
+                                    {:organization (or organization (default-organization))
                                      :form/title (or title "FORM")
                                      :form/fields (or fields [])}))]
     (assert (:success result) {:command command :result result})
@@ -244,7 +244,7 @@
         result (with-user actor
                  (catalogue/create-catalogue-item!
                   {:resid (or resource-id (create-resource! {:organization organization}))
-                   :form (or form-id (create-form! {:form/organization organization}))
+                   :form (or form-id (create-form! {:organization organization}))
                    :organization (or organization {:organization/id "default"})
                    :wfid (or workflow-id (create-workflow! {:organization organization}))
                    :localizations (or localizations {})}))]
@@ -324,7 +324,7 @@
 (defn- create-archived-form! [actor]
   (with-user actor
     (let [id (create-form! {:actor actor
-                            :form/organization {:organization/id "nbn"}
+                            :organization {:organization/id "nbn"}
                             :form/title "Archived form, should not be seen by applicants"})]
       (form/set-form-archived! {:id id :archived true}))))
 
@@ -471,7 +471,7 @@
   [actor organization title]
   (create-form!
    {:actor actor
-    :form/organization organization
+    :organization organization
     :form/title title
     :form/fields all-field-types-example}))
 
@@ -480,7 +480,7 @@
   [users]
   (create-form!
    {:actor (users :owner)
-    :form/organization {:organization/id "thl"}
+    :organization {:organization/id "thl"}
     :form/title "THL form"
     :form/fields [{:field/title {:en "Application title"
                                  :fi "Hakemuksen otsikko"
@@ -772,7 +772,7 @@
                                      :handlers handlers
                                      :forms [{:form/id (create-form! {:actor owner
                                                                       :form/title "Workflow form"
-                                                                      :form/organization {:organization/id "nbn"}
+                                                                      :organization {:organization/id "nbn"}
                                                                       :form/fields [{:field/type :description
                                                                                      :field/title {:fi "Kuvaus"
                                                                                                    :en "Description"
@@ -975,7 +975,7 @@
                                        :handlers handlers})
         form-id (create-form!
                  {:actor owner
-                  :form/organization {:organization/id "perf"}
+                  :organization {:organization/id "perf"}
                   :form/title "Performance tests"
                   :form/fields [{:field/title {:en "Project name"
                                                :fi "Projektin nimi"
@@ -1163,7 +1163,7 @@
 
         form (create-all-field-types-example-form! owner {:organization/id "nbn"} "Example form with all field types")
         form-private-thl (create-form! {:actor owner
-                                        :form/organization {:organization/id "thl"}
+                                        :organization {:organization/id "thl"}
                                         :form/title "Simple form"
                                         :form/fields [{:field/title {:en "Simple text field"
                                                                      :fi "Yksinkertainen tekstikenttä"
@@ -1173,7 +1173,7 @@
                                                        :field/max-length 100
                                                        :field/privacy :private}]})
         form-private-hus (create-form! {:actor owner
-                                        :form/organization {:organization/id "hus"}
+                                        :organization {:organization/id "hus"}
                                         :form/title "Simple form"
                                         :form/fields [{:field/title {:en "Simple text field"
                                                                      :fi "Yksinkertainen tekstikenttä"

--- a/src/clj/rems/db/test_data.clj
+++ b/src/clj/rems/db/test_data.clj
@@ -161,8 +161,8 @@
                       (:id existing-default-organization)
                       (create-organization! {}))})
 
-(defn create-license! [{:keys [actor]
-                        :license/keys [type title link organization text attachment-id]
+(defn create-license! [{:keys [actor organization]
+                        :license/keys [type title link text attachment-id]
                         :as command}]
   (let [actor (or actor (create-owner!))
         result (with-user actor
@@ -176,8 +176,7 @@
     (assert (:success result) {:command command :result result})
     (:id result)))
 
-(defn create-attachment-license! [{:keys [actor]
-                                   :license/keys [organization]}]
+(defn create-attachment-license! [{:keys [actor organization]}]
   (let [fi-attachment (:id (db/create-license-attachment! {:user (or actor "owner")
                                                            :filename "license-fi.txt"
                                                            :type "text/plain"
@@ -189,7 +188,7 @@
     (with-user actor
       (create-license! {:actor actor
                         :license/type :attachment
-                        :license/organization (or organization (default-organization))
+                        :organization (or organization (default-organization))
                         :license/title {:fi "Liitelisenssi" :en "Attachment license"}
                         :license/text {:fi "fi" :en "en"}
                         :license/attachment-id {:fi fi-attachment :en en-attachment}}))))
@@ -328,11 +327,10 @@
                             :form/title "Archived form, should not be seen by applicants"})]
       (form/set-form-archived! {:id id :archived true}))))
 
-(defn- create-disabled-license! [{:keys [actor]
-                                  :license/keys [organization]}]
+(defn- create-disabled-license! [{:keys [actor organization]}]
   (let [id (create-license! {:actor actor
                              :license/type "link"
-                             :license/organization organization
+                             :organization organization
                              :license/title {:en "Disabled license"
                                              :fi "Käytöstä poistettu lisenssi"}
                              :license/link {:en "http://disabled"
@@ -782,7 +780,7 @@
     ;; attach both kinds of licenses to all workflows created by owner
     (let [link (create-license! {:actor owner
                                  :license/type :link
-                                 :license/organization {:organization/id "nbn"}
+                                 :organization {:organization/id "nbn"}
                                  :license/title {:en "CC Attribution 4.0"
                                                  :fi "CC Nimeä 4.0"
                                                  :sv "CC Erkännande 4.0"}
@@ -791,7 +789,7 @@
                                                 :sv "https://creativecommons.org/licenses/by/4.0/legalcode.sv"}})
           text (create-license! {:actor owner
                                  :license/type :text
-                                 :license/organization {:organization/id "nbn"}
+                                 :organization {:organization/id "nbn"}
                                  :license/title {:en "General Terms of Use"
                                                  :fi "Yleiset käyttöehdot"
                                                  :sv "Allmänna villkor"}
@@ -997,7 +995,7 @@
         form (form/get-form-template form-id)
         license-id (create-license! {:actor owner
                                      :license/type :text
-                                     :license/organization {:organization/id "perf"}
+                                     :organization {:organization/id "perf"}
                                      :license/title {:en "Performance License"
                                                      :fi "Suorituskykylisenssi"
                                                      :sv "Licens för prestand"}
@@ -1106,7 +1104,7 @@
         ;; Create licenses
         license1 (create-license! {:actor owner
                                    :license/type :link
-                                   :license/organization {:organization/id "nbn"}
+                                   :organization {:organization/id "nbn"}
                                    :license/title {:en "Demo license"
                                                    :fi "Demolisenssi"
                                                    :sv "Demolicens"}
@@ -1115,7 +1113,7 @@
                                                   :sv "https://www.apache.org/licenses/LICENSE-2.0"}})
         extra-license (create-license! {:actor owner
                                         :license/type :link
-                                        :license/organization {:organization/id "nbn"}
+                                        :organization {:organization/id "nbn"}
                                         :license/title {:en "Extra license"
                                                         :fi "Ylimääräinen lisenssi"
                                                         :sv "Extra licens"}
@@ -1124,7 +1122,7 @@
                                                        :sv "https://www.apache.org/licenses/LICENSE-2.0"}})
         license-organization-owner (create-license! {:actor organization-owner1
                                                      :license/type :link
-                                                     :license/organization {:organization/id "organization1"}
+                                                     :organization {:organization/id "organization1"}
                                                      :license/title {:en "License owned by organization owner"
                                                                      :fi "Lisenssi, jonka omistaa organisaatio-omistaja"
                                                                      :sv "Licens som ägs av organisationägare"}
@@ -1132,9 +1130,9 @@
                                                                     :fi "https://www.apache.org/licenses/LICENSE-2.0"
                                                                     :sv "https://www.apache.org/licenses/LICENSE-2.0"}})
         _ (create-disabled-license! {:actor owner
-                                     :license/organization {:organization/id "nbn"}})
+                                     :organization {:organization/id "nbn"}})
         attachment-license (create-attachment-license! {:actor owner
-                                                        :license/organization {:organization/id "nbn"}})
+                                                        :organization {:organization/id "nbn"}})
 
         ;; Create resources
         res1 (create-resource! {:resource-ext-id "urn:nbn:fi:lb-201403262"

--- a/src/clj/rems/validate.clj
+++ b/src/clj/rems/validate.clj
@@ -37,7 +37,7 @@
   (let [organizations (->> (organizations/get-organizations-raw) (map :organization/id) set)
         valid-organization? (fn [organization] (contains? organizations (:organization/id organization)))]
     (doseq [form (form/get-form-templates {})]
-      (when-not (valid-organization? (:form/organization form))
+      (when-not (valid-organization? (:organization form))
         (log/warn "Unrecognized organization in form:" (pr-str form))))
     (doseq [resource (resources/get-resources nil)]
       (when-not (valid-organization? (:organization resource))

--- a/src/cljc/rems/common/form.cljc
+++ b/src/cljc/rems/common/form.cljc
@@ -91,10 +91,10 @@
     {key :t.form.validation/required}))
 
 (defn- validate-organization-field [m]
-  (let [organization (:form/organization m)]
+  (let [organization (:organization m)]
     (when (or (nil? organization)
               (str/blank? (:organization/id organization)))
-      {:form/organization :t.form.validation/required})))
+      {:organization :t.form.validation/required})))
 
 (def field-types #{:attachment :date :description :email :header :label :multiselect :option :text :texta})
 
@@ -234,7 +234,7 @@
       form)))
 
 (deftest validate-form-template-test
-  (let [form {:form/organization {:organization/id "abc"}
+  (let [form {:organization {:organization/id "abc"}
               :form/title "the title"
               :form/fields [{:field/id "fld1"
                              :field/title {:en "en title"
@@ -251,8 +251,8 @@
 
     (testing "missing organization"
       (is (= :t.form.validation/required
-             (:form/organization (validate-form-template (assoc-in form [:form/organization] nil) languages))
-             (:form/organization (validate-form-template (assoc-in form [:form/organization :organization/id] "") languages)))))
+             (:organization (validate-form-template (assoc-in form [:organization] nil) languages))
+             (:organization (validate-form-template (assoc-in form [:organization :organization/id] "") languages)))))
 
     (testing "missing title"
       (is (= :t.form.validation/required

--- a/src/cljs/rems/administration/create_catalogue_item.cljs
+++ b/src/cljs/rems/administration/create_catalogue_item.cljs
@@ -224,7 +224,7 @@
          :item-key :form/id
          :item-label #(str (:form/title %)
                            " (org: "
-                           (get-in % [:form/organization :organization/name language])
+                           (get-in % [:organization :organization/name language])
                            ")")
          :item-selected? item-selected?
          :on-change #(rf/dispatch [::set-selected-form %])}])]))

--- a/src/cljs/rems/administration/create_form.cljs
+++ b/src/cljs/rems/administration/create_form.cljs
@@ -158,7 +158,7 @@
                                              [:visibility/type :visibility/field :visibility/values])}))))
 
 (defn build-request [form languages]
-  {:form/organization {:organization/id (get-in form [:form/organization :organization/id])}
+  {:organization {:organization/id (get-in form [:organization :organization/id])}
    :form/title (trim-when-string (:form/title form))
    :form/fields (mapv #(build-request-field % languages) (:form/fields form))})
 
@@ -236,9 +236,9 @@
    :get-form-errors ::form-errors
    :update-form ::set-form-field})
 
-(rf/reg-sub ::selected-organization (fn [db _] (get-in db [::form :data :form/organization])))
+(rf/reg-sub ::selected-organization (fn [db _] (get-in db [::form :data :organization])))
 
-(rf/reg-event-db ::set-selected-organization (fn [db [_ organization]] (assoc-in db [::form :data :form/organization] organization)))
+(rf/reg-event-db ::set-selected-organization (fn [db [_ organization]] (assoc-in db [::form :data :organization] organization)))
 
 (defn- form-organization-field []
   [fields/organization-field {:id "organization-dropdown"
@@ -515,9 +515,9 @@
 (defn format-validation-errors [form-errors form lang]
   ;; TODO: deduplicate with field definitions
   (into [:ul
-         (when (:form/organization form-errors)
+         (when (:organization form-errors)
            [:li [:a {:href "#" :on-click (focus-input-field "organization")}
-                 (text-format (:form/organization form-errors) (text :t.administration/organization))]])
+                 (text-format (:organization form-errors) (text :t.administration/organization))]])
 
          (when (:form/title form-errors)
            [:li [:a {:href "#" :on-click (focus-input-field "title")}

--- a/src/cljs/rems/administration/form.cljs
+++ b/src/cljs/rems/administration/form.cljs
@@ -66,9 +66,9 @@
   [:div.spaced-vertically-3
    [collapsible/component
     {:id "form"
-     :title [:span (andstr (get-in form [:form/organization :organization/name language]) "/") (:form/title form)]
+     :title [:span (andstr (get-in form [:organization :organization/name language]) "/") (:form/title form)]
      :always [:div
-              [inline-info-field (text :t.administration/organization) (get-in form [:form/organization :organization/name language])]
+              [inline-info-field (text :t.administration/organization) (get-in form [:organization :organization/name language])]
               [inline-info-field (text :t.administration/title) (:form/title form)]
               [inline-info-field (text :t.administration/active) [readonly-checkbox {:value (status-flags/active? form)}]]]}]
    (let [id (:form/id form)]

--- a/src/cljs/rems/administration/forms.cljs
+++ b/src/cljs/rems/administration/forms.cljs
@@ -87,7 +87,7 @@
  (fn [[forms language] _]
    (map (fn [form]
           {:key (:form/id form)
-           :organization {:value (get-in form [:form/organization :organization/name language])}
+           :organization {:value (get-in form [:organization :organization/name language])}
            :title {:value (:form/title form)}
            :active (let [checked? (status-flags/active? form)]
                      {:td [:td.active

--- a/test/clj/rems/api/test_administration.clj
+++ b/test/clj/rems/api/test_administration.clj
@@ -19,9 +19,9 @@
                                   api-key user-id))
         resource-id (:id (api-call :post "/api/resources/create" {:resid "test" :organization {:organization/id "abc"} :licenses [license-id]}
                                    api-key user-id))
-        form-id (:id (api-call :post "/api/forms/create" {:form/organization {:organization/id "abc"} :form/title "form update test" :form/fields []}
+        form-id (:id (api-call :post "/api/forms/create" {:organization {:organization/id "abc"} :form/title "form update test" :form/fields []}
                                api-key user-id))
-        wf-form-id (:id (api-call :post "/api/forms/create" {:form/organization {:organization/id "abc"} :form/title "workflow form update test" :form/fields []}
+        wf-form-id (:id (api-call :post "/api/forms/create" {:organization {:organization/id "abc"} :form/title "workflow form update test" :form/fields []}
                                   api-key user-id))
         workflow-id (:id (api-call :post "/api/workflows/create"
                                    {:organization {:organization/id "abc"} :title "default workflow"

--- a/test/clj/rems/api/test_catalogue_items.clj
+++ b/test/clj/rems/api/test_catalogue_items.clj
@@ -14,7 +14,7 @@
 (deftest catalogue-items-api-test
   (let [api-key "42"
         user-id "alice"
-        form-id (test-data/create-form! {:form/title "form name" :form/organization {:organization/id "organization1"}})
+        form-id (test-data/create-form! {:form/title "form name" :organization {:organization/id "organization1"}})
         ;; can create catalogue items with mixed organizations:
         wf-id (test-data/create-workflow! {:title "workflow name" :organization {:organization/id "abc"}})
         res-id (test-data/create-resource! {:resource-ext-id "resource ext id" :organization {:organization/id "organization1"}})]
@@ -74,7 +74,7 @@
   (let [api-key "42"
         owner "owner"
         user "alice"
-        form-id (test-data/create-form! {:form/organization {:organization/id "organization1"}})
+        form-id (test-data/create-form! {:organization {:organization/id "organization1"}})
         wf-id (test-data/create-workflow! {:organization {:organization/id "organization1"}})
         res-id (test-data/create-resource! {:organization {:organization/id "organization1"}})]
     (testing "create"
@@ -224,9 +224,9 @@
   (let [api-key "42"
         resource-id (test-data/create-resource! {:organization {:organization/id "organization1"}})
         old-form-id (test-data/create-form! {:form/title "old form"
-                                             :form/organization {:organization/id "organization1"}})
+                                             :organization {:organization/id "organization1"}})
         new-form-id (test-data/create-form! {:form/title "new form"
-                                             :form/organization {:organization/id "organization1"}})
+                                             :organization {:organization/id "organization1"}})
         old-catalogue-item-id (test-data/create-catalogue-item!
                                {:organization {:organization/id "organization1"}
                                 :title {:en "change-form-test catalogue item en"
@@ -269,7 +269,7 @@
         (is (= (:end old-catalogue-item) (:start new-catalogue-item)))))
     (testing "can change to form that's in another organization"
       (let [form-id (test-data/create-form! {:form/title "wrong organization"
-                                             :form/organization {:organization/id "organization2"}})
+                                             :organization {:organization/id "organization2"}})
             response (-> (request :post (str "/api/catalogue-items/" old-catalogue-item-id "/change-form"))
                          (authenticate api-key "owner")
                          (json-body {:form form-id})

--- a/test/clj/rems/api/test_end_to_end.clj
+++ b/test/clj/rems/api/test_end_to_end.clj
@@ -83,7 +83,7 @@
                 wf-form-id
                 (testing "create workflow form"
                   (extract-id
-                   (api-call :post "/api/forms/create" {:form/organization {:organization/id "e2e"}
+                   (api-call :post "/api/forms/create" {:organization {:organization/id "e2e"}
                                                         :form/title "e2e wf"
                                                         :form/fields [{:field/id "description"
                                                                        :field/type :description
@@ -96,7 +96,7 @@
                 form-id
                 (testing "create form"
                   (extract-id
-                   (api-call :post "/api/forms/create" {:form/organization {:organization/id "e2e"}
+                   (api-call :post "/api/forms/create" {:organization {:organization/id "e2e"}
                                                         :form/title "e2e"
                                                         :form/fields [{:field/type :text
                                                                        :field/title {:en "text field"
@@ -108,7 +108,7 @@
                 form-id2
                 (testing "create form 2"
                   (extract-id
-                   (api-call :post "/api/forms/create" {:form/organization {:organization/id "e2e"}
+                   (api-call :post "/api/forms/create" {:organization {:organization/id "e2e"}
                                                         :form/title "e2e 2"
                                                         :form/fields [{:field/id "e2e_fld_2"
                                                                        :field/type :text
@@ -378,7 +378,7 @@
           form-id
           (testing "create form"
             (extract-id
-             (api-call :post "/api/forms/create" {:form/organization {:organization/id "e2e"}
+             (api-call :post "/api/forms/create" {:organization {:organization/id "e2e"}
                                                   :form/title "e2e"
                                                   :form/fields [{:field/type :text
                                                                  :field/title {:en "text field"

--- a/test/clj/rems/api/test_forms.clj
+++ b/test/clj/rems/api/test_forms.clj
@@ -30,7 +30,7 @@
         org-owner "organization-owner1"
         owner "owner"
 
-        command {:form/organization {:organization/id "organization1"}
+        command {:organization {:organization/id "organization1"}
                  :form/title (str "form title " (UUID/randomUUID))
                  :form/fields [{:field/title {:en "en title"
                                               :fi "fi title"
@@ -68,7 +68,7 @@
                                                             command-with-invalid-max-length
                                                             api-key user-id)))))
             (testing "duplicate field ids"
-              (let [command-with-duplicated-field-ids {:form/organization {:organization/id "organization1"}
+              (let [command-with-duplicated-field-ids {:organization {:organization/id "organization1"}
                                                        :form/title (str "form title " (UUID/randomUUID))
                                                        :form/fields [{:field/id "abc"
                                                                       :field/title {:en "en title"
@@ -102,10 +102,10 @@
                                               api-key user-id)]
                   (testing "result matches input"
                     (is (= (-> command
-                               (select-keys [:form/organization :form/title])
+                               (select-keys [:organization :form/title])
                                (assoc-in
-                                [:form/organization :organization/name] {:fi "Organization 1" :en "Organization 1" :sv "Organization 1"}))
-                           (select-keys form-template [:form/organization :form/title])))
+                                [:organization :organization/name] {:fi "Organization 1" :en "Organization 1" :sv "Organization 1"}))
+                           (select-keys form-template [:organization :form/title])))
                     (is (= (:form/fields command)
                            (mapv fixup-field-to-match-command (:form/fields form-template)))))))))
           (testing "valid create with given field id"
@@ -119,16 +119,16 @@
                                               api-key user-id)]
                   (testing "result matches input"
                     (is (= (-> command-with-given-field-id
-                               (select-keys [:form/organization :form/title])
-                               (assoc-in [:form/organization :organization/name] {:fi "Organization 1" :en "Organization 1" :sv "Organization 1"}))
-                           (select-keys form-template [:form/organization :form/title])))
+                               (select-keys [:organization :form/title])
+                               (assoc-in [:organization :organization/name] {:fi "Organization 1" :en "Organization 1" :sv "Organization 1"}))
+                           (select-keys form-template [:organization :form/title])))
                     (is (= (mapv #(dissoc % :field/id) (:form/fields command-with-given-field-id))
                            (mapv fixup-field-to-match-command (:form/fields form-template))))
                     (is (= (get-in command-with-given-field-id [:form/fields 0 :field/id]) ; field/id "not" in previous comparison
                            (get-in form-template [:form/fields 0 :field/id])))))))))))
     (testing "create as organization owner with incorrect organization"
       (let [response (api-response :post "/api/forms/create"
-                                   (assoc command :form/organization {:organization/id "organization2"})
+                                   (assoc command :organization {:organization/id "organization2"})
                                    api-key "organization-owner1")]
         (is (response-is-forbidden? response))
         (is (= "no access to organization \"organization2\"" (read-body response)))))))
@@ -137,7 +137,7 @@
   (let [api-key "42"
         user-id "owner"
         localized {:en "en" :fi "fi" :sv "sv"}
-        form-spec {:form/organization {:organization/id "organization1"}
+        form-spec {:organization {:organization/id "organization1"}
                    :form/title "all field types test"
                    :form/fields [{:field/type :text
                                   :field/title localized
@@ -196,9 +196,9 @@
                          handler
                          read-ok-body)]
             (is (= (-> form-spec
-                       (select-keys [:form/organization :form/title])
-                       (assoc-in [:form/organization :organization/name] {:fi "Organization 1" :en "Organization 1" :sv "Organization 1"}))
-                   (select-keys form [:form/organization :form/title])))
+                       (select-keys [:organization :form/title])
+                       (assoc-in [:organization :organization/name] {:fi "Organization 1" :en "Organization 1" :sv "Organization 1"}))
+                   (select-keys form [:organization :form/title])))
             (is (= (:form/fields form-spec)
                    (mapv fixup-field-to-match-command (:form/fields form))))))))))
 
@@ -206,7 +206,7 @@
   (let [api-key "42"
         user-id "owner"]
     (let [form-id (:id (api-call :post "/api/forms/create"
-                                 {:form/organization {:organization/id "organization1"}
+                                 {:organization {:organization/id "organization1"}
                                   :form/title "form editable test"
                                   :form/fields []}
                                  api-key user-id))]
@@ -237,7 +237,7 @@
                    (api-call :get (str "/api/forms/" form-id "/editable") nil
                              api-key user-id)))))))
     (let [form-id (:id (api-call :post "/api/forms/create"
-                                 {:form/organization {:organization/id "organization1"}
+                                 {:organization {:organization/id "organization1"}
                                   :form/title "form editable test 2"
                                   :form/fields []}
                                  api-key user-id))]
@@ -267,7 +267,7 @@
   (let [api-key "42"
         user-id "owner"
         form-id (:id (api-call :post "/api/forms/create"
-                               {:form/organization {:organization/id "organization1"}
+                               {:organization {:organization/id "organization1"}
                                 :form/title "form edit test"
                                 :form/fields []}
                                api-key user-id))]
@@ -275,7 +275,7 @@
       (testing "can edit title in own organization"
         (is (true? (:success (api-call :put "/api/forms/edit"
                                        {:form/id form-id
-                                        :form/organization {:organization/id "organization1"}
+                                        :organization {:organization/id "organization1"}
                                         :form/title "changed title"
                                         :form/fields []}
                                        api-key "organization-owner1"))))
@@ -284,35 +284,35 @@
       (testing "can't edit title in another organization"
         (is (response-is-forbidden? (api-response :put "/api/forms/edit"
                                                   {:form/id form-id
-                                                   :form/organization {:organization/id "organization1"}
+                                                   :organization {:organization/id "organization1"}
                                                    :form/title "changed title more"
                                                    :form/fields []}
                                                   api-key "organization-owner2"))))
       (testing "can't change organization"
         (is (response-is-forbidden? (api-response :put "/api/forms/edit"
                                                   {:form/id form-id
-                                                   :form/organization {:organization/id "organization2"}
+                                                   :organization {:organization/id "organization2"}
                                                    :form/title "changed title"
                                                    :form/fields []}
                                                   api-key "organization-owner1")))))
     (testing "owner can change title and organization"
       (is (true? (:success (api-call :put "/api/forms/edit"
                                      {:form/id form-id
-                                      :form/organization {:organization/id "abc"}
+                                      :organization {:organization/id "abc"}
                                       :form/title "I am owner"
                                       :form/fields []}
                                      api-key user-id))))
       (let [form (api-call :get (str "/api/forms/" form-id) {} api-key user-id)]
         (is (= {:organization/id "abc"
                 :organization/name {:fi "ABC" :en "ABC" :sv "ABC"}}
-               (:form/organization form)))
+               (:organization form)))
         (is (= "I am owner" (:form/title form)))))))
 
 (deftest form-enabled-archived-test
   (let [api-key "42"
         form-id (-> (request :post "/api/forms/create")
                     (authenticate api-key "owner")
-                    (json-body {:form/organization {:organization/id "organization1"}
+                    (json-body {:organization {:organization/id "organization1"}
                                 :form/title "form update test"
                                 :form/fields []})
                     handler
@@ -359,7 +359,7 @@
   (let [api-key "42"
         user-id "owner"]
     (testing "create"
-      (let [command {:form/organization {:organization/id "abc"}
+      (let [command {:organization {:organization/id "abc"}
                      :form/title (str "form title " (UUID/randomUUID))
                      :form/fields [{:field/title {:en "en title"
                                                   :fi "fi title"
@@ -398,7 +398,7 @@
   (let [api-key "42"
         user-id "owner"
         localized {:en "en" :fi "fi" :sv "sv"}
-        command {:form/organization {:organization/id "abc"}
+        command {:organization {:organization/id "abc"}
                  :form/title "form fields with privacy"
                  :form/fields [{:field/id "header"
                                 :field/type :header
@@ -459,7 +459,7 @@
   (let [api-key "42"
         user-id "owner"
         localized {:en "en" :fi "fi" :sv "sv"}
-        command {:form/organization {:organization/id "abc"}
+        command {:organization {:organization/id "abc"}
                  :form/title "text fields that depend on a field"
                  :form/fields [{:field/id "fld1"
                                 :field/type :option
@@ -543,9 +543,9 @@
             (let [form (api-call :get (str "/api/forms/" form-id) nil
                                  api-key user-id)]
               (is (= (-> command
-                         (select-keys [:form/organization :form/title])
-                         (assoc-in [:form/organization :organization/name] {:fi "ABC" :en "ABC" :sv "ABC"}))
-                     (select-keys form [:form/organization :form/title])))
+                         (select-keys [:organization :form/title])
+                         (assoc-in [:organization :organization/name] {:fi "ABC" :en "ABC" :sv "ABC"}))
+                     (select-keys form [:organization :form/title])))
               (is (= [{:field/id "fld1"
                        :field/type "option"
                        :field/title localized
@@ -613,7 +613,7 @@
                                                      :field/options [{:key "opt"
                                                                       :label {:sv "Swedish label"}}]}]}))]
     (is (= {:form/id id
-            :form/organization {:organization/id "default" :organization/name {:fi "Oletusorganisaatio" :en "The Default Organization" :sv "Standardorganisationen"}}
+            :organization {:organization/id "default" :organization/name {:fi "Oletusorganisaatio" :en "The Default Organization" :sv "Standardorganisationen"}}
             :form/title "invalid form"
             :form/fields [{:field/placeholder {:en "Placeholder"}
                            :field/title {:fi "Title in Finnish"}
@@ -649,7 +649,7 @@
         (is (= "unauthorized" body))))
     (testing "create"
       (let [response (-> (request :post "/api/forms/create")
-                         (json-body {:form/organization {:organization/id "abc"}
+                         (json-body {:organization {:organization/id "abc"}
                                      :form/title "the title"
                                      :form/fields []})
                          handler)]
@@ -667,7 +667,7 @@
     (testing "create"
       (let [response (-> (request :post "/api/forms/create")
                          (authenticate "42" "alice")
-                         (json-body {:form/organization {:organization/id "abc"}
+                         (json-body {:organization {:organization/id "abc"}
                                      :form/title "the title"
                                      :form/fields []})
                          handler)]

--- a/test/clj/rems/api/test_resources.clj
+++ b/test/clj/rems/api/test_resources.clj
@@ -35,8 +35,8 @@
   (let [api-key "42"
         owner "owner"
         org-owner "organization-owner1"
-        licid-org1 (test-data/create-license! {:license/organization {:organization/id "organization1"}})
-        licid-org2 (test-data/create-license! {:license/organization {:organization/id "organization2"}})
+        licid-org1 (test-data/create-license! {:organization {:organization/id "organization1"}})
+        licid-org2 (test-data/create-license! {:organization {:organization/id "organization2"}})
         resid "resource-api-test"]
 
     (doseq [user-id [owner org-owner]]

--- a/test/clj/rems/application/test_model.clj
+++ b/test/clj/rems/application/test_model.clj
@@ -18,7 +18,7 @@
 
 (def ^:private get-form-template
   {40 {:form/id 40
-       :form/organization {:organization/id "org" :organization/name {:fi "ORG" :en "ORG"}}
+       :organization {:organization/id "org" :organization/name {:fi "ORG" :en "ORG"}}
        :form/title "form title"
        :form/fields [{:field/id "41"
                       :field/title {:en "en title" :fi "fi title"}
@@ -43,7 +43,7 @@
        :enabled true
        :archived false}
    41 {:form/id 41
-       :form/organization {:organization/id "org" :organization/name {:fi "ORG" :en "ORG"}}
+       :organization {:organization/id "org" :organization/name {:fi "ORG" :en "ORG"}}
        :form/title "form title 2"
        :form/fields [{:field/id "41"
                       :field/title {:en "en title" :fi "fi title"}

--- a/test/clj/rems/test_browser.clj
+++ b/test/clj/rems/test_browser.clj
@@ -736,7 +736,7 @@
     (testing "fetch form via api"
       (let [form-id (Integer/parseInt (last (str/split (btu/get-url) #"/")))]
         (is (= {:form/id form-id
-                :form/organization {:organization/id "nbn" :organization/name {:fi "NBN" :en "NBN" :sv "NBN"}}
+                :organization {:organization/id "nbn" :organization/name {:fi "NBN" :en "NBN" :sv "NBN"}}
                 :form/title "Form editor test"
                 :form/fields [{:field/placeholder {:fi "" :en "" :sv ""}
                                :field/title {:fi "Description (FI)" :en "Description (EN)" :sv "Description (SV)"}

--- a/test/cljs/rems/administration/test_create_catalogue_item.cljs
+++ b/test/cljs/rems/administration/test_create_catalogue_item.cljs
@@ -13,7 +13,7 @@
               :resource {:id 456
                          :organization {:organization/id "organization1"}}
               :form {:form/id 789
-                     :form/organization {:organization/id "organization1"}}}
+                     :organization {:organization/id "organization1"}}}
         languages [:en :fi]]
 
     (testing "valid form"

--- a/test/cljs/rems/administration/test_create_form.cljs
+++ b/test/cljs/rems/administration/test_create_form.cljs
@@ -165,7 +165,7 @@
             "after move 3")))))
 
 (deftest build-request-test
-  (let [form {:form/organization {:organization/id "abc"}
+  (let [form {:organization {:organization/id "abc"}
               :form/title "the title"
               :form/fields [{:field/id "fld1"
                              :field/index 0
@@ -179,7 +179,7 @@
         languages [:en :fi]]
 
     (testing "basic form"
-      (is (= {:form/organization {:organization/id "abc"}
+      (is (= {:organization {:organization/id "abc"}
               :form/title "the title"
               :form/fields [{:field/id "fld1"
                              :field/title {:en "en title"
@@ -192,7 +192,7 @@
              (build-request form languages))))
 
     (testing "trim strings"
-      (is (= {:form/organization {:organization/id "abc"}
+      (is (= {:organization {:organization/id "abc"}
               :form/title "the title"
               :form/fields [{:field/id "fld1"
                              :field/title {:en "en title"
@@ -205,14 +205,14 @@
              (build-request (assoc form :form/title " the title\t\n") languages))))
 
     (testing "zero fields"
-      (is (= {:form/organization {:organization/id "abc"}
+      (is (= {:organization {:organization/id "abc"}
               :form/title "the title"
               :form/fields []}
              (build-request (assoc-in form [:form/fields] []) languages))))
 
     (testing "date fields"
       (let [form (assoc-in form [:form/fields 0 :field/type] :date)]
-        (is (= {:form/organization {:organization/id "abc"}
+        (is (= {:organization {:organization/id "abc"}
                 :form/title "the title"
                 :form/fields [{:field/id "fld1"
                                :field/title {:en "en title"
@@ -249,7 +249,7 @@
                                                                 {:key "no"
                                                                  :label {:en "en no"
                                                                          :fi "fi no"}}]))]
-        (is (= {:form/organization {:organization/id "abc"}
+        (is (= {:organization {:organization/id "abc"}
                 :form/title "the title"
                 :form/fields [{:field/id "fld1"
                                :field/title {:en "en title"
@@ -273,7 +273,7 @@
                                                                 {:key "bacon"
                                                                  :label {:en "Bacon"
                                                                          :fi "Pekonia"}}]))]
-        (is (= {:form/organization {:organization/id "abc"}
+        (is (= {:organization {:organization/id "abc"}
                 :form/title "the title"
                 :form/fields [{:field/id "fld1"
                                :field/title {:en "en title"


### PR DESCRIPTION
Technical change to use the organization fields of each concept using the `:organization` key. Renames `:form/organization` and `:license/organization`.
