### PR TITLE
feat: represent researcher status as string, not keyword

### DIFF
--- a/src/clj/rems/api/schema.clj
+++ b/src/clj/rems/api/schema.clj
@@ -33,7 +33,7 @@
    :email (s/maybe s/Str)
    (s/optional-key :organizations) [OrganizationId]
    (s/optional-key :notification-email) (s/maybe s/Str)
-   (s/optional-key :researcher-status-by) s/Keyword
+   (s/optional-key :researcher-status-by) s/Str
    s/Keyword s/Any})
 
 (s/defschema OrganizationOverview

--- a/src/clj/rems/db/test_data_users.clj
+++ b/src/clj/rems/db/test_data_users.clj
@@ -27,7 +27,7 @@
 
 (def +fake-user-data+
   {"developer" {:eppn "developer" :mail "developer@example.com" :commonName "Developer" :nickname "The Dev"}
-   "alice" {:eppn "alice" :mail "alice@example.com" :commonName "Alice Applicant" :organizations [{:organization/id "default"}] :nickname "In Wonderland" :researcher-status-by :so}
+   "alice" {:eppn "alice" :mail "alice@example.com" :commonName "Alice Applicant" :organizations [{:organization/id "default"}] :nickname "In Wonderland" :researcher-status-by "so"}
    "malice" {:eppn "malice" :mail "malice@example.com" :commonName "Malice Applicant" :twinOf "alice" :other "Attribute Value"}
    "handler" {:eppn "handler" :mail "handler@example.com" :commonName "Hannah Handler"}
    "carl" {:eppn "carl" :mail "carl@example.com" :commonName "Carl Reviewer"}

--- a/src/clj/rems/db/users.clj
+++ b/src/clj/rems/db/users.clj
@@ -15,9 +15,7 @@
           :name (or (:commonName u)
                     (:displayName u))
           :email (:mail u)}
-         (select-keys u [:organizations :notification-email])
-         (when-let [by (:researcher-status-by u)]
-           {:researcher-status-by (keyword by)})
+         (select-keys u [:organizations :notification-email :researcher-status-by])
          (select-keys u (map (comp keyword :attribute) (:oidc-extra-attributes env)))))
 
 (defn- unformat-user

--- a/src/clj/rems/ga4gh.clj
+++ b/src/clj/rems/ga4gh.clj
@@ -102,7 +102,7 @@
 ;; Reading visas
 
 (defn visa->researcher-status-by
-  "Return the :by attribute (as a keyword) of a decoded GA4GH Visa
+  "Return the :by attribute of a decoded GA4GH Visa
   Claim, if the Visa asserts the \"Bona Fide\" researcher status."
   [visa-claim]
   ;; Let's keep this validation non-fatal for now.
@@ -115,7 +115,7 @@
                (#{"so" "system"} (:by visa))
                ;; should we also check this?
                #_(= (:value visa) "https://doi.org/10.1038/s41431-018-0219-y"))
-      (keyword (getx visa :by)))))
+      (getx visa :by))))
 
 (defn passport->researcher-status-by
   "Given an OIDC id token, check the visas in the :ga4gh_passport_v1

--- a/src/cljs/rems/application.cljs
+++ b/src/cljs/rems/application.cljs
@@ -834,7 +834,7 @@
                                        :notification-email "notification@example.com"
                                        :organizations [{:organization/id "Testers"} {:organization/id "Users"}]
                                        :address "Testikatu 1, 00100 Helsinki"
-                                       :researcher-status-by :so}
+                                       :researcher-status-by "so"}
                           :application {:application/id 42
                                         :application/applicant {:userid "developer"}}
                           :accepted-licenses? true}])

--- a/src/cljs/rems/user.cljs
+++ b/src/cljs/rems/user.cljs
@@ -33,7 +33,7 @@
              [info-field (text :t.applicant-info/email) mail {:inline? true}])
            (when-let [organizations (seq (:organizations attributes))]
              [info-field (text :t.applicant-info/organization) (str/join ", " (map organization-name-if-known organizations)) {:inline? true}])
-           (when (#{:so :system} (:researcher-status-by attributes))
+           (when (#{"so" "system"} (:researcher-status-by attributes))
              [info-field (text :t.applicant-info/researcher-status) [readonly-checkbox {:value true}] {:inline? true}])]
           (for [[k v] other-attributes]
             (let [title (or (localized (get-in extra-attributes [(name k) :name]))
@@ -60,7 +60,7 @@
                          :notification-email "notification@example.com"
                          :organizations [{:organization/id "Testers"} {:organization/id "Users"}]
                          :address "Testikatu 1, 00100 Helsinki"
-                         :researcher-status-by :so
+                         :researcher-status-by "so"
                          :nickname "The Dev"}])
    (example "invalid value for researcher status"
             [attributes {:userid "developer@uu.id"


### PR DESCRIPTION
- The current user's identity is communicated to the frontend using
  JSON (setIdentity), which means researcher-status-by was a string.
- Other users' identities are communicated to the frontend using
  transit from our api, which meant researcher-status-by was a keyword.
- Additional logic was needed to keywordify the value, since the user
  attributes are stored in the database as JSON.
- The value is propagated from the "by" attribute of a GA4GH passport,
  which has a string value (again, due to being JSON).

All in all, the path of least resistance seems to be to not keywordify
the attribute.

Fixes #2420

# Definition of Done / Review checklist

## Reviewability
- [x] link to issue

## API
- [ ] API is documented and shows up in Swagger UI
- [ ] API is backwards compatible or completely new
  - backwards compatible with previous release, incompatible with previous master

## Documentation
- [ ] update changelog if necessary
  - changelog line exists for this feature already
- [x] add or update docstrings for namespaces and functions
- [x] components are added to guide page

## Testing
- [ ] complex logic is unit tested
- [ ] valuable features are integration / browser / acceptance tested automatically

## Follow-up
- [x] no critical TODOs left to implement