### PR TITLE
feat: introduce short-name for organizations

### DIFF
--- a/resources/translations/en.edn
+++ b/resources/translations/en.edn
@@ -96,6 +96,7 @@
                    :resources "Resources"
                    :review-emails "Review emails"
                    :save "Save"
+                   :short-name "Short name"
                    :start "Start"
                    :title "Title"
                    :type "Type"

--- a/resources/translations/fi.edn
+++ b/resources/translations/fi.edn
@@ -96,6 +96,7 @@
                    :resources "Resurssit"
                    :review-emails "Katselmointisähköpostit"
                    :save "Tallenna"
+                   :short-name "Lyhenne"
                    :start "Alku"
                    :title "Nimi"
                    :type "Tyyppi"

--- a/resources/translations/sv.edn
+++ b/resources/translations/sv.edn
@@ -96,6 +96,7 @@
                    :resources "Resurser"
                    :review-emails "E-postaddresser för granskning"
                    :save "Spara"
+                   :short-name "Kort namn"
                    :start "Början"
                    :title "Namn"
                    :type "Typ"

--- a/src/clj/rems/api/schema.clj
+++ b/src/clj/rems/api/schema.clj
@@ -36,7 +36,8 @@
 
 (s/defschema OrganizationOverview
   (merge OrganizationId
-         {:organization/name LocalizedString}))
+         {:organization/short-name LocalizedString
+          :organization/name LocalizedString}))
 
 (s/defschema OrganizationFull
   (merge OrganizationOverview

--- a/src/clj/rems/db/organizations.clj
+++ b/src/clj/rems/db/organizations.clj
@@ -50,7 +50,7 @@
         organization-id (if (string? organization) organization (:organization/id organization))
         organization-overview (-> organization-id
                                   getx-organization-by-id
-                                  (select-keys [:organization/id :organization/name]))]
+                                  (select-keys [:organization/id :organization/name :organization/short-name]))]
     (-> x
         (update-existing :organization (fn [_] organization-overview))
         (update-existing :organization (fn [_] organization-overview)))))

--- a/src/clj/rems/db/test_data.clj
+++ b/src/clj/rems/db/test_data.clj
@@ -142,12 +142,13 @@
   "owner")
 
 (defn create-organization! [{:keys [actor users]
-                             :organization/keys [id name owners review-emails]
+                             :organization/keys [id name short-name owners review-emails]
                              :as command}]
   (let [actor (or actor (create-owner!))
         result (organizations/add-organization! actor
                                                 {:organization/id (or id "default")
                                                  :organization/name (or name {:fi "Oletusorganisaatio" :en "The Default Organization" :sv "Standardorganisationen"})
+                                                 :organization/short-name (or short-name {:fi "Oletus" :en "Default" :sv "Standard"})
                                                  :organization/owners (or owners
                                                                           (if users
                                                                             [{:userid (users :organization-owner1)} {:userid (users :organization-owner2)}]
@@ -965,6 +966,7 @@
         owner (+fake-users+ :owner)
         _perf (organizations/add-organization! owner {:organization/id "perf"
                                                       :organization/name {:fi "Suorituskykytestiorganisaatio" :en "Performance Test Organization" :sv "Organisationen för utvärderingsprov"}
+                                                      :organization/short-name {:fi "Suorituskyky" :en "Performance" :sv "Uvärderingsprov"}
                                                       :organization/owners [{:userid (+fake-users+ :organization-owner1)}]
                                                       :organization/review-emails []})
         workflow-id (create-workflow! {:actor owner
@@ -1073,30 +1075,37 @@
         default (create-organization! {:actor owner :users users})
         hus (organizations/add-organization! owner {:organization/id "hus"
                                                     :organization/name {:fi "Helsingin yliopistollinen sairaala" :en "Helsinki University Hospital" :sv "Helsingfors Universitetssjukhus"}
+                                                    :organization/short-name {:fi "HUS" :en "HUS" :sv "HUS"}
                                                     :organization/owners [{:userid organization-owner1}]
                                                     :organization/review-emails []})
         thl (organizations/add-organization! owner {:organization/id "thl"
                                                     :organization/name {:fi "Terveyden ja hyvinvoinnin laitos" :en "Finnish institute for health and welfare" :sv "Institutet för hälsa och välfärd"}
+                                                    :organization/short-name {:fi "THL" :en "THL" :sv "THL"}
                                                     :organization/owners [{:userid organization-owner2}]
                                                     :organization/review-emails []})
         nbn (organizations/add-organization! owner {:organization/id "nbn"
                                                     :organization/name {:fi "NBN" :en "NBN" :sv "NBN"}
+                                                    :organization/short-name {:fi "NBN" :en "NBN" :sv "NBN"}
                                                     :organization/owners [{:userid organization-owner2}]
                                                     :organization/review-emails []})
         abc (organizations/add-organization! owner {:organization/id "abc"
                                                     :organization/name {:fi "ABC" :en "ABC" :sv "ABC"}
+                                                    :organization/short-name {:fi "ABC" :en "ABC" :sv "ABC"}
                                                     :organization/owners []
                                                     :organization/review-emails [{:name {:fi "ABC Kirjaamo"} :email "kirjaamo@abc.efg"}]})
         csc (organizations/add-organization! owner {:organization/id "csc"
                                                     :organization/name {:fi "CSC – TIETEEN TIETOTEKNIIKAN KESKUS OY" :en "CSC – IT CENTER FOR SCIENCE LTD." :sv "CSC – IT CENTER FOR SCIENCE LTD."}
+                                                    :organization/short-name {:fi "CSC" :en "CSC" :sv "CSC"}
                                                     :organization/owners []
                                                     :organization/review-emails []})
         organization1 (organizations/add-organization! owner {:organization/id "organization1"
                                                               :organization/name {:fi "Organization 1" :en "Organization 1" :sv "Organization 1"}
+                                                              :organization/short-name {:fi "ORG 1" :en "ORG 1" :sv "ORG 1"}
                                                               :organization/owners [{:userid organization-owner1}]
                                                               :organization/review-emails []})
         organization2 (organizations/add-organization! owner {:organization/id "organization2"
                                                               :organization/name {:fi "Organization 2" :en "Organization 2" :sv "Organization 2"}
+                                                              :organization/short-name {:fi "ORG 2" :en "ORG 2" :sv "ORG 2"}
                                                               :organization/owners [{:userid organization-owner2}]
                                                               :organization/review-emails []})
 

--- a/src/cljs/rems/administration/catalogue_items.cljs
+++ b/src/cljs/rems/administration/catalogue_items.cljs
@@ -99,7 +99,7 @@
  (fn [[catalogue language] _]
    (map (fn [item]
           {:key (:id item)
-           :organization {:value (get-in item [:organization :organization/name language])}
+           :organization {:value (get-in item [:organization :organization/short-name language])}
            :name {:value (get-localized-title item language)
                   :sort-value [(get-localized-title item language)
                                (- (time-coerce/to-long (:start item)))]} ; secondary sort by created, reverse

--- a/src/cljs/rems/administration/create_catalogue_item.cljs
+++ b/src/cljs/rems/administration/create_catalogue_item.cljs
@@ -178,7 +178,7 @@
          :item-key :id
          :item-label #(str (:title %)
                            " (org: "
-                           (get-in % [:organization :organization/name language])
+                           (get-in % [:organization :organization/short-name language])
                            ")")
          :item-selected? item-selected?
          :on-change #(rf/dispatch [::set-selected-workflow %])}])]))
@@ -201,7 +201,7 @@
          :item-key :id
          :item-label #(str (:resid %)
                            " (org: "
-                           (get-in % [:organization :organization/name language])
+                           (get-in % [:organization :organization/short-name language])
                            ")")
          :item-selected? item-selected?
          :on-change #(rf/dispatch [::set-selected-resource %])}])]))
@@ -224,7 +224,7 @@
          :item-key :form/id
          :item-label #(str (:form/title %)
                            " (org: "
-                           (get-in % [:organization :organization/name language])
+                           (get-in % [:organization :organization/short-name language])
                            ")")
          :item-selected? item-selected?
          :on-change #(rf/dispatch [::set-selected-form %])}])]))

--- a/src/cljs/rems/administration/create_resource.cljs
+++ b/src/cljs/rems/administration/create_resource.cljs
@@ -88,7 +88,7 @@
        :item-key :id
        :item-label #(str (get-localized-title % language)
                          " (org: "
-                         (get-in % [:organization :organization/name language])
+                         (get-in % [:organization :organization/short-name language])
                          ")")
        :item-selected? #(contains? (set selected-licenses) %)
        :multi? true

--- a/src/cljs/rems/administration/form.cljs
+++ b/src/cljs/rems/administration/form.cljs
@@ -66,7 +66,7 @@
   [:div.spaced-vertically-3
    [collapsible/component
     {:id "form"
-     :title [:span (andstr (get-in form [:organization :organization/name language]) "/") (:form/title form)]
+     :title [:span (andstr (get-in form [:organization :organization/short-name language]) "/") (:form/title form)]
      :always [:div
               [inline-info-field (text :t.administration/organization) (get-in form [:organization :organization/name language])]
               [inline-info-field (text :t.administration/title) (:form/title form)]

--- a/src/cljs/rems/administration/forms.cljs
+++ b/src/cljs/rems/administration/forms.cljs
@@ -87,7 +87,7 @@
  (fn [[forms language] _]
    (map (fn [form]
           {:key (:form/id form)
-           :organization {:value (get-in form [:organization :organization/name language])}
+           :organization {:value (get-in form [:organization :organization/short-name language])}
            :title {:value (:form/title form)}
            :active (let [checked? (status-flags/active? form)]
                      {:td [:td.active

--- a/src/cljs/rems/administration/license.cljs
+++ b/src/cljs/rems/administration/license.cljs
@@ -5,6 +5,7 @@
             [rems.administration.components :refer [inline-info-field]]
             [rems.administration.status-flags :as status-flags]
             [rems.atoms :as atoms :refer [license-attachment-link external-link readonly-checkbox document-title]]
+            [rems.common.util :refer [andstr]]
             [rems.collapsible :as collapsible]
             [rems.flash-message :as flash-message]
             [rems.roles :as roles]
@@ -39,7 +40,7 @@
   [:div.spaced-vertically-3
    [collapsible/component
     {:id "license"
-     :title [:span (get-localized-title license language)]
+     :title [:span (andstr (get-in license [:organization :organization/short-name language]) "/") (get-localized-title license language)]
      :always (into [:div#license
                     [inline-info-field (text :t.administration/organization) (get-in license [:organization :organization/name language])]]
                    (concat

--- a/src/cljs/rems/administration/licenses.cljs
+++ b/src/cljs/rems/administration/licenses.cljs
@@ -79,7 +79,7 @@
           {:key (:id license)
            :title {:value (get-localized-title license language)}
            :type {:value (:licensetype license)}
-           :organization {:value (get-in license [:organization :organization/name language])}
+           :organization {:value (get-in license [:organization :organization/short-name language])}
            :active (let [checked? (status-flags/active? license)]
                      {:td [:td.active
                            [readonly-checkbox {:value checked?}]]

--- a/src/cljs/rems/administration/organization.cljs
+++ b/src/cljs/rems/administration/organization.cljs
@@ -47,6 +47,10 @@
      :title (get-in organization [:organization/name language])
      :always [:div
               [inline-info-field (text :t.administration/id) (:organization/id organization)]
+              (for [[langcode localization] (:organization/short-name organization)]
+                [inline-info-field (str (text :t.administration/short-name)
+                                        " (" (str/upper-case (name langcode)) ")")
+                 localization])
               (for [[langcode localization] (:organization/name organization)]
                 [inline-info-field (str (text :t.administration/title)
                                         " (" (str/upper-case (name langcode)) ")")

--- a/src/cljs/rems/administration/organizations.cljs
+++ b/src/cljs/rems/administration/organizations.cljs
@@ -77,7 +77,7 @@
  (fn [[organizations language] _]
    (for [organization organizations]
      {:key (:organization/id organization)
-      :name {:value (get-in organization [:organization/name language])}
+      :name {:value (get-in organization [:organization/short-name language])}
       :active (let [checked? (status-flags/active? organization)]
                 {:td [:td.active
                       [readonly-checkbox {:value checked?}]]

--- a/src/cljs/rems/administration/resource.cljs
+++ b/src/cljs/rems/administration/resource.cljs
@@ -51,7 +51,7 @@
   [:div.spaced-vertically-3
    [collapsible/component
     {:id "resource"
-     :title [:span (andstr (:domain resource) "/") (:resid resource)]
+     :title [:span (andstr (get-in resource [:organization :organization/short-name language]) "/") (:resid resource)]
      :always [:div
               [inline-info-field (text :t.administration/organization) (get-in resource [:organization :organization/name language])]
               [inline-info-field (text :t.administration/resource) (:resid resource)]

--- a/src/cljs/rems/administration/resources.cljs
+++ b/src/cljs/rems/administration/resources.cljs
@@ -77,7 +77,7 @@
  (fn [[resources language] _]
    (map (fn [resource]
           {:key (:id resource)
-           :organization {:value (get-in resource [:organization :organization/name language])}
+           :organization {:value (get-in resource [:organization :organization/short-name language])}
            :title {:value (:resid resource)}
            :active (let [checked? (status-flags/active? resource)]
                      {:td [:td.active

--- a/src/cljs/rems/administration/workflow.cljs
+++ b/src/cljs/rems/administration/workflow.cljs
@@ -51,7 +51,7 @@
   [:div.spaced-vertically-3
    [collapsible/component
     {:id "workflow"
-     :title [:span (andstr (get-in workflow [:organization :organization/name language]) "/") (:title workflow)]
+     :title [:span (andstr (get-in workflow [:organization :organization/short-name language]) "/") (:title workflow)]
      :always [:div
               [inline-info-field (text :t.administration/organization) (get-in workflow [:organization :organization/name language])]
               [inline-info-field (text :t.administration/title) (:title workflow)]

--- a/src/cljs/rems/administration/workflows.cljs
+++ b/src/cljs/rems/administration/workflows.cljs
@@ -77,7 +77,7 @@
  (fn [[workflows language] _]
    (map (fn [workflow]
           {:key (:id workflow)
-           :organization {:value (get-in workflow [:organization :organization/name language])}
+           :organization {:value (get-in workflow [:organization :organization/short-name language])}
            :title {:value (:title workflow)}
            :active (let [checked? (status-flags/active? workflow)]
                      {:td [:td.active

--- a/src/cljs/rems/application.cljs
+++ b/src/cljs/rems/application.cljs
@@ -610,7 +610,7 @@
         language @(rf/subscribe [:language])
         organization-name-if-known (fn [organization]
                                      (if-let [known-organization (organization-by-id (:organization/id organization))] ; comes from idp, maybe unknown
-                                       (get-in known-organization [:organization/name language])
+                                       (get-in known-organization [:organization/short-name language])
                                        (:organization/id organization)))]
     [collapsible/minimal
      {:id (str element-id "-info")

--- a/test/clj/rems/api/services/test_workflow.clj
+++ b/test/clj/rems/api/services/test_workflow.clj
@@ -18,7 +18,7 @@
   (create-users)
 
   (with-user "owner"
-    (test-data/create-organization! {:organization/id "abc" :organization/name {:en "ABC"}})
+    (test-data/create-organization! {:organization/id "abc" :organization/name {:en "ABC"} :organization/short-name {:en "ABC"}})
     (testing "default workflow with forms"
       (let [form-id (test-data/create-form! {:form/title "workflow form"
                                              :form/fields [{:field/type :text
@@ -30,7 +30,7 @@
                                                :handlers ["user1" "user2"]
                                                :forms [{:form/id form-id}]})]
         (is (= {:id wf-id
-                :organization {:organization/id "abc" :organization/name {:en "ABC"}}
+                :organization {:organization/id "abc" :organization/name {:en "ABC"} :organization/short-name {:en "ABC"}}
                 :title "the title"
                 :workflow {:type :workflow/default
                            :handlers [{:userid "user1" :name "User 1" :email "user1@example.com"}
@@ -49,7 +49,7 @@
                                                :title "the title"
                                                :handlers ["user1" "user2"]})]
         (is (= {:id wf-id
-                :organization {:organization/id "abc" :organization/name {:en "ABC"}}
+                :organization {:organization/id "abc" :organization/name {:en "ABC"} :organization/short-name {:en "ABC"}}
                 :title "the title"
                 :workflow {:type :workflow/decider
                            :handlers [{:userid "user1" :name "User 1" :email "user1@example.com"}
@@ -68,7 +68,7 @@
                                                :title "the title"
                                                :handlers ["user1" "user2"]})]
         (is (= {:id wf-id
-                :organization {:organization/id "abc" :organization/name {:en "ABC"}}
+                :organization {:organization/id "abc" :organization/name {:en "ABC"} :organization/short-name {:en "ABC"}}
                 :title "the title"
                 :workflow {:type :workflow/master
                            :handlers [{:userid "user1" :name "User 1" :email "user1@example.com"}
@@ -85,7 +85,7 @@
   (create-users)
 
   (with-user "owner"
-    (test-data/create-organization! {:organization/id "abc" :organization/name {:en "ABC"}})
+    (test-data/create-organization! {:organization/id "abc" :organization/name {:en "ABC"} :organization/short-name {:en "ABC"}})
     (testing "change title"
       (let [wf-id (test-data/create-workflow! {:organization {:organization/id "abc"}
                                                :type :workflow/master

--- a/test/clj/rems/api/test_catalogue_items.clj
+++ b/test/clj/rems/api/test_catalogue_items.clj
@@ -49,7 +49,7 @@
                       :workflow-name "workflow name"
                       :form-name "form name"
                       :resource-name "resource ext id"
-                      :organization {:organization/id "organization1" :organization/name {:fi "Organization 1" :en "Organization 1" :sv "Organization 1"}}
+                      :organization {:organization/id "organization1" :organization/name {:fi "Organization 1" :en "Organization 1" :sv "Organization 1"} :organization/short-name {:fi "ORG 1" :en "ORG 1" :sv "ORG 1"}}
                       :localizations {}}
                      (select-keys data [:id :organization :workflow-name :form-name :resource-name :localizations])))))
           (testing "and fetch non-existing item"

--- a/test/clj/rems/api/test_end_to_end.clj
+++ b/test/clj/rems/api/test_end_to_end.clj
@@ -55,6 +55,7 @@
             (api-call :post "/api/organizations/create"
                       {:organization/id "e2e"
                        :organization/name {:fi "Päästä loppuun -testi" :en "End-to-end"}
+                       :organization/short-name {:fi "E2E" :en "E2E"}
                        :organization/owners []
                        :organization/review-emails []}
                       api-key owner-id))

--- a/test/clj/rems/api/test_forms.clj
+++ b/test/clj/rems/api/test_forms.clj
@@ -104,7 +104,9 @@
                     (is (= (-> command
                                (select-keys [:organization :form/title])
                                (assoc-in
-                                [:organization :organization/name] {:fi "Organization 1" :en "Organization 1" :sv "Organization 1"}))
+                                [:organization :organization/name] {:fi "Organization 1" :en "Organization 1" :sv "Organization 1"})
+                               (assoc-in
+                                [:organization :organization/short-name] {:fi "ORG 1" :en "ORG 1" :sv "ORG 1"}))
                            (select-keys form-template [:organization :form/title])))
                     (is (= (:form/fields command)
                            (mapv fixup-field-to-match-command (:form/fields form-template)))))))))
@@ -120,7 +122,9 @@
                   (testing "result matches input"
                     (is (= (-> command-with-given-field-id
                                (select-keys [:organization :form/title])
-                               (assoc-in [:organization :organization/name] {:fi "Organization 1" :en "Organization 1" :sv "Organization 1"}))
+                               (assoc-in [:organization :organization/name] {:fi "Organization 1" :en "Organization 1" :sv "Organization 1"})
+                               (assoc-in
+                                [:organization :organization/short-name] {:fi "ORG 1" :en "ORG 1" :sv "ORG 1"}))
                            (select-keys form-template [:organization :form/title])))
                     (is (= (mapv #(dissoc % :field/id) (:form/fields command-with-given-field-id))
                            (mapv fixup-field-to-match-command (:form/fields form-template))))
@@ -197,7 +201,9 @@
                          read-ok-body)]
             (is (= (-> form-spec
                        (select-keys [:organization :form/title])
-                       (assoc-in [:organization :organization/name] {:fi "Organization 1" :en "Organization 1" :sv "Organization 1"}))
+                       (assoc-in [:organization :organization/name] {:fi "Organization 1" :en "Organization 1" :sv "Organization 1"})
+                       (assoc-in
+                        [:organization :organization/short-name] {:fi "ORG 1" :en "ORG 1" :sv "ORG 1"}))
                    (select-keys form [:organization :form/title])))
             (is (= (:form/fields form-spec)
                    (mapv fixup-field-to-match-command (:form/fields form))))))))))
@@ -304,7 +310,8 @@
                                      api-key user-id))))
       (let [form (api-call :get (str "/api/forms/" form-id) {} api-key user-id)]
         (is (= {:organization/id "abc"
-                :organization/name {:fi "ABC" :en "ABC" :sv "ABC"}}
+                :organization/name {:fi "ABC" :en "ABC" :sv "ABC"}
+                :organization/short-name {:fi "ABC" :en "ABC" :sv "ABC"}}
                (:organization form)))
         (is (= "I am owner" (:form/title form)))))))
 
@@ -544,7 +551,8 @@
                                  api-key user-id)]
               (is (= (-> command
                          (select-keys [:organization :form/title])
-                         (assoc-in [:organization :organization/name] {:fi "ABC" :en "ABC" :sv "ABC"}))
+                         (assoc-in [:organization :organization/name] {:fi "ABC" :en "ABC" :sv "ABC"})
+                         (assoc-in [:organization :organization/short-name] {:fi "ABC" :en "ABC" :sv "ABC"}))
                      (select-keys form [:organization :form/title])))
               (is (= [{:field/id "fld1"
                        :field/type "option"
@@ -613,7 +621,9 @@
                                                      :field/options [{:key "opt"
                                                                       :label {:sv "Swedish label"}}]}]}))]
     (is (= {:form/id id
-            :organization {:organization/id "default" :organization/name {:fi "Oletusorganisaatio" :en "The Default Organization" :sv "Standardorganisationen"}}
+            :organization {:organization/id "default"
+                           :organization/name {:fi "Oletusorganisaatio" :en "The Default Organization" :sv "Standardorganisationen"}
+                           :organization/short-name {:fi "Oletus" :en "Default" :sv "Standard"}}
             :form/title "invalid form"
             :form/fields [{:field/placeholder {:en "Placeholder"}
                            :field/title {:fi "Title in Finnish"}

--- a/test/clj/rems/api/test_licenses.clj
+++ b/test/clj/rems/api/test_licenses.clj
@@ -60,7 +60,8 @@
                 (is (= {:id id
                         :licensetype "link"
                         :organization {:organization/id "organization1"
-                                       :organization/name {:fi "Organization 1" :en "Organization 1" :sv "Organization 1"}}
+                                       :organization/name {:fi "Organization 1" :en "Organization 1" :sv "Organization 1"}
+                                       :organization/short-name {:fi "ORG 1" :en "ORG 1" :sv "ORG 1"}}
                         :localizations {:en {:title "en title"
                                              :textcontent "http://example.com/license/en"
                                              :attachment-id nil}
@@ -92,7 +93,8 @@
                 (is (= {:id id
                         :licensetype "text"
                         :organization {:organization/id "organization1"
-                                       :organization/name {:fi "Organization 1" :en "Organization 1" :sv "Organization 1"}}
+                                       :organization/name {:fi "Organization 1" :en "Organization 1" :sv "Organization 1"}
+                                       :organization/short-name {:fi "ORG 1" :en "ORG 1" :sv "ORG 1"}}
                         :localizations {:en {:title "en title"
                                              :textcontent "en text"
                                              :attachment-id nil}
@@ -157,7 +159,8 @@
                 (is (= {:id license-id
                         :licensetype "text"
                         :organization {:organization/id "organization1"
-                                       :organization/name {:fi "Organization 1" :en "Organization 1" :sv "Organization 1"}}
+                                       :organization/name {:fi "Organization 1" :en "Organization 1" :sv "Organization 1"}
+                                       :organization/short-name {:fi "ORG 1" :en "ORG 1" :sv "ORG 1"}}
                         :localizations {:en {:title "en title"
                                              :textcontent "en text"
                                              :attachment-id attachment-id}

--- a/test/clj/rems/api/test_organizations.clj
+++ b/test/clj/rems/api/test_organizations.clj
@@ -30,6 +30,7 @@
                            {:organization/id "organizations-api-test-org"
                             :organization/name {:fi "Organisaatiot API Test ORG"
                                                 :en "Organizations API Test ORG"}
+                            :organization/short-name {:fi "ORG" :en "ORG"}
                             :organization/owners [{:userid org-owner}]
                             :organization/review-emails [{:email "test@organization.test.org"
                                                           :name {:fi "Organisaatiot API Test ORG Katselmoijat"
@@ -45,6 +46,7 @@
             (is (= {:organization/id "organizations-api-test-org"
                     :organization/name {:fi "Organisaatiot API Test ORG"
                                         :en "Organizations API Test ORG"}
+                    :organization/short-name {:fi "ORG" :en "ORG"}
                     :organization/owners [{:userid org-owner}]
                     :organization/last-modified test-time
                     :organization/modifier {:userid owner}
@@ -74,6 +76,8 @@
                                    {:organization/id "test-organization"
                                     :organization/name {:fi "Testiorganisaatio"
                                                         :en "Test Organization"}
+                                    :organization/short-name {:fi "ORG"
+                                                              :en "ORG"}
                                     :organization/owners []
                                     :organization/review-emails []})]
         (is (response-is-unauthorized? response))
@@ -93,6 +97,8 @@
                                    {:organization/id "test-organization"
                                     :organization/name {:fi "Testiorganisaatio"
                                                         :en "Test Organization"}
+                                    :organization/short-name {:fi "ORG"
+                                                              :en "ORG"}
                                     :organization/owners []
                                     :organization/review-emails []}
                                    "42" "alice")]

--- a/test/clj/rems/api/test_workflows.clj
+++ b/test/clj/rems/api/test_workflows.clj
@@ -15,7 +15,9 @@
 
 ;; this is a subset of what we expect to get from the api
 (def ^:private expected
-  {:organization {:organization/id "organization1" :organization/name {:fi "Organization 1" :en "Organization 1" :sv "Organization 1"}}
+  {:organization {:organization/id "organization1"
+                  :organization/name {:fi "Organization 1" :en "Organization 1" :sv "Organization 1"}
+                  :organization/short-name {:fi "ORG 1" :en "ORG 1" :sv "ORG 1"}}
    :title "workflow title"
    :workflow {:type "workflow/default"
               :forms []

--- a/test/clj/rems/application/test_model.clj
+++ b/test/clj/rems/application/test_model.clj
@@ -18,7 +18,7 @@
 
 (def ^:private get-form-template
   {40 {:form/id 40
-       :organization {:organization/id "org" :organization/name {:fi "ORG" :en "ORG"}}
+       :organization {:organization/id "org" :organization/name {:fi "Organisaatio" :en "Organisation"} :organization/short-name {:fi "ORG" :en "ORG"}}
        :form/title "form title"
        :form/fields [{:field/id "41"
                       :field/title {:en "en title" :fi "fi title"}
@@ -43,7 +43,7 @@
        :enabled true
        :archived false}
    41 {:form/id 41
-       :organization {:organization/id "org" :organization/name {:fi "ORG" :en "ORG"}}
+       :organization {:organization/id "org" :organization/name {:fi "Organisaatio" :en "Organization"} :organization/short-name {:fi "ORG" :en "ORG"}}
        :form/title "form title 2"
        :form/fields [{:field/id "41"
                       :field/title {:en "en title" :fi "fi title"}
@@ -61,7 +61,7 @@
        :resid "urn:11"
        :wfid 50
        :formid 40
-       :organization {:organization/id "org" :organization/name {:fi "ORG" :en "ORG"}}
+       :organization {:organization/id "org" :organization/name {:fi "Organisaatio" :en "Organization"} :organization/short-name {:fi "ORG" :en "ORG"}}
        :localizations {:en {:id 10
                             :langcode :en
                             :title "en title"
@@ -80,7 +80,7 @@
        :resid "urn:21"
        :wfid 50
        :formid 40
-       :organization {:organization/id "org" :organization/name {:fi "ORG" :en "ORG"}}
+       :organization {:organization/id "org" :organization/name {:fi "Organisaatio" :en "Organization"} :organization/short-name {:fi "ORG" :en "ORG"}}
        :localizations {:en {:id 20
                             :langcode :en
                             :title "en title"
@@ -99,7 +99,7 @@
        :resid "urn:31"
        :wfid 50
        :formid 40
-       :organization {:organization/id "org" :organization/name {:fi "ORG" :en "ORG"}}
+       :organization {:organization/id "org" :organization/name {:fi "Organisaatio" :en "Organization"} :organization/short-name {:fi "ORG" :en "ORG"}}
        :localizations {:en {:id 20
                             :langcode :en
                             :title "en title"
@@ -118,7 +118,7 @@
        :resid "urn:31"
        :wfid 50
        :formid 41
-       :organization {:organization/id "org" :organization/name {:fi "ORG" :en "ORG"}}
+       :organization {:organization/id "org" :organization/name {:fi "Organisaatio" :en "Organization"} :organization/short-name {:fi "ORG" :en "ORG"}}
        :localizations {:en {:id 20
                             :langcode :en
                             :title "en title"
@@ -138,7 +138,7 @@
 
 (def ^:private get-license
   {30 {:id 30
-       :organization {:organization/id "org" :organization/name {:fi "ORG" :en "ORG"}}
+       :organization {:organization/id "org" :organization/name {:fi "Organisaatio" :en "Organization"} :organization/short-name {:fi "ORG" :en "ORG"}}
        :licensetype "link"
        :localizations {:en {:title "en title"
                             :textcontent "http://en-license-link"}
@@ -147,7 +147,7 @@
        :enabled true
        :archived false}
    31 {:id 31
-       :organization {:organization/id "org" :organization/name {:fi "ORG" :en "ORG"}}
+       :organization {:organization/id "org" :organization/name {:fi "Organisaatio" :en "Organization"} :organization/short-name {:fi "ORG" :en "ORG"}}
        :licensetype "text"
        :localizations {:en {:title "en title"
                             :textcontent "en license text"}
@@ -156,7 +156,7 @@
        :enabled true
        :archived false}
    32 {:id 32
-       :organization {:organization/id "org" :organization/name {:fi "ORG" :en "ORG"}}
+       :organization {:organization/id "org" :organization/name {:fi "Organisaatio" :en "Organization"} :organization/short-name {:fi "ORG" :en "ORG"}}
        :licensetype "attachment"
        :localizations {:en {:title "en title"
                             :textcontent "en filename"
@@ -167,7 +167,7 @@
        :enabled true
        :archived false}
    33 {:id 33
-       :organization {:organization/id "org" :organization/name {:fi "ORG" :en "ORG"}}
+       :organization {:organization/id "org" :organization/name {:fi "Organisaatio" :en "Organization"} :organization/short-name {:fi "ORG" :en "ORG"}}
        :licensetype "attachment"
        :localizations {:en {:title "en title"
                             :textcontent "en filename"
@@ -178,7 +178,7 @@
        :enabled true
        :archived false}
    34 {:id 34
-       :organization {:organization/id "org" :organization/name {:fi "ORG" :en "ORG"}}
+       :organization {:organization/id "org" :organization/name {:fi "Organisaatio" :en "Organization"} :organization/short-name {:fi "ORG" :en "ORG"}}
        :licensetype "attachment"
        :localizations {:en {:title "en title"
                             :textcontent "en filename"
@@ -212,7 +212,7 @@
 
 (def ^:private get-workflow
   {50 {:id 50
-       :organization {:organization/id "org" :organization/name {:fi "ORG" :en "ORG"}}
+       :organization {:organization/id "org" :organization/name {:fi "Organisaatio" :en "Organization"} :organization/short-name {:fi "ORG" :en "ORG"}}
        :title "workflow title"
        :workflow {:type "workflow/dynamic"
                   :handlers [{:userid "handler"

--- a/test/clj/rems/test_browser.clj
+++ b/test/clj/rems/test_browser.clj
@@ -376,7 +376,7 @@
               "Accepted terms of use" ""
               "Username" "alice"
               "Email (from identity provider)" "alice@example.com"
-              "Organization" "The Default Organization"}
+              "Organization" "Default"}
              (slurp-fields :applicant-info))))
     (testing "open the approve form"
       (btu/scroll-and-click :approve-reject-action-button))
@@ -742,7 +742,7 @@
     (testing "fetch form via api"
       (let [form-id (Integer/parseInt (last (str/split (btu/get-url) #"/")))]
         (is (= {:form/id form-id
-                :organization {:organization/id "nbn" :organization/name {:fi "NBN" :en "NBN" :sv "NBN"}}
+                :organization {:organization/id "nbn" :organization/name {:fi "NBN" :en "NBN" :sv "NBN"} :organization/short-name {:fi "NBN" :en "NBN" :sv "NBN"}}
                 :form/title "Form editor test"
                 :form/fields [{:field/placeholder {:fi "" :en "" :sv ""}
                                :field/title {:fi "Description (FI)" :en "Description (EN)" :sv "Description (SV)"}


### PR DESCRIPTION
Implements short name from #2039.

The short name is used in the table views because organization names
can be long.

NB: we add the short-name to the existing organization migration that
should not be used anywhere yet. 
NB: Since this is not yet in a release we also add the fields as required into the API.
NB: Changelog already contains enough about org ui.
NB: Also fixed two detail views without organization for consistency (resource and license)

![short-name1](https://user-images.githubusercontent.com/823661/90670498-f47dae00-e25b-11ea-9cce-3c83980f8bbf.png)
![short-name2](https://user-images.githubusercontent.com/823661/90670499-f5164480-e25b-11ea-8221-38437bb9b50b.png)

# Definition of Done / Review checklist

## Reviewability
- [x] link to issue
- [x] consider adding screenshots for ease of review

## API
- [ ] API is documented and shows up in Swagger UI
- [ ] API is backwards compatible or completely new

## Documentation
- [ ] update changelog if necessary

## Testing
- [x] complex logic is unit tested
- [x] valuable features are integration / browser / acceptance tested automatically
