### PR TITLE
feat: enable report browser test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@
 /.rebel_readline_history
 /package-lock.json
 /browsertest-errors/
+/browsertest-downloads/

--- a/test/clj/rems/browser_test_util.clj
+++ b/test/clj/rems/browser_test_util.clj
@@ -47,6 +47,15 @@
           :when (re-matches name-or-regex (.getName file))]
       file)))
 
+(defn delete-downloaded-files! [name-or-regex]
+  (let [files (if (string? name-or-regex)
+                [(io/file download-dir name-or-regex)]
+                (for [file (.listFiles download-dir)
+                      :when (re-matches name-or-regex (.getName file))]
+                  file))]
+    (doseq [file files]
+      (.delete file))))
+
 (defn- mod-nth [coll i]
   (nth coll (mod (int i) (count coll))))
 

--- a/test/clj/rems/test_browser.clj
+++ b/test/clj/rems/test_browser.clj
@@ -901,7 +901,9 @@
                            :actor "alice"})
       (test-data/command! {:type :application.command/submit
                            :application-id (btu/context-get :application-id)
-                           :actor "alice"}))
+                           :actor "alice"})
+
+      (btu/delete-downloaded-files! #"applications_.*\.csv")) ; make sure no report exists
 
     (testing "open report"
       (login-as "owner")
@@ -910,11 +912,9 @@
       (btu/wait-page-loaded)
       (select-option* "Form" (btu/context-get :form-title))
       (btu/scroll-and-click :export-applications-button)
-      #_(btu/wait-for-downloads #"applications_.*\.csv"))
+      (btu/wait-for-downloads #"applications_.*\.csv")) ; report has time in it that is difficult to control
 
-    ;; TODO disabled until chromedriver 83 is available and has bugfix for downloading in other tab (target blank)
-    (is true)
-    #_(testing "check report CSV"
+    (testing "check report CSV"
       (let [application (get-application-from-api (btu/context-get :application-id))
             q (fn [s] (str "\"" s "\""))]
         (is (= ["\"Id\",\"External id\",\"Applicant\",\"Submitted\",\"State\",\"Resources\",\"description\""


### PR DESCRIPTION
Enables the commented browser test for reports.

Works on ChromeDriver 83+ only (since it has a bugfix for downloading
target blank i.e. other tab.
