### PR TITLE
Improve browser tests

### DIFF
--- a/test/clj/rems/browser_test_util.clj
+++ b/test/clj/rems/browser_test_util.clj
@@ -112,11 +112,16 @@
          :url url
          :mode mode
          :seed (random-seed))
-  (enable-downloads! (get-driver))
+  (enable-downloads! (get-driver)))
+
+(defn refresh-driver!
+  "Refreshes an existing driver and cleans up."
+  []
+  (assert (get-driver) "must have initialized driver already!")
   ;; start with a clean slate
   (et/delete-cookies (get-driver)))
 
-(defn fixture-driver
+(defn fixture-init-driver
   "Executes a test running a fresh driver except when in development."
   [f]
   (letfn [(run []
@@ -128,6 +133,12 @@
       (catch SocketException e
         (log/warn e "WebDriver failed to start, retrying...")
         (run)))))
+
+(defn fixture-refresh-driver
+  "Executes a test running with a re-used but clean and refreshed driver."
+  [f]
+  (refresh-driver!)
+  (f))
 
 (defn smoke-test [f]
   (let [response (http/get (str (get-server-url) "js/app.js"))]

--- a/test/clj/rems/browser_test_util.clj
+++ b/test/clj/rems/browser_test_util.clj
@@ -296,6 +296,7 @@
 (def +typo-probability+ 0.05)
 
 (defn fill-human [q text]
+  (wait-visible q)
   (doseq [c text]
     (et/wait (* +max-extra-delay+ (Math/pow (rand) 5)))
     (when (< (rand) +typo-probability+)

--- a/test/clj/rems/test_browser.clj
+++ b/test/clj/rems/test_browser.clj
@@ -29,14 +29,15 @@
 (comment ; convenience for development testing
   (btu/init-driver! :chrome "http://localhost:3000/" :development))
 
-(use-fixtures :each btu/fixture-driver)
+(use-fixtures :each btu/fixture-refresh-driver)
 
 (use-fixtures
   :once
   btu/ensure-empty-directories-fixture
   btu/test-dev-or-standalone-fixture
   btu/smoke-test
-  btu/accessibility-report-fixture)
+  btu/accessibility-report-fixture
+  btu/fixture-init-driver)
 
 ;;; common functionality
 


### PR DESCRIPTION
Trying to improve the speed of running browser tests by reusing the browser instance.

Also try waiting before inputting so that we would not get the lost initial character error.