### PR TITLE
fix: actions with empty comment

### DIFF
--- a/src/cljs/rems/actions/add_licenses.cljs
+++ b/src/cljs/rems/actions/add_licenses.cljs
@@ -23,7 +23,7 @@
    {:db (assoc db
                ::potential-licenses #{}
                ::selected-licenses #{})
-    :dispatch [:rems.actions.components/set-comment action-form-id nil]
+    :dispatch [:rems.actions.components/set-comment action-form-id ""]
     ::fetch-licenses #(rf/dispatch [::set-potential-licenses %])}))
 
 (defn- assoc-all-titles

--- a/src/cljs/rems/actions/approve_reject.cljs
+++ b/src/cljs/rems/actions/approve_reject.cljs
@@ -18,7 +18,7 @@
  ::open-form
  (fn [{:keys [db]} _]
    {:db (assoc db ::entitlement-end (default-end (get-in db [:config :entitlement-default-length-days])))
-    :dispatch-n [[:rems.actions.components/set-comment action-form-id nil]
+    :dispatch-n [[:rems.actions.components/set-comment action-form-id ""]
                  [:rems.actions.components/set-attachments action-form-id []]]}))
 
 (rf/reg-sub ::entitlement-end (fn [db _] (::entitlement-end db)))

--- a/src/cljs/rems/actions/change_resources.cljs
+++ b/src/cljs/rems/actions/change_resources.cljs
@@ -17,7 +17,7 @@
     {:db (assoc db
                 ::initial-resources (into #{} (map :catalogue-item/id initial-resources))
                 ::selected-resources (into #{} (map :catalogue-item/id initial-resources)))
-     :dispatch-n (concat [[:rems.actions.components/set-comment action-form-id nil]]
+     :dispatch-n (concat [[:rems.actions.components/set-comment action-form-id ""]]
                          (when-not (:rems.catalogue/catalogue db)
                            [[:rems.catalogue/full-catalogue]]))})))
 

--- a/src/cljs/rems/actions/close.cljs
+++ b/src/cljs/rems/actions/close.cljs
@@ -8,7 +8,7 @@
 (rf/reg-event-fx
  ::open-form
  (fn [_ _]
-   {:dispatch-n [[:rems.actions.components/set-comment action-form-id nil]
+   {:dispatch-n [[:rems.actions.components/set-comment action-form-id ""]
                  [:rems.actions.components/set-attachments action-form-id []]]}))
 
 (rf/reg-event-fx

--- a/src/cljs/rems/actions/decide.cljs
+++ b/src/cljs/rems/actions/decide.cljs
@@ -8,7 +8,7 @@
 (rf/reg-event-fx
  ::open-form
  (fn [_ _]
-   {:dispatch-n [[:rems.actions.components/set-comment action-form-id nil]
+   {:dispatch-n [[:rems.actions.components/set-comment action-form-id ""]
                  [:rems.actions.components/set-attachments action-form-id []]]}))
 
 (rf/reg-event-fx

--- a/src/cljs/rems/actions/remark.cljs
+++ b/src/cljs/rems/actions/remark.cljs
@@ -9,7 +9,7 @@
 (rf/reg-event-fx
  ::open-form
  (fn [_ _]
-   {:dispatch-n [[:rems.actions.components/set-comment action-form-id nil]
+   {:dispatch-n [[:rems.actions.components/set-comment action-form-id ""]
                  [:rems.actions.components/set-comment-public action-form-id false]
                  [:rems.actions.components/set-attachments action-form-id []]]}))
 
@@ -38,7 +38,7 @@
    [[button-wrapper {:id action-form-id
                      :text (text :t.actions/remark)
                      :class "btn-primary"
-                     :on-click on-send}]]
+                     :on-click on-send}]] ;; TODO disable submit if comment field is empty?
    [:div
     [comment-field {:field-key action-form-id
                     :label (text :t.form/add-remark)

--- a/src/cljs/rems/actions/request_decision.cljs
+++ b/src/cljs/rems/actions/request_decision.cljs
@@ -10,7 +10,7 @@
  (fn [_ _]
    {:dispatch-n [[:rems.actions.components/deciders]
                  [:rems.actions.components/set-users action-form-id nil]
-                 [:rems.actions.components/set-comment action-form-id nil]
+                 [:rems.actions.components/set-comment action-form-id ""]
                  [:rems.actions.components/set-attachments action-form-id []]]}))
 
 (rf/reg-event-fx

--- a/src/cljs/rems/actions/request_review.cljs
+++ b/src/cljs/rems/actions/request_review.cljs
@@ -11,7 +11,7 @@
    [_ _]
    {:dispatch-n [[:rems.actions.components/reviewers]
                  [:rems.actions.components/set-users action-form-id nil]
-                 [:rems.actions.components/set-comment action-form-id nil]
+                 [:rems.actions.components/set-comment action-form-id ""]
                  [:rems.actions.components/set-attachments action-form-id []]]}))
 
 (rf/reg-event-fx

--- a/src/cljs/rems/actions/return_action.cljs
+++ b/src/cljs/rems/actions/return_action.cljs
@@ -8,7 +8,7 @@
 (rf/reg-event-fx
  ::open-form
  (fn [_ _]
-   {:dispatch-n [[:rems.actions.components/set-comment action-form-id nil]
+   {:dispatch-n [[:rems.actions.components/set-comment action-form-id ""]
                  [:rems.actions.components/set-attachments action-form-id []]]}))
 
 (rf/reg-event-fx

--- a/src/cljs/rems/actions/review.cljs
+++ b/src/cljs/rems/actions/review.cljs
@@ -8,7 +8,7 @@
 (rf/reg-event-fx
  ::open-form
  (fn [_ _]
-   {:dispatch-n [[:rems.actions.components/set-comment action-form-id nil]
+   {:dispatch-n [[:rems.actions.components/set-comment action-form-id ""]
                  [:rems.actions.components/set-attachments action-form-id []]]}))
 
 (rf/reg-event-fx
@@ -35,7 +35,7 @@
    [[button-wrapper {:id "review-button"
                      :text (text :t.actions/review)
                      :class "btn-primary"
-                     :on-click on-send}]]
+                     :on-click on-send}]] ;; TODO disable submit if comment field is empty?
    [:<>
     [comment-field {:field-key action-form-id
                     :label (text :t.form/add-comments-not-shown-to-applicant)}]

--- a/src/cljs/rems/actions/revoke.cljs
+++ b/src/cljs/rems/actions/revoke.cljs
@@ -8,7 +8,7 @@
 (rf/reg-event-fx
  ::open-form
  (fn [_ _]
-   {:dispatch-n [[:rems.actions.components/set-comment action-form-id nil]
+   {:dispatch-n [[:rems.actions.components/set-comment action-form-id ""]
                  [:rems.actions.components/set-attachments action-form-id []]]}))
 
 (rf/reg-event-fx


### PR DESCRIPTION
Before #2425 the action comment defaulted to "", which was sent to the
backend if no comment was entered. After, it defaulted to nil, which
violated the API schema and resulted in a HTTP 400. Return to the old
behaviour, but add TODOs for cases where it might make sense to
require a nonempty comment.


# Definition of Done / Review checklist

## Reviewability
- [ ] link to issue

## Testing
- [ ] valuable features are integration / browser / acceptance tested automatically
  - these could have browser tests

## Follow-up
- [x] new tasks are created for pending or remaining tasks
- [x] no critical TODOs left to implement