### PR TITLE
fix: hide {revierwer,decider}-{invited,joined} events from applicant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ have notable changes.
 ### Fixes
 - Fixed small issues in the form editor regarding validating empty values and field description (#2399)
 - Reading of `:oidc-domain` config option was broken in v2.14, now fixed. (#2489)
+- Hide decider/reviewer invitation events from applicant.
 
 ### Additions
 

--- a/src/clj/rems/application/model.clj
+++ b/src/clj/rems/application/model.clj
@@ -596,7 +596,11 @@
 
 (def ^:private sensitive-events #{:application.event/review-requested
                                   :application.event/reviewed
+                                  :application.event/reviewer-invited
+                                  :application.event/reviewer-joined
                                   :application.event/decided
+                                  :application.event/decider-invited
+                                  :application.event/decider-joined
                                   :application.event/decision-requested})
 (deftest test-sensitive-events
   (let [public-events #{:application.event/approved
@@ -604,8 +608,6 @@
                         :application.event/copied-from
                         :application.event/copied-to
                         :application.event/created
-                        :application.event/decider-invited
-                        :application.event/decider-joined
                         :application.event/deleted
                         :application.event/draft-saved
                         :application.event/external-id-assigned
@@ -620,8 +622,6 @@
                         :application.event/remarked
                         :application.event/resources-changed
                         :application.event/returned
-                        :application.event/reviewer-invited
-                        :application.event/reviewer-joined
                         :application.event/revoked
                         :application.event/submitted}]
     (is (= #{}

--- a/src/clj/rems/application/model.clj
+++ b/src/clj/rems/application/model.clj
@@ -1,5 +1,6 @@
 (ns rems.application.model
-  (:require [clojure.test :refer [deftest is testing]]
+  (:require [clojure.set :as set]
+            [clojure.test :refer [deftest is testing]]
             [com.rpl.specter :refer [ALL select transform]]
             [medley.core :refer [find-first map-vals update-existing]]
             [rems.application.events :as events]
@@ -593,12 +594,46 @@
 
 ;;;; Authorization
 
+(def ^:private sensitive-events #{:application.event/review-requested
+                                  :application.event/reviewed
+                                  :application.event/decided
+                                  :application.event/decision-requested})
+(deftest test-sensitive-events
+  (let [public-events #{:application.event/approved
+                        :application.event/closed
+                        :application.event/copied-from
+                        :application.event/copied-to
+                        :application.event/created
+                        :application.event/decider-invited
+                        :application.event/decider-joined
+                        :application.event/deleted
+                        :application.event/draft-saved
+                        :application.event/external-id-assigned
+                        :application.event/licenses-accepted
+                        :application.event/licenses-added
+                        :application.event/member-added
+                        :application.event/member-invited
+                        :application.event/member-joined
+                        :application.event/member-removed
+                        :application.event/member-uninvited
+                        :application.event/rejected
+                        :application.event/remarked
+                        :application.event/resources-changed
+                        :application.event/returned
+                        :application.event/reviewer-invited
+                        :application.event/reviewer-joined
+                        :application.event/revoked
+                        :application.event/submitted}]
+    (is (= #{}
+           (set/intersection sensitive-events public-events)))
+    (is (= #{}
+           (set/difference (set events/event-types)
+                           (set/union public-events sensitive-events)))
+        "seems like a new event has been added; is public or sensitive?")))
+
 (defn- hide-sensitive-events [events]
   (->> events
-       (remove (comp #{:application.event/review-requested
-                       :application.event/reviewed
-                       :application.event/decided
-                       :application.event/decision-requested}
+       (remove (comp sensitive-events
                      :event/type))
        (remove #(and (= :application.event/remarked
                         (:event/type %))


### PR DESCRIPTION
fixes #2485, related to #2040

# Checklist for author

Remove items that aren't applicable, check items that are done.

## Reviewability
- [x] Link to issue

## Backwards compatibility
- [x] API is backwards compatible or completely new
- [x] Events are backwards compatible _or_ have migrations

## Documentation
- [x] Update changelog if necessary

## Testing
- [x] Complex logic is unit tested