### PR TITLE
fix: don't try to parse response of /api/keepalive

### DIFF
--- a/src/cljs/rems/keepalive.cljs
+++ b/src/cljs/rems/keepalive.cljs
@@ -6,7 +6,7 @@
 (def keepalive-interval (time/minutes 1))
 
 (defn keepalive! []
-  (fetch "/api/keepalive" {}))
+  (fetch "/api/keepalive" {:response-format nil})) ;; the response is empty
 
 (rf/reg-event-db
  ::activity


### PR DESCRIPTION
... since it's empty. Was causing spurious errors in js console.