### PR TITLE
improve entitlement end ui behaviour

### DIFF
--- a/src/cljc/rems/text.cljc
+++ b/src/cljc/rems/text.cljc
@@ -2,9 +2,9 @@
   (:require [clojure.test :refer [deftest is]]
             #?(:clj [clj-time.core :as time]
                :cljs [cljs-time.core :as time])
-            #?(:clj [clj-time.format :as format]
-               :cljs [cljs-time.format :as format])
-            #?(:cljs [cljs-time.coerce :as coerce])
+            #?(:clj [clj-time.format :as time-format]
+               :cljs [cljs-time.format :as time-format])
+            #?(:cljs [cljs-time.coerce :as time-coerce])
             [clojure.string :as str]
             #?(:cljs [re-frame.core :as rf])
             [rems.common.application-util :as application-util]
@@ -26,7 +26,7 @@
                  (cons k args)))))
 
 (defn text-format
-  "Return the tempura translation for a given key & format arguments"
+  "Return the tempura translation for a given key & time arguments"
   [k & args]
   #?(:clj (context/*tempura* [k :t/missing] (vec args))
      :cljs (let [translations (rf/subscribe [:translations])
@@ -90,21 +90,21 @@
     (text (get todos todo :t.applications.todos/unknown))))
 
 (defn- time-format []
-  (format/formatter "yyyy-MM-dd HH:mm" (time/default-time-zone)))
+  (time-format/formatter "yyyy-MM-dd HH:mm" (time/default-time-zone)))
 
 (defn localize-time [time]
   #?(:clj (when time
-            (let [time (if (string? time) (format/parse time) time)]
-              (format/unparse (time-format) time)))
-     :cljs (let [time (if (string? time) (format/parse time) time)]
+            (let [time (if (string? time) (time-format/parse time) time)]
+              (time-format/unparse (time-format) time)))
+     :cljs (let [time (if (string? time) (time-format/parse time) time)]
              (when time
-               (format/unparse-local (time-format) (time/to-default-time-zone time))))))
+               (time-format/unparse-local (time-format) (time/to-default-time-zone time))))))
 
 (defn localize-utc-date
   "For a given time instant, return the ISO date (yyyy-MM-dd) that it corresponds to in UTC."
   [time]
-  #?(:clj (format/unparse (format/formatter "yyyy-MM-dd") time)
-     :cljs (format/unparse (format/formatter "yyyy-MM-dd") (coerce/to-local-date time))))
+  #?(:clj (time-format/unparse (time-format/formatter "yyyy-MM-dd") time)
+     :cljs (time-format/unparse (time-format/formatter "yyyy-MM-dd") (time-coerce/to-local-date time))))
 
 (deftest test-localize-utc-date []
   (is (= "2020-09-29" (localize-utc-date (time/date-time 2020 9 29 1 1))))

--- a/src/cljc/rems/text.cljc
+++ b/src/cljc/rems/text.cljc
@@ -1,8 +1,10 @@
 (ns rems.text
-  (:require #?(:clj [clj-time.core :as time]
+  (:require [clojure.test :refer [deftest is]]
+            #?(:clj [clj-time.core :as time]
                :cljs [cljs-time.core :as time])
             #?(:clj [clj-time.format :as format]
                :cljs [cljs-time.format :as format])
+            #?(:cljs [cljs-time.coerce :as coerce])
             [clojure.string :as str]
             #?(:cljs [re-frame.core :as rf])
             [rems.common.application-util :as application-util]
@@ -98,6 +100,23 @@
              (when time
                (format/unparse-local (time-format) (time/to-default-time-zone time))))))
 
+(defn localize-utc-date
+  "For a given time instant, return the ISO date (yyyy-MM-dd) that it corresponds to in UTC."
+  [time]
+  #?(:clj (format/unparse (format/formatter "yyyy-MM-dd") time)
+     :cljs (format/unparse (format/formatter "yyyy-MM-dd") (coerce/to-local-date time))))
+
+(deftest test-localize-utc-date []
+  (is (= "2020-09-29" (localize-utc-date (time/date-time 2020 9 29 1 1))))
+  (is (= "2020-09-29" (localize-utc-date (time/date-time 2020 9 29 23 59))))
+  ;; [cl]js dates are always in UTC, so we can only test these for clj
+  #?(:clj (do
+            (is (= "2020-09-29" (localize-utc-date (time/to-time-zone (time/date-time 2020 9 29 23 59)
+                                                                      (time/time-zone-for-offset 5))))
+            (is (= "2020-09-29" (localize-utc-date (time/to-time-zone (time/date-time 2020 9 29 1 1)
+                                                                      (time/time-zone-for-offset -5)))))))))
+
+
 (def ^:private event-types
   {:application.event/approved :t.applications.events/approved
    :application.event/closed :t.applications.events/closed
@@ -166,6 +185,6 @@
      (case event-type
        :application.event/approved
        (when-let [end (:entitlement/end event)]
-         (str " " (text-format :t.applications/entitlement-end (localize-time end))))
+         (str " " (text-format :t.applications/entitlement-end (localize-utc-date end))))
 
        nil))))

--- a/src/cljs/rems/actions/approve_reject.cljs
+++ b/src/cljs/rems/actions/approve_reject.cljs
@@ -1,5 +1,6 @@
 (ns rems.actions.approve-reject
-  (:require [cljs-time.core :as time]
+  (:require [cljs-time.coerce :as time-coerce]
+            [cljs-time.core :as time]
             [cljs-time.format :as time-format]
             [re-frame.core :as rf]
             [rems.actions.action :refer [action-attachment action-button action-comment action-form-view button-wrapper command!]]
@@ -33,7 +34,11 @@
                      :comment comment
                      :attachments attachments}
                     (when end
-                      {:entitlement-end (js/Date. end)}))
+                      ;; selecting an entitlement end of 2008-03-15 means the entitlement ends 2008-03-15T23:59:59
+                      {:entitlement-end (-> (time-format/parse (time-format/formatters :year-month-day) end)
+                                            (time/plus (time/days 1))
+                                            (time/minus (time/seconds 1))
+                                            (time-coerce/to-date))}))
              {:description [text :t.actions/approve]
               :collapse action-form-id
               :on-finished on-finished})

--- a/test/clj/rems/test_browser.clj
+++ b/test/clj/rems/test_browser.clj
@@ -446,8 +446,7 @@
       (btu/scroll-and-click :approve)
       (btu/wait-predicate #(= "Approved" (btu/get-element-text :application-state))))
     (testing "event visible in eventlog"
-      ;; time rendering depends on time zone
-      (is (btu/visible? {:css "div.event-description b" :fn/has-text "Developer approved the application. Access rights end"})))
+      (is (btu/visible? {:css "div.event-description b" :fn/text "Developer approved the application. Access rights end 2100-05-06"})))
     (testing "event via api"
       (is (= {:application/id (btu/context-get :application-id)
               :event/type "application.event/approved"

--- a/test/clj/rems/test_browser.clj
+++ b/test/clj/rems/test_browser.clj
@@ -452,7 +452,7 @@
       (is (= {:application/id (btu/context-get :application-id)
               :event/type "application.event/approved"
               :application/comment "this is a comment"
-              :entitlement/end "2100-05-06T00:00:00.000Z"
+              :entitlement/end "2100-05-06T23:59:59.000Z"
               :event/actor "developer"}
              (-> (get-application-from-api (btu/context-get :application-id) "developer")
                  :application/events

--- a/test/cljs/rems/cljs_tests.cljs
+++ b/test/cljs/rems/cljs_tests.cljs
@@ -13,7 +13,8 @@
             rems.flash-message
             rems.test-fields
             rems.test-table
-            rems.test-util))
+            rems.test-util
+            rems.text))
 
 (doo-tests 'rems.administration.test-create-catalogue-item
            'rems.administration.test-create-form
@@ -28,4 +29,5 @@
            'rems.flash-message
            'rems.test-fields
            'rems.test-table
-           'rems.test-util)
+           'rems.test-util
+           'rems.text)


### PR DESCRIPTION
- entitlement now ends at the end of the specified day (in UTC)
- only date is rendered for end

fixes #2331

# Definition of Done / Review checklist

## Reviewability
- [x] link to issue

## Documentation
- [ ] update changelog if necessary
  - fix for entry already in changelog, no need

## Testing
- [x] complex logic is unit tested
- [x] valuable features are integration / browser / acceptance tested automatically

## Follow-up
- [x] no critical TODOs left to implement