### PR TITLE
test: add waits before slurps in browsertests

### DIFF
--- a/test/clj/rems/test_browser.clj
+++ b/test/clj/rems/test_browser.clj
@@ -950,6 +950,7 @@
                         (select-button-by-label "View"))
       (btu/wait-visible {:tag :h1 :fn/text "Resource"})
       (btu/wait-page-loaded)
+      (btu/wait-visible :blacklist)
       (is (= [{}] (slurp-rows :blacklist)))
       (btu/fill-human :blacklist-user "baddie\n")
       (btu/fill-human :blacklist-comment "This is a test.")
@@ -958,6 +959,7 @@
       (btu/wait-visible {:css ".alert-success"})
       (is (str/includes? (btu/get-element-text {:css ".alert-success"}) "Success")))
     (testing "check entry on resource page"
+      (btu/wait-visible :blacklist)
       (is (= [{} ;; TODO remove the header row in slurp-rows
               {"resource" "blacklist-test"
                "user" "Bruce Baddie"
@@ -971,6 +973,7 @@
       (go-to-admin "Blacklist")
       (btu/wait-visible {:tag :h1 :fn/text "Blacklist"})
       (btu/wait-page-loaded)
+      (btu/wait-visible :blacklist)
       (is (= [{}
               {"resource" "blacklist-test"
                "user" "Bruce Baddie"
@@ -985,6 +988,7 @@
                         (select-button-by-label "Remove"))
       (btu/wait-visible {:css ".alert-success"})
       (is (str/includes? (btu/get-element-text {:css ".alert-success"}) "Success"))
+      (btu/wait-visible :blacklist)
       (is (= [{}] (slurp-rows :blacklist))))))
 
 (deftest test-report


### PR DESCRIPTION
# Definition of Done / Review checklist

## Reviewability
- [ ] link to issue
- [ ] note if PR is on top of other PR
- [ ] note if related change in rems-deploy repo
- [ ] consider adding screenshots for ease of review

## API
- [ ] API is documented and shows up in Swagger UI
- [ ] API is backwards compatible or completely new
- [ ] Events are backwards compatible

## Documentation
- [ ] update changelog if necessary
- [ ] add or update docstrings for namespaces and functions
- [ ] components are added to guide page
- [ ] documentation _at least_ for config options (i.e. docs folder)
- [ ] ADR for major architectural decisions or experiments

## Different installations
- [ ] new configuration options added to rems-deploy repository
- [ ] instance specific translations (i.e. LBR kielivara)

## Testing
- [ ] complex logic is unit tested
- [ ] valuable features are integration / browser / acceptance tested automatically

## Accessibility
- [ ] all icons have the aria-label attribute
- [ ] all fields have a label
- [ ] errors are linked to fields with aria-describedby
- [ ] contrast is checked
- [ ] conscious decision about where to move focus after an action

## Follow-up
- [ ] new tasks are created for pending or remaining tasks
- [ ] no critical TODOs left to implement
