### PR TITLE
Focus on h1 element when triggered by user-navigation

### DIFF
--- a/src/cljs/rems/spa.cljs
+++ b/src/cljs/rems/spa.cljs
@@ -101,6 +101,7 @@
     :languages [:en]
     :default-language :en
     :translations {}
+    ::grab-focus? true
     :identity {:user nil :roles nil}}))
 
 (rf/reg-event-db
@@ -300,10 +301,11 @@
   [:div.logo [:div.container.img]])
 
 (defn main-content [_page-id _grab-focus?]
-  (let [on-update (fn [this]
+  (let [on-update (fn [& [this :as args]]
                     (let [[_ _page-id grab-focus?] (r/argv this)]
                       (when grab-focus?
-                        (when-let [element (.querySelector js/document "#main-content")]
+                        (when-let [element (or (.querySelector js/document "h1")
+                                               (.querySelector js/document "#main-content"))]
                           (focus/focus element)
                           (rf/dispatch [::focus-grabbed])))))]
     (r/create-class

--- a/src/cljs/rems/spa.cljs
+++ b/src/cljs/rems/spa.cljs
@@ -301,7 +301,7 @@
   [:div.logo [:div.container.img]])
 
 (defn main-content [_page-id _grab-focus?]
-  (let [on-update (fn [& [this :as args]]
+  (let [on-update (fn [this]
                     (let [[_ _page-id grab-focus?] (r/argv this)]
                       (when grab-focus?
                         (when-let [element (or (.querySelector js/document "h1")

--- a/src/cljs/rems/spa.cljs
+++ b/src/cljs/rems/spa.cljs
@@ -101,7 +101,6 @@
     :languages [:en]
     :default-language :en
     :translations {}
-    ::grab-focus? true
     :identity {:user nil :roles nil}}))
 
 (rf/reg-event-db


### PR DESCRIPTION
Partially fixes
https://github.com/CSCfi/rems/issues/2367

This is the basic solution to getting headers to focus when navigating between pages. Falls back to `
#main-container` if it cannot find any headers. Due to the semantic nature of `h1`, there should be only 1 present on the page at any given moment so it should be okay. 

Although I've mostly been out of action for a couple of weeks I'm happy to continue with the next step which is getting focus on first load (due to the lifecycle management of the application, this may need bigger modifications).