### PR TITLE
fix: first click to invite reviewr/decider action didn't show form

### DIFF
--- a/src/cljs/rems/actions/invite_decider_reviewer.cljs
+++ b/src/cljs/rems/actions/invite_decider_reviewer.cljs
@@ -120,10 +120,10 @@
         email @(rf/subscribe [:rems.actions.components/email reviewer-form-id])
         comment @(rf/subscribe [:rems.actions.components/comment reviewer-form-id])
         attachments @(rf/subscribe [:rems.actions.components/attachments reviewer-form-id])]
-     [invite-reviewer-view {:application-id application-id
-                            :disabled (empty? email)
-                            :on-send #(rf/dispatch [::send-invite-reviewer {:application-id application-id
-                                                                            :reviewer {:name name :email email}
-                                                                            :comment comment
-                                                                            :attachments attachments
-                                                                            :on-finished on-finished}])}]))
+    [invite-reviewer-view {:application-id application-id
+                           :disabled (empty? email)
+                           :on-send #(rf/dispatch [::send-invite-reviewer {:application-id application-id
+                                                                           :reviewer {:name name :email email}
+                                                                           :comment comment
+                                                                           :attachments attachments
+                                                                           :on-finished on-finished}])}]))

--- a/src/cljs/rems/actions/invite_decider_reviewer.cljs
+++ b/src/cljs/rems/actions/invite_decider_reviewer.cljs
@@ -6,13 +6,10 @@
             [rems.text :refer [text]]))
 
 
-(def ^:private field-key "invite-decider-reviewer")
-
 (rf/reg-event-fx
  ::open-form
- (fn [{:keys [db]} [_ role]]
-   {:db (assoc db ::role role)
-    :dispatch-n [[:rems.actions.components/set-name field-key ""]
+ (fn [{:keys [db]} [_ field-key]]
+   {:dispatch-n [[:rems.actions.components/set-name field-key ""]
                  [:rems.actions.components/set-email field-key ""]
                  [:rems.actions.components/set-comment field-key ""]
                  [:rems.actions.components/set-attachments field-key []]]}))
@@ -62,56 +59,71 @@
 (defn invite-decider-action-link []
   [action-link {:id decider-form-id
                 :text (text :t.actions/request-decision-dropdown-via-email)
-                :on-click #(rf/dispatch [::open-form :decider])}])
+                :on-click #(rf/dispatch [::open-form decider-form-id])}])
 
 (defn invite-reviewer-action-link []
   [action-link {:id reviewer-form-id
                 :text (text :t.actions/request-review-dropdown-via-email)
-                :on-click #(rf/dispatch [::open-form :reviewer])}])
+                :on-click #(rf/dispatch [::open-form reviewer-form-id])}])
 
-(defn invite-decider-reviewer-view
-  [{:keys [role application-id on-send disabled]}]
+(defn invite-decider-view
+  [{:keys [application-id on-send disabled]}]
   [action-form-view
-   (if (= :decider role)
-     decider-form-id
-     reviewer-form-id)
-   (if (= :decider role)
-     (text :t.actions/request-decision-via-email)
-     (text :t.actions/request-review-via-email))
-   [[button-wrapper {:id "invite-decider-reviewer"
-                     :text (if (= :decider role)
-                             (text :t.actions/request-decision)
-                             (text :t.actions/request-review))
+   decider-form-id
+   (text :t.actions/request-decision-via-email)
+   [[button-wrapper {:id "invite-decider"
+                     :text (text :t.actions/request-decision)
                      :class "btn-primary"
                      :on-click on-send
                      :disabled disabled}]]
    [:<>
-    [name-field {:field-key field-key}]
-    [email-field {:field-key field-key}]
-    [comment-field {:field-key field-key
+    [name-field {:field-key decider-form-id}]
+    [email-field {:field-key decider-form-id}]
+    [comment-field {:field-key decider-form-id
                     :label (text :t.form/add-comments-not-shown-to-applicant)}]
-    [action-attachment {:field-key field-key
+    [action-attachment {:field-key decider-form-id
                         :application-id application-id}]]])
 
-(defn invite-decider-reviewer-form [application-id on-finished]
-  (let [name @(rf/subscribe [:rems.actions.components/name field-key])
-        email @(rf/subscribe [:rems.actions.components/email field-key])
-        comment @(rf/subscribe [:rems.actions.components/comment field-key])
-        attachments @(rf/subscribe [:rems.actions.components/attachments field-key])]
-    [:<>
-     [invite-decider-reviewer-view {:application-id application-id
-                                    :role :decider
-                                    :disabled (empty? email)
-                                    :on-send #(rf/dispatch [::send-invite-decider {:application-id application-id
-                                                                                   :decider {:name name :email email}
-                                                                                   :comment comment
-                                                                                   :attachments attachments
-                                                                                   :on-finished on-finished}])}]
-     [invite-decider-reviewer-view {:application-id application-id
-                                    :role :reviewer
-                                    :disabled (empty? email)
-                                    :on-send #(rf/dispatch [::send-invite-reviewer {:application-id application-id
-                                                                                    :reviewer {:name name :email email}
-                                                                                    :comment comment
-                                                                                    :attachments attachments
-                                                                                    :on-finished on-finished}])}]]))
+(defn invite-reviewer-view
+  [{:keys [application-id on-send disabled]}]
+  [action-form-view
+   reviewer-form-id
+   (text :t.actions/request-review-via-email)
+   [[button-wrapper {:id "invite-reviewer"
+                     :text (text :t.actions/request-review)
+                     :class "btn-primary"
+                     :on-click on-send
+                     :disabled disabled}]]
+   [:<>
+    [name-field {:field-key reviewer-form-id}]
+    [email-field {:field-key reviewer-form-id}]
+    [comment-field {:field-key reviewer-form-id
+                    :label (text :t.form/add-comments-not-shown-to-applicant)}]
+    [action-attachment {:field-key reviewer-form-id
+                        :application-id application-id}]]])
+
+(defn invite-decider-form [application-id on-finished]
+  (let [name @(rf/subscribe [:rems.actions.components/name decider-form-id])
+        email @(rf/subscribe [:rems.actions.components/email decider-form-id])
+        comment @(rf/subscribe [:rems.actions.components/comment decider-form-id])
+        attachments @(rf/subscribe [:rems.actions.components/attachments decider-form-id])]
+    [invite-decider-view {:application-id application-id
+                          :disabled (empty? email)
+                          :on-send #(rf/dispatch [::send-invite-decider {:application-id application-id
+                                                                         :decider {:name name :email email}
+                                                                         :comment comment
+                                                                         :attachments attachments
+                                                                         :on-finished on-finished}])}]))
+
+(defn invite-reviewer-form [application-id on-finished]
+  (let [name @(rf/subscribe [:rems.actions.components/name reviewer-form-id])
+        email @(rf/subscribe [:rems.actions.components/email reviewer-form-id])
+        comment @(rf/subscribe [:rems.actions.components/comment reviewer-form-id])
+        attachments @(rf/subscribe [:rems.actions.components/attachments reviewer-form-id])]
+     [invite-reviewer-view {:application-id application-id
+                            :disabled (empty? email)
+                            :on-send #(rf/dispatch [::send-invite-reviewer {:application-id application-id
+                                                                            :reviewer {:name name :email email}
+                                                                            :comment comment
+                                                                            :attachments attachments
+                                                                            :on-finished on-finished}])}]))

--- a/src/cljs/rems/actions/invite_decider_reviewer.cljs
+++ b/src/cljs/rems/actions/invite_decider_reviewer.cljs
@@ -72,16 +72,16 @@
 (defn invite-decider-reviewer-view
   [{:keys [role application-id on-send disabled]}]
   [action-form-view
-   (case role
-     :decider decider-form-id
-     :reviewer reviewer-form-id)
-   (case role
-     :decider (text :t.actions/request-decision-via-email)
-     :reviewer (text :t.actions/request-review-via-email))
+   (if (= :decider role)
+     decider-form-id
+     reviewer-form-id)
+   (if (= :decider role)
+     (text :t.actions/request-decision-via-email)
+     (text :t.actions/request-review-via-email))
    [[button-wrapper {:id "invite-decider-reviewer"
-                     :text (case role
-                             :decider (text :t.actions/request-decision)
-                             :reviewer (text :t.actions/request-review))
+                     :text (if (= :decider role)
+                             (text :t.actions/request-decision)
+                             (text :t.actions/request-review))
                      :class "btn-primary"
                      :on-click on-send
                      :disabled disabled}]]
@@ -99,18 +99,17 @@
         email @(rf/subscribe [:rems.actions.components/email field-key])
         comment @(rf/subscribe [:rems.actions.components/comment field-key])
         attachments @(rf/subscribe [:rems.actions.components/attachments field-key])]
-    (when role
-      [invite-decider-reviewer-view {:application-id application-id
-                                     :role role
-                                     :disabled (empty? email)
-                                     :on-send #(rf/dispatch (case role
-                                                              :decider [::send-invite-decider {:application-id application-id
-                                                                                               :decider {:name name :email email}
+    [invite-decider-reviewer-view {:application-id application-id
+                                   :role role
+                                   :disabled (empty? email)
+                                   :on-send #(rf/dispatch (case role
+                                                            :decider [::send-invite-decider {:application-id application-id
+                                                                                             :decider {:name name :email email}
+                                                                                             :comment comment
+                                                                                             :attachments attachments
+                                                                                             :on-finished on-finished}]
+                                                            :reviewer [::send-invite-reviewer {:application-id application-id
+                                                                                               :reviewer {:name name :email email}
                                                                                                :comment comment
                                                                                                :attachments attachments
-                                                                                               :on-finished on-finished}]
-                                                              :reviewer [::send-invite-reviewer {:application-id application-id
-                                                                                                 :reviewer {:name name :email email}
-                                                                                                 :comment comment
-                                                                                                 :attachments attachments
-                                                                                                 :on-finished on-finished}]))}])))
+                                                                                               :on-finished on-finished}]))}]))

--- a/src/cljs/rems/actions/invite_decider_reviewer.cljs
+++ b/src/cljs/rems/actions/invite_decider_reviewer.cljs
@@ -94,22 +94,24 @@
                         :application-id application-id}]]])
 
 (defn invite-decider-reviewer-form [application-id on-finished]
-  (let [role @(rf/subscribe [::role])
-        name @(rf/subscribe [:rems.actions.components/name field-key])
+  (let [name @(rf/subscribe [:rems.actions.components/name field-key])
         email @(rf/subscribe [:rems.actions.components/email field-key])
         comment @(rf/subscribe [:rems.actions.components/comment field-key])
         attachments @(rf/subscribe [:rems.actions.components/attachments field-key])]
-    [invite-decider-reviewer-view {:application-id application-id
-                                   :role role
-                                   :disabled (empty? email)
-                                   :on-send #(rf/dispatch (case role
-                                                            :decider [::send-invite-decider {:application-id application-id
-                                                                                             :decider {:name name :email email}
-                                                                                             :comment comment
-                                                                                             :attachments attachments
-                                                                                             :on-finished on-finished}]
-                                                            :reviewer [::send-invite-reviewer {:application-id application-id
-                                                                                               :reviewer {:name name :email email}
-                                                                                               :comment comment
-                                                                                               :attachments attachments
-                                                                                               :on-finished on-finished}]))}]))
+    [:<>
+     [invite-decider-reviewer-view {:application-id application-id
+                                    :role :decider
+                                    :disabled (empty? email)
+                                    :on-send #(rf/dispatch [::send-invite-decider {:application-id application-id
+                                                                                   :decider {:name name :email email}
+                                                                                   :comment comment
+                                                                                   :attachments attachments
+                                                                                   :on-finished on-finished}])}]
+     [invite-decider-reviewer-view {:application-id application-id
+                                    :role :reviewer
+                                    :disabled (empty? email)
+                                    :on-send #(rf/dispatch [::send-invite-reviewer {:application-id application-id
+                                                                                    :reviewer {:name name :email email}
+                                                                                    :comment comment
+                                                                                    :attachments attachments
+                                                                                    :on-finished on-finished}])}]]))

--- a/src/cljs/rems/application.cljs
+++ b/src/cljs/rems/application.cljs
@@ -11,7 +11,7 @@
             [rems.actions.close :refer [close-action-button close-form]]
             [rems.actions.decide :refer [decide-action-button decide-form]]
             [rems.actions.delete :refer [delete-action-button delete-form]]
-            [rems.actions.invite-decider-reviewer :refer [invite-decider-action-link invite-reviewer-action-link invite-decider-reviewer-form]]
+            [rems.actions.invite-decider-reviewer :refer [invite-decider-action-link invite-reviewer-action-link invite-decider-form invite-reviewer-form]]
             [rems.actions.invite-member :refer [invite-member-action-button invite-member-form]]
             [rems.actions.remark :refer [remark-action-button remark-form]]
             [rems.actions.remove-member :refer [remove-member-action-button remove-member-form]]
@@ -723,7 +723,8 @@
         forms [[:div#actions-forms.mt-3
                 [request-review-form app-id reload]
                 [request-decision-form app-id reload]
-                [invite-decider-reviewer-form app-id reload]
+                [invite-decider-form app-id reload]
+                [invite-reviewer-form app-id reload]
                 [review-form app-id reload]
                 [remark-form app-id reload]
                 [close-form app-id show-comment-field? reload]


### PR DESCRIPTION
Since the component only gets populated once role is set, there was
nothing to uncollapse.

Follow-up to #2040

# Definition of Done / Review checklist

## Reviewability
- [x] link to issue

## Testing
- [ ] valuable features are integration / browser / acceptance tested automatically