### PR TITLE
fix: transit requests with dates

### DIFF
--- a/src/clj/rems/middleware.clj
+++ b/src/clj/rems/middleware.clj
@@ -113,15 +113,6 @@
                      :title "System error occurred!"
                      :message "We are working on fixing the issue."})))))
 
-(defn wrap-formats [handler]
-  (let [wrapped (wrap-restful-format
-                 handler
-                 {:formats [:json-kw :transit-json :transit-msgpack]})]
-    (fn [request]
-      ;; disable wrap-formats for websockets
-      ;; since they're not compatible with this middleware
-      ((if (:websocket? request) handler wrapped) request))))
-
 (defn on-restricted-page [request response]
   (assoc (redirect "/login")
          :session (assoc (:session response) :redirect-to (:uri request))))
@@ -244,5 +235,4 @@
       wrap-webjars ;; serves our webjar (https://www.webjars.org/) dependencies as /assets/<webjar>/<file>
       (wrap-defaults (wrap-defaults-settings))
       wrap-internal-error
-      wrap-formats
       wrap-request-context))


### PR DESCRIPTION
- configure transit (or rather, muuntaja) to decode timestamps as joda
  DateTimes
- remove redundant wrap-formats middleware that was decoding transit
  using defaults before our muuntaja
- test /api/applications/approve via transit
- implement some test helpers to make the previous nicer

follow-up for #2300, part of #2123

# Definition of Done / Review checklist

## Reviewability
- [x] link to issue

## API
- [x] API is backwards compatible or completely new

## Testing
- [x] complex logic is unit tested
- [x] valuable features are integration / browser / acceptance tested automatically