### PR TITLE
new, simpler, docker-based circle configuration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,9 @@ defaults: &defaults
 
 jobs:
   build:
-    <<: *defaults
+    executor: docker
+    docker:
+      - image: circleci/clojure:openjdk-11-lein-2.9.3-node-browsers
     steps:
       - checkout
 
@@ -33,9 +35,9 @@ jobs:
 
       # upgrade node
       # TODO: could upgrade node using NVM but it seems poorly documented and a hassle
-      - run: sudo rm /opt/circleci/.nvm/versions/node/v6.1.0/bin/node
-      - run: curl -sL https://deb.nodesource.com/setup_13.x | sudo bash -
-      - run: sudo apt install nodejs
+      #- run: sudo rm /opt/circleci/.nvm/versions/node/v6.1.0/bin/node
+      #- run: curl -sL https://deb.nodesource.com/setup_13.x | sudo bash -
+      #- run: sudo apt install nodejs
 
       - run: lein deps
 
@@ -51,7 +53,7 @@ jobs:
   without-db:
     executor: docker
     docker:
-      - image: clojure:openjdk-11-lein-2.9.3
+      - image: circleci/clojure:openjdk-11-lein-2.9.3-node-browsers
     steps:
       - checkout
       # TODO cache restore puts stuff in the wrong directories due to the build step being non-docker

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,22 +29,14 @@ jobs:
     <<: *docker
     steps:
       - checkout
-
       # Download and cache dependencies
       - restore_cache:
           keys:
             - v3-dependencies-{{ checksum "project.clj" }}
             # fallback to using the latest cache if no exact match is found
             - v3-dependencies-
-
-      # upgrade node
-      # TODO: could upgrade node using NVM but it seems poorly documented and a hassle
-      #- run: sudo rm /opt/circleci/.nvm/versions/node/v6.1.0/bin/node
-      #- run: curl -sL https://deb.nodesource.com/setup_13.x | sudo bash -
-      #- run: sudo apt install nodejs
-
       - run: lein deps
-
+      # TODO using persist_to_workspace might be more robust than using cache
       - save_cache:
           paths:
             - ~/.m2
@@ -117,6 +109,7 @@ jobs:
           paths:
             - target/uberjar/rems.jar
 
+  # TODO: use docker executor and setup_remote_docker for these builder too:
   docker-snapshot:
     <<: *defaults
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,8 +54,7 @@ jobs:
       - checkout
       # TODO cache restore puts stuff in the wrong directories due to the build step being non-docker
       - restore_cache:
-          keys:
-            - v3-dependencies-{{ checksum "project.clj" }}
+          key: v3-dependencies-{{ checksum "project.clj" }}
       # verify that we can run unit tests without the database:
       - run: DATABASE_URL=invalid lein kaocha --reporter kaocha.report/documentation unit
       - store_test_results:
@@ -66,8 +65,7 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          keys:
-            - v3-dependencies-{{ checksum "project.clj" }}
+          key: v3-dependencies-{{ checksum "project.clj" }}
       - run: lein cljtests-ci
       - store_test_results:
           path: target/test-results
@@ -81,8 +79,7 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          keys:
-            - v3-dependencies-{{ checksum "project.clj" }}
+          key: v3-dependencies-{{ checksum "project.clj" }}
       - run: lein doo chrome-headless test once
       - store_test_results:
           path: target/test-results
@@ -92,8 +89,7 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          keys:
-            - v3-dependencies-{{ checksum "project.clj" }}
+          key: v3-dependencies-{{ checksum "project.clj" }}
       - run: lein uberwar
       - store_artifacts:
           path: target/uberjar/rems.war

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,7 +49,9 @@ jobs:
           key: v2-dependencies-{{ checksum "project.clj" }}
 
   without-db:
-    <<: *defaults
+    executor: docker
+    docker:
+      - image: clojure:openjdk-11-lein-2.9.3
     steps:
       - checkout
       - restore_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,7 +27,7 @@ executors:
           POSTGRES_USER: rems_test
 
 jobs:
-  build:
+  deps:
     executor: clojure
     steps:
       - checkout
@@ -48,7 +48,7 @@ jobs:
             - node_modules
           key: v3-dependencies-{{ checksum "project.clj" }}
 
-  without-db:
+  unit-test:
     executor: clojure
     steps:
       - checkout
@@ -56,16 +56,29 @@ jobs:
           key: v3-dependencies-{{ checksum "project.clj" }}
       # verify that we can run unit tests without the database:
       - run: DATABASE_URL=invalid lein kaocha --reporter kaocha.report/documentation unit
+      - run: lein cljsbuild once
+      - run: lein doo chrome-headless test once
       - store_test_results:
           path: target/test-results
 
-  test:
+  integration-test:
     executor: db
     steps:
       - checkout
       - restore_cache:
           key: v3-dependencies-{{ checksum "project.clj" }}
-      - run: lein cljtests-ci
+      - run: lein kaocha --reporter kaocha.report/documentation integration
+      - store_test_results:
+          path: target/test-results
+
+  browser-test:
+    executor: db
+    steps:
+      - checkout
+      - restore_cache:
+          key: v3-dependencies-{{ checksum "project.clj" }}
+      - run: lein cljsbuild once
+      - run: lein kaocha --reporter kaocha.report/documentation browser
       - store_test_results:
           path: target/test-results
       - store_artifacts:
@@ -73,17 +86,7 @@ jobs:
       - store_artifacts:
           path: browsertest-downloads
 
-  doo:
-    executor: clojure
-    steps:
-      - checkout
-      - restore_cache:
-          key: v3-dependencies-{{ checksum "project.clj" }}
-      - run: lein doo chrome-headless test once
-      - store_test_results:
-          path: target/test-results
-
-  war:
+  build:
     executor: clojure
     steps:
       - checkout
@@ -140,31 +143,31 @@ workflows:
   version: 2
   build-test-and-deploy:
     jobs:
+      - deps:
+          filters:
+            tags:
+              only: /.*/
+      - unit-test:
+          requires:
+            - deps
+          filters:
+            tags:
+              only: /.*/
+      - integration-test:
+          requires:
+            - deps
+          filters:
+            tags:
+              only: /.*/
+      - browser-test:
+          requires:
+            - deps
+          filters:
+            tags:
+              only: /.*/
       - build:
-          filters:
-            tags:
-              only: /.*/
-      - without-db:
           requires:
-            - build
-          filters:
-            tags:
-              only: /.*/
-      - test:
-          requires:
-            - build
-          filters:
-            tags:
-              only: /.*/
-      - doo:
-          requires:
-            - build
-          filters:
-            tags:
-              only: /.*/
-      - war:
-          requires:
-            - build
+            - deps
           filters:
             tags:
               only: /.*/
@@ -173,16 +176,16 @@ workflows:
                 - master
       - docker-snapshot:
           requires:
+            - deps
             - build
-            - war
           filters:
             branches:
               only:
                 - master
       - docker-release:
           requires:
+            - deps
             - build
-            - war
           filters:
             tags:
               only: /v[0-9]\.[0-9].*/
@@ -190,16 +193,16 @@ workflows:
               ignore: /.*/
       - rahti-dev:
           requires:
+            - deps
             - build
-            - war
           filters:
             branches:
               only:
                 - master
       - rahti-demo:
           requires:
+            - deps
             - build
-            - war
           filters:
             tags:
               only: /v[0-9]\.[0-9].*/
@@ -207,11 +210,11 @@ workflows:
               ignore: /.*/
       - ok:
           requires:
+            - deps
+            - unit-test
+            - integration-test
+            - browser-test
             - build
-            - without-db
-            - test
-            - doo
-            - war
           filters:
             tags:
               only: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -103,6 +103,7 @@ jobs:
       - restore_cache:
           keys:
             - v2-dependencies-{{ checksum "project.clj" }}
+      - run: lein deps # just in case cache fails
       - run: lein doo chrome-headless test once
       - store_test_results:
           path: target/test-results

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,8 +1,4 @@
-# Clojure CircleCI 2.0 configuration file
-#
-# Check https://circleci.com/docs/2.0/language-clojure/ for more details
-#
-version: 2
+version: 2.1
 
 # We use the machine executor because our dev_db.sh uses docker to run
 # a fixed postgres version. Additionally, if we wanted to use docker
@@ -18,15 +14,21 @@ defaults: &defaults
     # Customize the JVM maximum heap limit
     JVM_OPTS: -Xmx3200m
 
-docker: &docker
-  executor: docker
-  docker:
-    - image: circleci/clojure:openjdk-11-lein-2.9.3-node-browsers
-
+executors:
+  clojure:
+    docker:
+      - image: circleci/clojure:openjdk-11-lein-2.9.3-node-browsers
+  db:
+    docker:
+      - image: circleci/clojure:openjdk-11-lein-2.9.3-node-browsers
+      - image: postgres:9.6
+        environment:
+          POSTGRES_HOST_AUTH_METHOD: trust
+          POSTGRES_USER: rems_test
 
 jobs:
   build:
-    <<: *docker
+    executor: clojure
     steps:
       - checkout
       # Download and cache dependencies
@@ -47,7 +49,7 @@ jobs:
           key: v3-dependencies-{{ checksum "project.clj" }}
 
   without-db:
-    <<: *docker
+    executor: clojure
     steps:
       - checkout
       # TODO cache restore puts stuff in the wrong directories due to the build step being non-docker
@@ -60,13 +62,7 @@ jobs:
           path: target/test-results
 
   test:
-    executor: docker
-    docker:
-      - image: circleci/clojure:openjdk-11-lein-2.9.3-node-browsers
-      - image: postgres:9.6
-        environment:
-          POSTGRES_HOST_AUTH_METHOD: trust
-          POSTGRES_USER: rems_test
+    executor: db
     steps:
       - checkout
       - restore_cache:
@@ -81,7 +77,7 @@ jobs:
           path: browsertest-downloads
 
   doo:
-    <<: *docker
+    executor: clojure
     steps:
       - checkout
       - restore_cache:
@@ -92,7 +88,7 @@ jobs:
           path: target/test-results
 
   war:
-    <<: *docker
+    executor: clojure
     steps:
       - checkout
       - restore_cache:
@@ -140,7 +136,6 @@ jobs:
 
   # pseudo job to post a single ok status to github after all the tests
   ok:
-    executor: docker
     docker:
       - image: alpine
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,10 +1,7 @@
 version: 2.1
 
-# We use the machine executor because our dev_db.sh uses docker to run
-# a fixed postgres version. Additionally, if we wanted to use docker
-# for builds we'd need to setup a custom lein+npm+postgres image and
-# publish it on docker hub. Maybe some day.
-
+# We still use this legacy machine executor for building docker images.
+# TODO: use docker executor and setup_remote_docker for these builds.
 defaults: &defaults
   machine:
     image: ubuntu-1604:201903-01
@@ -104,7 +101,6 @@ jobs:
           paths:
             - target/uberjar/rems.jar
 
-  # TODO: use docker executor and setup_remote_docker for these builder too:
   docker-snapshot:
     <<: *defaults
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,9 +33,9 @@ jobs:
       # Download and cache dependencies
       - restore_cache:
           keys:
-            - v2-dependencies-{{ checksum "project.clj" }}
+            - v3-dependencies-{{ checksum "project.clj" }}
             # fallback to using the latest cache if no exact match is found
-            - v2-dependencies-
+            - v3-dependencies-
 
       # upgrade node
       # TODO: could upgrade node using NVM but it seems poorly documented and a hassle
@@ -52,7 +52,7 @@ jobs:
             # unless the project.clj is changed. This might create differences
             # between dev, CI and actual deployment.
             - node_modules
-          key: v2-dependencies-{{ checksum "project.clj" }}
+          key: v3-dependencies-{{ checksum "project.clj" }}
 
   without-db:
     <<: *docker
@@ -61,7 +61,7 @@ jobs:
       # TODO cache restore puts stuff in the wrong directories due to the build step being non-docker
       - restore_cache:
           keys:
-            - v2-dependencies-{{ checksum "project.clj" }}
+            - v3-dependencies-{{ checksum "project.clj" }}
       # verify that we can run unit tests without the database:
       - run: DATABASE_URL=invalid lein kaocha --reporter kaocha.report/documentation unit
       - store_test_results:
@@ -79,7 +79,7 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - v2-dependencies-{{ checksum "project.clj" }}
+            - v3-dependencies-{{ checksum "project.clj" }}
       - run: lein cljtests-ci
       - store_test_results:
           path: target/test-results
@@ -94,8 +94,7 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - v2-dependencies-{{ checksum "project.clj" }}
-      - run: lein deps # just in case cache fails
+            - v3-dependencies-{{ checksum "project.clj" }}
       - run: lein doo chrome-headless test once
       - store_test_results:
           path: target/test-results
@@ -106,7 +105,7 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - v2-dependencies-{{ checksum "project.clj" }}
+            - v3-dependencies-{{ checksum "project.clj" }}
       - run: lein uberwar
       - store_artifacts:
           path: target/uberjar/rems.war

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,6 +38,7 @@ jobs:
             # fallback to using the latest cache if no exact match is found
             - v3-dependencies-
       - run: lein deps
+      - run: lein cljsbuild deps
       # TODO using persist_to_workspace might be more robust than using cache
       - save_cache:
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -95,7 +95,9 @@ jobs:
           path: browsertest-downloads
 
   doo:
-    <<: *defaults
+    executor: docker
+    docker:
+      - image: circleci/clojure:openjdk-11-lein-2.9.3-node-browsers
     steps:
       - checkout
       - restore_cache:
@@ -106,7 +108,9 @@ jobs:
           path: target/test-results
 
   war:
-    <<: *defaults
+    executor: docker
+    docker:
+      - image: circleci/clojure:openjdk-11-lein-2.9.3-node-browsers
     steps:
       - checkout
       - restore_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,7 +52,6 @@ jobs:
     executor: clojure
     steps:
       - checkout
-      # TODO cache restore puts stuff in the wrong directories due to the build step being non-docker
       - restore_cache:
           key: v3-dependencies-{{ checksum "project.clj" }}
       # verify that we can run unit tests without the database:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,6 +54,7 @@ jobs:
       - image: clojure:openjdk-11-lein-2.9.3
     steps:
       - checkout
+      # TODO cache restore puts stuff in the wrong directories due to the build step being non-docker
       - restore_cache:
           keys:
             - v2-dependencies-{{ checksum "project.clj" }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,26 +68,18 @@ jobs:
           path: target/test-results
 
   test:
-    <<: *defaults
+    executor: docker
+    docker:
+      - image: circleci/clojure:openjdk-11-lein-2.9.3-node-browsers
+      - image: postgres:9.6
+        environment:
+          POSTGRES_HOST_AUTH_METHOD: trust
+          POSTGRES_USER: rems_test
     steps:
       - checkout
       - restore_cache:
           keys:
             - v2-dependencies-{{ checksum "project.clj" }}
-      # dl.google.com new apt key isn't trusted by the image
-      - run: curl https://dl.google.com/linux/linux_signing_key.pub | sudo apt-key add -
-      # killall is a workaround for apt failing with: Could not get lock /var/lib/apt/lists/lock
-      - run: sudo killall -9 apt-get || true; sudo apt update
-
-      # upgrade chromedriver and node
-      - run: sudo apt remove google-chrome-stable
-      # remove conflicting versions installed by circle
-      # TODO: could upgrade node using NVM but it seems poorly documented and a hassle
-      - run: sudo rm /usr/local/bin/chromedriver /opt/circleci/.nvm/versions/node/v6.1.0/bin/node
-      - run: curl -sL https://deb.nodesource.com/setup_13.x | sudo bash -
-      - run: sudo apt install chromium-chromedriver nodejs
-
-      - run: FOR_TESTS=1 ./dev_db.sh
       - run: lein cljtests-ci
       - store_test_results:
           path: target/test-results

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,11 +18,15 @@ defaults: &defaults
     # Customize the JVM maximum heap limit
     JVM_OPTS: -Xmx3200m
 
+docker: &docker
+  executor: docker
+  docker:
+    - image: circleci/clojure:openjdk-11-lein-2.9.3-node-browsers
+
+
 jobs:
   build:
-    executor: docker
-    docker:
-      - image: circleci/clojure:openjdk-11-lein-2.9.3-node-browsers
+    <<: *docker
     steps:
       - checkout
 
@@ -51,9 +55,7 @@ jobs:
           key: v2-dependencies-{{ checksum "project.clj" }}
 
   without-db:
-    executor: docker
-    docker:
-      - image: circleci/clojure:openjdk-11-lein-2.9.3-node-browsers
+    <<: *docker
     steps:
       - checkout
       # TODO cache restore puts stuff in the wrong directories due to the build step being non-docker
@@ -95,9 +97,7 @@ jobs:
           path: browsertest-downloads
 
   doo:
-    executor: docker
-    docker:
-      - image: circleci/clojure:openjdk-11-lein-2.9.3-node-browsers
+    <<: *docker
     steps:
       - checkout
       - restore_cache:
@@ -108,9 +108,7 @@ jobs:
           path: target/test-results
 
   war:
-    executor: docker
-    docker:
-      - image: circleci/clojure:openjdk-11-lein-2.9.3-node-browsers
+    <<: *docker
     steps:
       - checkout
       - restore_cache:

--- a/project.clj
+++ b/project.clj
@@ -89,7 +89,7 @@
   :migratus {:store :database :db ~(get (System/getenv) "DATABASE_URL" "postgresql://localhost/rems?user=rems")}
 
   :plugins [[lein-cljfmt "0.6.7"]
-            [lein-cljsbuild "1.1.7"]
+            [lein-cljsbuild "1.1.8"]
             [lein-cprop "1.0.3"]
             [lein-npm "0.6.2"]
             [lein-shell "0.5.0"]


### PR DESCRIPTION
- use docker to run tests
- upgrade to circle config format 2.1
- better names for jobs: unit-test, integration-test, browser-test
- better parallelism: integration & browser tests are in separate jobs