### PR TITLE
deps: upgrade buddy-sign

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -4,7 +4,7 @@
   :url "https://github.com/CSCfi/rems"
 
   :dependencies [[buddy/buddy-auth "2.1.0"]
-                 [buddy/buddy-sign "3.1.0"]
+                 [buddy/buddy-sign "3.2.0"]
                  [ch.qos.logback/logback-classic "1.2.3"]
                  [clj-commons/secretary "1.2.4"]
                  [clj-http "3.10.2"]


### PR DESCRIPTION
buddy-sign 3.2.0 depends on buddy-core 1.8.0 which fixes
https://github.com/funcool/buddy-core/issues/70