### PR TITLE
fix: UI text for close action comment field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Changes since v2.12
 ### Fixes
 - Various fixes in workflow editor UI
 - Form field placeholders now fulfil accessibility contrast ratio requirements (#2229)
+- UI for the close action erroneously claimed the comment is not shown to the applicant. (#2212)
 
 ### Additions
 - The form administration pages now flag forms that have missing localizations. REMS also logs a warning on startup for these forms. (#2098)

--- a/src/cljs/rems/actions/close.cljs
+++ b/src/cljs/rems/actions/close.cljs
@@ -44,7 +44,7 @@
     (when show-comment-field?
       [:<>
        [action-comment {:id action-form-id
-                        :label (text :t.form/add-comments-not-shown-to-applicant)
+                        :label (text :t.form/add-comments-shown-to-applicant)
                         :comment comment
                         :on-comment on-set-comment}]
        [action-attachment {:application-id application-id


### PR DESCRIPTION
Now :t.form/add-comments-not-shown-to-applicant is used only in
decide, request-decision, review and request-review, which matches
rems.application.model/hide-sensitive-events.

fixes #2212

# Definition of Done / Review checklist

## Reviewability
- [x] link to issue