### PR TITLE
fix: use UserId instead of plain s/Str

### DIFF
--- a/src/clj/rems/application/events.clj
+++ b/src/clj/rems/application/events.clj
@@ -43,7 +43,7 @@
   (assoc EventWithComment
          :event/type (s/enum :application.event/review-requested)
          :application/request-id s/Uuid
-         :application/reviewers [s/Str]))
+         :application/reviewers [UserId]))
 (s/defschema CopiedFromEvent
   (assoc EventBase
          :event/type (s/enum :application.event/copied-from)
@@ -77,7 +77,7 @@
   (assoc EventWithComment
          :event/type (s/enum :application.event/decision-requested)
          :application/request-id s/Uuid
-         :application/deciders [s/Str]))
+         :application/deciders [UserId]))
 (s/defschema DeletedEvent
   (assoc EventBase
          :event/type (s/enum :application.event/deleted)))


### PR DESCRIPTION
I noticed that we have two spots in the event schemas where we use `s/Str` though we could use the `UserId` alias. Eventually perhaps we would use the `{:userid xxx}` structure but this is better than nothing.