### PR TITLE
fix: try a longer timeout for booting driver

### DIFF
--- a/test/clj/rems/browser_test_util.clj
+++ b/test/clj/rems/browser_test_util.clj
@@ -89,15 +89,16 @@
   (when (get-driver) (try (et/quit (get-driver)) (catch Exception e)))
   (swap! test-context
          assoc-some
-         :driver (et/boot-driver browser-id
-                                 {:args ["--lang=en-US"]
-                                  :prefs {:intl.accept_languages "en-US"
-                                          :download.directory_upgrade true
-                                          :safebrowsing.enabled false
-                                          :safebrowsing.disable_download_protection true}
-                                  :download-dir (.getAbsolutePath download-dir)
-                                  :headless (not (or (= "0" (get (System/getenv) "HEADLESS"))
-                                                     (= :development mode)))})
+         :driver (et/with-wait-timeout 60
+                   (et/boot-driver browser-id
+                                   {:args ["--lang=en-US"]
+                                    :prefs {:intl.accept_languages "en-US"
+                                            :download.directory_upgrade true
+                                            :safebrowsing.enabled false
+                                            :safebrowsing.disable_download_protection true}
+                                    :download-dir (.getAbsolutePath download-dir)
+                                    :headless (not (or (= "0" (get (System/getenv) "HEADLESS"))
+                                                       (= :development mode)))}))
          :url url
          :mode mode
          :seed (random-seed))


### PR DESCRIPTION
We have the the CI env sometimes timing out here. Let's try with a
longer timeout to see if it helps. NB: default wait has decreased from
20s to 7s in the 0.3.9.

See also https://github.com/igrishaev/etaoin/issues/338