### PR TITLE
fix: don't allow handlers to edit all organizations

### DIFF
--- a/src/clj/rems/api/services/util.clj
+++ b/src/clj/rems/api/services/util.clj
@@ -5,20 +5,20 @@
             [rems.context :as context]
             [rems.util :refer [getx-user-id]]))
 
-(defn- forbidden-organization? [organization]
-  (let [not-owner? (not (contains? context/*roles* :owner))
+(defn- may-edit-organization? [organization]
+  (let [owner? (contains? context/*roles* :owner)
         organization-owners (set (map :userid (:organization/owners organization)))
-        not-organization-owner? (not (contains? organization-owners (getx-user-id)))]
-    (and not-owner?
-         not-organization-owner?)))
+        organization-owner? (contains? organization-owners (getx-user-id))]
+    (or owner?
+        organization-owner?)))
 
 (defn check-allowed-organization! [organization]
   (assert (:organization/id organization) {:error "invalid organization"
                                            :organization organization})
-  (when (forbidden-organization? (organizations/get-organization-raw organization))
+  (when-not (may-edit-organization? (organizations/get-organization-raw organization))
     (throw-forbidden (str "no access to organization " (pr-str (:organization/id organization))))))
 
-(deftest test-forbidden-organization?
+(deftest test-may-edit-organization?
   (let [org-empty {:organization/id ""}
         org-nobody {:organization/id "organization with no owners" :organization/owners []}
         org-bob {:organization/id "organization owned by bob" :organization/owners [{:userid "bob"}]}
@@ -27,44 +27,44 @@
     (testing "for owner, all organizations are permitted"
       (binding [context/*user* {:eppn "owner"}
                 context/*roles* #{:owner}]
-        (is (not (forbidden-organization? org-empty)))
-        (is (not (forbidden-organization? org-nobody)))
-        (is (not (forbidden-organization? org-bob)))
-        (is (not (forbidden-organization? org-carl)))
-        (is (not (forbidden-organization? org-bob-carl)))))
+        (is (may-edit-organization? org-empty))
+        (is (may-edit-organization? org-nobody))
+        (is (may-edit-organization? org-bob))
+        (is (may-edit-organization? org-carl))
+        (is (may-edit-organization? org-bob-carl))))
 
     (testing "for owner who is also an organization owner, all organizations are permitted"
       (binding [context/*user* {:eppn "bob"}
                 context/*roles* #{:owner}]
-        (is (not (forbidden-organization? org-empty)))
-        (is (not (forbidden-organization? org-nobody)))
-        (is (not (forbidden-organization? org-bob)))
-        (is (not (forbidden-organization? org-carl)))
-        (is (not (forbidden-organization? org-bob-carl)))))
+        (is (may-edit-organization? org-empty))
+        (is (may-edit-organization? org-nobody))
+        (is (may-edit-organization? org-bob))
+        (is (may-edit-organization? org-carl))
+        (is (may-edit-organization? org-bob-carl))))
 
     (testing "for organization owner, only own organizations are permitted"
       (binding [context/*user* {:eppn "bob"}
                 context/*roles* #{}]
-        (is (forbidden-organization? org-empty))
-        (is (forbidden-organization? org-nobody))
-        (is (not (forbidden-organization? org-bob)))
-        (is (forbidden-organization? org-carl))
-        (is (not (forbidden-organization? org-bob-carl))))
+        (is (not (may-edit-organization? org-empty)))
+        (is (not (may-edit-organization? org-nobody)))
+        (is (may-edit-organization? org-bob))
+        (is (not (may-edit-organization? org-carl)))
+        (is (may-edit-organization? org-bob-carl)))
 
       (testing ", even if they are a handler"
         (binding [context/*user* {:eppn "bob"}
                   context/*roles* #{:handler}]
-          (is (forbidden-organization? org-empty))
-          (is (forbidden-organization? org-nobody))
-          (is (not (forbidden-organization? org-bob)))
-          (is (forbidden-organization? org-carl))
-          (is (not (forbidden-organization? org-bob-carl))))))
+          (is (not (may-edit-organization? org-empty)))
+          (is (not (may-edit-organization? org-nobody)))
+          (is (may-edit-organization? org-bob))
+          (is (not (may-edit-organization? org-carl)))
+          (is (may-edit-organization? org-bob-carl)))))
 
     (testing "for other user, no organizations are permitted"
       (binding [context/*user* {:eppn "alice"}
                 context/*roles* #{}]
-        (is (forbidden-organization? org-empty))
-        (is (forbidden-organization? org-nobody))
-        (is (forbidden-organization? org-bob))
-        (is (forbidden-organization? org-carl))
-        (is (forbidden-organization? org-bob-carl))))))
+        (is (not (may-edit-organization? org-empty)))
+        (is (not (may-edit-organization? org-nobody)))
+        (is (not (may-edit-organization? org-bob)))
+        (is (not (may-edit-organization? org-carl)))
+        (is (not (may-edit-organization? org-bob-carl)))))))

--- a/test/clj/rems/api/test_resources.clj
+++ b/test/clj/rems/api/test_resources.clj
@@ -120,7 +120,16 @@
       (testing "archive"
         (is (response-is-forbidden? (api-response :put "/api/resources/archived"
                                                   {:id id :archived true}
-                                                  api-key "organization-owner2")))))))
+                                                  api-key "organization-owner2")))))
+    (testing "handler"
+      (testing "disable"
+        (is (response-is-forbidden? (api-response :put "/api/resources/enabled"
+                                                  {:id id :enabled false}
+                                                  api-key "handler"))))
+      (testing "archive"
+        (is (response-is-forbidden? (api-response :put "/api/resources/archived"
+                                                  {:id id :archived true}
+                                                  api-key "handler")))))))
 
 (deftest resources-api-filtering-test
   (let [api-key "42"


### PR DESCRIPTION
This leftover case in forbidden-organization? caused a bug where a
handler that was the owner of one organization could edit items in any
organization.

The special case for handlers was needed in the old design
(see PR #1959) that only allowed organization owners to see items in
their own organization. A new design (issue #1893, PR #2034, ADR 009)
allows everyone (handlers, owners, organization owners) to see
items in all organizations.

Fixes #2441.

# Definition of Done / Review checklist

## Reviewability
- [x] link to issue

## Documentation
- [x] update changelog if necessary
  - entry already exists

## Testing
- [x] complex logic is unit tested
- [ ] valuable features are integration / browser / acceptance tested automatically
  - couldn't figure out a nice way to regression test this, unless we
    want to add a very specific test

## Follow-up
- [x] no critical TODOs left to implement