### PR TITLE
Edit catalogue item organization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ Changes since v2.13
 - Fix accessibility problems with aria-required attribute placement and increase default link contrast (#2431)
 - Small navbar is now properly closed after a link is clicked (#1194)
 - Fixed an issue where changing field type to label after entering field description crashes form editor (#2399)
+- Catalogue item organization can be edited (#2333)
 
 ### Additions
 - All fields can have an info text, shown if the small icon is clicked. (#1863)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ Changes since v2.13
 - Small navbar is now properly closed after a link is clicked (#1194)
 - Fixed an issue where changing field type to label after entering field description crashes form editor (#2399)
 - Catalogue item organization can be edited (#2333)
+- Hide organization creation button from non-owners who don't have the right to create organizations
 
 ### Additions
 - All fields can have an info text, shown if the small icon is clicked. (#1863)

--- a/resources/sql/queries.sql
+++ b/resources/sql/queries.sql
@@ -60,6 +60,11 @@ UPDATE catalogue_item
 SET (endt) = (:end)
 WHERE id = :id;
 
+-- :name set-catalogue-item-organization! :!
+UPDATE catalogue_item
+SET organization = :organization
+WHERE id = :id;
+
 -- :name create-catalogue-item! :insert
 -- :doc Create a single catalogue item
 INSERT INTO catalogue_item

--- a/src/clj/rems/api/catalogue_items.clj
+++ b/src/clj/rems/api/catalogue_items.clj
@@ -39,6 +39,7 @@
 
 (s/defschema EditCatalogueItemCommand
   {:id s/Int
+   (s/optional-key :organization) OrganizationId
    :localizations WriteCatalogueItemLocalizations})
 
 (s/defschema CreateCatalogueItemResponse

--- a/src/clj/rems/api/services/catalogue.clj
+++ b/src/clj/rems/api/services/catalogue.clj
@@ -46,8 +46,12 @@
       :organization
       util/check-allowed-organization!))
 
-(defn edit-catalogue-item! [{:keys [id localizations]}]
+(defn edit-catalogue-item! [{:keys [id localizations organization]}]
   (check-allowed-to-edit! id)
+  (when (:organization/id organization)
+    (util/check-allowed-organization! organization)
+    (db/set-catalogue-item-organization! {:id id
+                                          :organization (:organization/id organization)}))
   (doseq [[langcode localization] localizations]
     (db/upsert-catalogue-item-localization!
      (merge {:id id

--- a/src/cljs/rems/administration/create_catalogue_item.cljs
+++ b/src/cljs/rems/administration/create_catalogue_item.cljs
@@ -98,6 +98,7 @@
         description [text :t.administration/edit-catalogue-item]]
     (put! "/api/catalogue-items/edit"
           {:params {:id id
+                    :organization (:organization request)
                     :localizations (:localizations request)}
            :handler (flash-message/default-success-handler
                      :top

--- a/src/cljs/rems/administration/organizations.cljs
+++ b/src/cljs/rems/administration/organizations.cljs
@@ -121,7 +121,8 @@
         (if @(rf/subscribe [::loading?])
           [[spinner/big]]
           [[roles/show-when roles/+admin-write-roles+ ;; TODO doesn't match API roles exactly
-            [to-create-organization]
+            [roles/show-when #{:owner}
+              [to-create-organization]]
             [status-flags/display-archived-toggle #(rf/dispatch [::fetch-organizations])]
             [status-flags/disabled-and-archived-explanation]]
            [organizations-list]])))

--- a/src/cljs/rems/administration/organizations.cljs
+++ b/src/cljs/rems/administration/organizations.cljs
@@ -122,7 +122,7 @@
           [[spinner/big]]
           [[roles/show-when roles/+admin-write-roles+ ;; TODO doesn't match API roles exactly
             [roles/show-when #{:owner}
-              [to-create-organization]]
+             [to-create-organization]]
             [status-flags/display-archived-toggle #(rf/dispatch [::fetch-organizations])]
             [status-flags/disabled-and-archived-explanation]]
            [organizations-list]])))


### PR DESCRIPTION
Support for catalogue item organization changing in the editor for #2333.

Also hides the create organization button for non-owners.

# Definition of Done / Review checklist

## Reviewability
- [x] link to issue

## API
- [x] API is backwards compatible or completely new

## Documentation
- [x] update changelog if necessary

## Testing
- [x] valuable features are integration / browser / acceptance tested automatically

## Follow-up
- [x] no critical TODOs left to implement
