### PR TITLE
Fix form editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ have notable changes.
 ### Changes
 
 ### Fixes
+- Fixed small issues in the form editor regarding validating empty values and field description (#2399)
 
 ### Additions
 

--- a/src/cljc/rems/common/form.cljc
+++ b/src/cljc/rems/common/form.cljc
@@ -24,7 +24,7 @@
   (not (contains? #{:label :header} (:field/type field))))
 
 (defn supports-info-text? [field]
-  (not (contains? #{:label} (:field/type field))))
+  (not (contains? #{:label :header} (:field/type field))))
 
 (defn supports-visibility? [field]
   true) ; at the moment all field types

--- a/src/cljs/rems/administration/create_form.cljs
+++ b/src/cljs/rems/administration/create_form.cljs
@@ -131,8 +131,10 @@
   (get-in field [:field/title lang]))
 
 (defn build-localized-string [lstr languages]
-  (into {} (for [language languages]
-             [language (trim-when-string (get lstr language ""))])))
+  (let [v (into {} (for [language languages]
+                     [language (trim-when-string (get lstr language ""))]))]
+    (when-not (every? str/blank? (vals v))
+      v)))
 
 (defn- build-request-field [field languages]
   (merge {:field/id (:field/id field)
@@ -142,9 +144,11 @@
                             (boolean (:field/optional field))
                             false)}
          (when (common-form/supports-info-text? field)
-           {:field/info-text (build-localized-string (:field/info-text field) languages)})
+           (when-let [v (build-localized-string (:field/info-text field) languages)]
+             {:field/info-text v}))
          (when (common-form/supports-placeholder? field)
-           {:field/placeholder (build-localized-string (:field/placeholder field) languages)})
+           (when-let [v (build-localized-string (:field/placeholder field) languages)]
+             {:field/placeholder v}))
          (when (common-form/supports-max-length? field)
            {:field/max-length (parse-int (:field/max-length field))})
          (when (common-form/supports-options? field)

--- a/test/clj/rems/test_browser.clj
+++ b/test/clj/rems/test_browser.clj
@@ -1147,8 +1147,7 @@
         (is (= {:form/id form-id
                 :organization {:organization/id "nbn" :organization/name {:fi "NBN" :en "NBN" :sv "NBN"} :organization/short-name {:fi "NBN" :en "NBN" :sv "NBN"}}
                 :form/title "Form editor test"
-                :form/fields [{:field/placeholder {:fi "" :en "" :sv ""}
-                               :field/title {:fi "Description (FI)" :en "Description (EN)" :sv "Description (SV)"}
+                :form/fields [{:field/title {:fi "Description (FI)" :en "Description (EN)" :sv "Description (SV)"}
                                :field/info-text {:en "Info text (EN)", :fi "Info text (FI)", :sv "Info text (SV)"}
                                :field/type "description"
                                :field/id "fld3"

--- a/test/clj/rems/test_browser.clj
+++ b/test/clj/rems/test_browser.clj
@@ -1031,9 +1031,9 @@
       (btu/fill-human :fields-0-placeholder-en "Placeholder (EN)")
       (btu/fill-human :fields-0-placeholder-fi "Placeholder (FI)")
       (btu/fill-human :fields-0-placeholder-sv "Placeholder (SV)")
-      (btu/fill-human :fields-0-info-text-en "Info text (EN)")
-      (btu/fill-human :fields-0-info-text-fi "Info text (FI)")
-      (btu/fill-human :fields-0-info-text-sv "Info text (SV)")
+      (btu/fill-human :fields-0-info-text-en "") ; should not get passed as is blank
+      (btu/fill-human :fields-0-info-text-fi " ")
+      (btu/fill-human :fields-0-info-text-sv "")
       (btu/scroll-and-click :fields-0-type-texta)
       (btu/scroll-and-click :fields-0-optional)
       (btu/fill-human :fields-0-max-length "127")
@@ -1155,7 +1155,6 @@
                                :field/optional false}
                               {:field/placeholder {:fi "Placeholder (FI)" :en "Placeholder (EN)" :sv "Placeholder (SV)"}
                                :field/title {:fi "Text area (FI)" :en "Text area (EN)" :sv "Text area (SV)"}
-                               :field/info-text {:en "Info text (EN)", :fi "Info text (FI)", :sv "Info text (SV)"}
                                :field/type "texta"
                                :field/id "fld1"
                                :field/max-length 127

--- a/test/cljs/rems/administration/test_create_form.cljs
+++ b/test/cljs/rems/administration/test_create_form.cljs
@@ -192,12 +192,10 @@
 
              (mapv #(build-request-field % languages) fields)))
 
-      (testing "empty info texts should be passed on"
+      (testing "empty info texts should be passed on except when all empty"
         (is (= [{:field/id "fld1"
                  :field/title {:en "en title"
                                :fi "fi title"}
-                 :field/info-text {:en ""
-                                   :fi ""}
                  :field/optional true
                  :field/type :text
                  :field/max-length 12
@@ -258,8 +256,6 @@
               :form/fields [{:field/id "fld1"
                              :field/title {:en "en title"
                                            :fi "fi title"}
-                             :field/info-text {:en ""
-                                               :fi ""}
                              :field/optional true
                              :field/type :text
                              :field/max-length 12
@@ -307,13 +303,13 @@
                            [:form/fields 0 :field/optional]))))
 
     (testing "placeholder is optional"
-      (is (= {:en "" :fi ""}
-             (getx-in (build-request (assoc-in form [:form/fields 0 :field/placeholder] nil) languages)
-                      [:form/fields 0 :field/placeholder])
-             (getx-in (build-request (assoc-in form [:form/fields 0 :field/placeholder] {:en ""}) languages)
-                      [:form/fields 0 :field/placeholder])
-             (getx-in (build-request (assoc-in form [:form/fields 0 :field/placeholder] {:en "" :fi ""}) languages)
-                      [:form/fields 0 :field/placeholder]))))
+      (is (= nil
+             (get-in (build-request (assoc-in form [:form/fields 0 :field/placeholder] nil) languages)
+                     [:form/fields 0 :field/placeholder])
+             (get-in (build-request (assoc-in form [:form/fields 0 :field/placeholder] {:en ""}) languages)
+                     [:form/fields 0 :field/placeholder])
+             (get-in (build-request (assoc-in form [:form/fields 0 :field/placeholder] {:en "" :fi ""}) languages)
+                     [:form/fields 0 :field/placeholder]))))
 
     (testing "max length is optional"
       (is (nil? (getx-in (build-request (assoc-in form [:form/fields 0 :field/max-length] "") languages)
@@ -443,8 +439,11 @@
     (testing "localizations are copied as-is"
       (is (= {:en "x", :fi "y"}
              (build-localized-string {:en "x", :fi "y"} languages))))
-    (testing "missing localizations default to empty string"
-      (is (= {:en "", :fi ""}
+    (testing "missing localization defaults to an empty string"
+      (is (= {:en "x", :fi ""}
+             (build-localized-string {:en "x"} languages))))
+    (testing "missing all localizations is nil"
+      (is (= nil
              (build-localized-string {} languages))))
     (testing "additional languages are excluded"
       (is (= {:en "x", :fi "y"}


### PR DESCRIPTION
Fixes #2399.

I wanted to make the placeholder behave the same as info-text so that nothing is sent to back-end if only blank strings are given. I guess this should not break anything as our tests covered this :shrug:

## Reviewability
- [x] Link to issue

## Documentation
- [x] Update changelog if necessary

## Testing
- [x] Complex logic is unit tested
