### PR TITLE
test: faster fill-human

### DIFF
--- a/test/clj/rems/browser_test_util.clj
+++ b/test/clj/rems/browser_test_util.clj
@@ -174,8 +174,8 @@
 ;; Etaoin's fill-human almost works, but very rarely loses characters,
 ;; probably due to the lack of a _minimum_ delay between keypresses.
 ;; This is a reimplementation.
-(def +character-delay+ 0.05)
-(def +max-extra-delay+ 0.2)
+(def +character-delay+ 0.02)
+(def +max-extra-delay+ 0.15)
 (def +typo-probability+ 0.05)
 
 (defn fill-human [q text]

--- a/test/clj/rems/browser_test_util.clj
+++ b/test/clj/rems/browser_test_util.clj
@@ -175,12 +175,12 @@
 ;; probably due to the lack of a _minimum_ delay between keypresses.
 ;; This is a reimplementation.
 (def +character-delay+ 0.02)
-(def +max-extra-delay+ 0.15)
+(def +max-extra-delay+ 0.2)
 (def +typo-probability+ 0.05)
 
 (defn fill-human [q text]
   (doseq [c text]
-    (et/wait (* +max-extra-delay+ (rand)))
+    (et/wait (* +max-extra-delay+ (Math/pow (rand) 5)))
     (when (< (rand) +typo-probability+)
       (et/wait +character-delay+)
       (et/fill (get-driver) q (char (inc (int c))))

--- a/test/clj/rems/browser_test_util.clj
+++ b/test/clj/rems/browser_test_util.clj
@@ -174,7 +174,7 @@
 ;; Etaoin's fill-human almost works, but very rarely loses characters,
 ;; probably due to the lack of a _minimum_ delay between keypresses.
 ;; This is a reimplementation.
-(def +character-delay+ 0.02)
+(def +character-delay+ 0.01)
 (def +max-extra-delay+ 0.2)
 (def +typo-probability+ 0.05)
 


### PR DESCRIPTION
baseline (master):
timings on my machine for `lein kaocha test-browser`: 476s, 496s, 492s
timings on CircleCI for `browser-test`: 10:27, 11:10, 9:58

after first commit:
my machine: 401s, 408s, 402s
CircleCI: 8:45, 8:05, 8:33

after second commit:
my machine: 371s, 395s, 435s
CircleCI: 8:04, 7:57, (timeout while starting driver), 8:11

after third commit:
my machine: 411s, 441s, 445s (weird, it should be faster, I guess my machine has more load now than previously)
CircleCI: 7:57, 7:46, (timeout while starting driver). Run the next day: 11:57, 11:10