### PR TITLE
Scrollable actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ have notable changes.
 Changes since v2.14.1
 
 ### Changes
+- The actions area has been adjusted to work better on small screens. (#2501)
 
 ### Fixes
 

--- a/src/clj/rems/css/styles.clj
+++ b/src/clj/rems/css/styles.clj
@@ -147,7 +147,7 @@
 (defn- generate-actions-float-menu
   "The #actions floating menu can be too long for some screens. There is no clean solution for this in pure CSS
   and to avoid yet another random JS-library we make the element scrollable with a dynamic max-height. This can
-  break if the 150px space is not enough anymore but works for now.
+  break if the 105px space is not enough anymore but works for now.
 
   We also do not want these styles to affect the mobile layout (i.e. more narrow than 992) where the actions
   is at the bottom of everything and has any height available."
@@ -163,7 +163,7 @@
    (stylesheet/at-media {:min-width (u/px 992)}
                         [:#actions {:overflow-x :hidden
                                     :overflow-y :auto
-                                    :max-height "calc(100vh - 150px)"}])))
+                                    :max-height "calc(100vh - 105px)"}])))
 
 (defn- button-navbar-font-weight []
   ;; Default font-weight to 700 so the text is considered

--- a/src/clj/rems/css/styles.clj
+++ b/src/clj/rems/css/styles.clj
@@ -144,6 +144,27 @@
                    :border-color (get-theme-attribute :phase-bgcolor-completed "#ccc")
                    :color (get-theme-attribute :phase-color-completed :phase-color)}]]])
 
+(defn- generate-actions-float-sizes
+  "The #actions floating menu can be too long for some screens. There is no clean solution for this in pure CSS
+  and to avoid yet another random JS-library we make the element scrollable on certain sizes.
+
+  We also do not want these styles to affect the mobile layout (i.e. more narrow than 992) where the actions
+  is at the bottom of everything and has any height available."
+  []
+  (list
+   (stylesheet/at-media {:min-width (u/px 992)
+                         :max-height (u/px 1080)}
+                        [:#actions ; make buttons here smaller on small screens
+                         [:.btn {:font-size "0.875rem" ; duplicates bootstrap style btn-sm
+                                 :padding "0.25rem 0.5rem"
+                                 :line-height 1.5
+                                 :border-radius "0.2rem"}]])
+   (for [height (range 1080 500 -100)]
+     (stylesheet/at-media {:min-width (u/px 992)
+                           :max-height (u/px height)}
+                          [:#actions {:overflow-y :auto
+                                      :max-height (u/px (- height 200))}]))))
+
 (defn- button-navbar-font-weight []
   ;; Default font-weight to 700 so the text is considered
   ;; 'large text' and thus requires smaller contrast ratio for
@@ -819,6 +840,7 @@
      {:color "#555"})]
 
    (generate-phase-styles)
+   (generate-actions-float-sizes)
    [(s/descendant :.document :h3) {:margin-top (u/rem 4)}]
 
    ;; print styling

--- a/src/clj/rems/css/styles.clj
+++ b/src/clj/rems/css/styles.clj
@@ -144,7 +144,7 @@
                    :border-color (get-theme-attribute :phase-bgcolor-completed "#ccc")
                    :color (get-theme-attribute :phase-color-completed :phase-color)}]]])
 
-(defn- generate-actions-float-sizes
+(defn- generate-actions-float-menu
   "The #actions floating menu can be too long for some screens. There is no clean solution for this in pure CSS
   and to avoid yet another random JS-library we make the element scrollable on certain sizes.
 
@@ -159,11 +159,10 @@
                                  :padding "0.25rem 0.5rem"
                                  :line-height 1.5
                                  :border-radius "0.2rem"}]])
-   (for [height (range 1080 500 -100)]
-     (stylesheet/at-media {:min-width (u/px 992)
-                           :max-height (u/px height)}
-                          [:#actions {:overflow-y :auto
-                                      :max-height (u/px (- height 200))}]))))
+   (stylesheet/at-media {:min-width (u/px 992)
+                         :max-height (u/px 1080)}
+                        [:#actions {:overflow-y :auto
+                                    :max-height "calc(100vh - 150px)"}])))
 
 (defn- button-navbar-font-weight []
   ;; Default font-weight to 700 so the text is considered
@@ -840,7 +839,7 @@
      {:color "#555"})]
 
    (generate-phase-styles)
-   (generate-actions-float-sizes)
+   (generate-actions-float-menu)
    [(s/descendant :.document :h3) {:margin-top (u/rem 4)}]
 
    ;; print styling

--- a/src/clj/rems/css/styles.clj
+++ b/src/clj/rems/css/styles.clj
@@ -146,7 +146,8 @@
 
 (defn- generate-actions-float-menu
   "The #actions floating menu can be too long for some screens. There is no clean solution for this in pure CSS
-  and to avoid yet another random JS-library we make the element scrollable on certain sizes.
+  and to avoid yet another random JS-library we make the element scrollable with a dynamic max-height. This can
+  break if the 150px space is not enough anymore but works for now.
 
   We also do not want these styles to affect the mobile layout (i.e. more narrow than 992) where the actions
   is at the bottom of everything and has any height available."

--- a/src/clj/rems/css/styles.clj
+++ b/src/clj/rems/css/styles.clj
@@ -159,8 +159,7 @@
                                  :padding "0.25rem 0.5rem"
                                  :line-height 1.5
                                  :border-radius "0.2rem"}]])
-   (stylesheet/at-media {:min-width (u/px 992)
-                         :max-height (u/px 1080)}
+   (stylesheet/at-media {:min-width (u/px 992)}
                         [:#actions {:overflow-y :auto
                                     :max-height "calc(100vh - 150px)"}])))
 

--- a/src/clj/rems/css/styles.clj
+++ b/src/clj/rems/css/styles.clj
@@ -771,8 +771,8 @@
    ;; working around garden minifier bug that causes 1800.0px to lose the px (1800px works fine)
    ;; https://github.com/noprompt/garden/issues/120
    [:#main-content.page-application {:max-width (u/px (int (* 1.5 (:magnitude content-width))))}]
-   [:#float-actions {:position :sticky
-                     :top "100px"}]
+   [:#actions {:position :sticky
+               :top "85px"}]
    [:.reload-indicator {:position :fixed
                         :bottom "15px"
                         :right "15px"

--- a/src/clj/rems/css/styles.clj
+++ b/src/clj/rems/css/styles.clj
@@ -160,7 +160,8 @@
                                  :line-height 1.5
                                  :border-radius "0.2rem"}]])
    (stylesheet/at-media {:min-width (u/px 992)}
-                        [:#actions {:overflow-y :auto
+                        [:#actions {:overflow-x :hidden
+                                    :overflow-y :auto
                                     :max-height "calc(100vh - 150px)"}])))
 
 (defn- button-navbar-font-weight []

--- a/src/cljs/rems/actions/components.cljs
+++ b/src/cljs/rems/actions/components.cljs
@@ -179,7 +179,7 @@
                   :ref (fn [elem]
                          (when elem
                            (.on (js/$ elem) "shown.bs.collapse" #(.focus elem))))}
-   [:h3.mt-5 title]
+   [:h3.mt-3 title]
    content
    (into [:div.col.commands [cancel-action-button id]] buttons)])
 

--- a/src/cljs/rems/application.cljs
+++ b/src/cljs/rems/application.cljs
@@ -808,10 +808,9 @@
        [:div.mt-3 [previous-applications (get-in application [:application/applicant :userid])]])
      [:div.my-3 [application-licenses application userid]]
      [:div.mt-3 [application-fields application edit-application]]]
-    [:div.col-lg-4
-     [:div#float-actions.mb-3
-      [flash-message/component :actions]
-      [actions-form application]]]]])
+    [:div.col-lg-4.spaced-vertically-3
+     [flash-message/component :actions]
+     [actions-form application]]]])
 
 ;;;; Entrypoint
 


### PR DESCRIPTION
Fixes #2501 

This is a workaround because the browsers will not handle overflow in
a sticky element properly. We don't want to add yet another JS
component for just this right now. Perhaps once we upgrade to
Bootstrap 5 we can work out better layout or solution.

https://user-images.githubusercontent.com/823661/102723315-a236c180-430f-11eb-89a3-91e226391880.mp4

Pretty difficult to test so maybe not worthwhile now.

# Checklist for author

Remove items that aren't applicable, check items that are done.

## Reviewability
- [x] Link to issue
- [x] Consider adding screenshots for ease of review

## Documentation
- [x] Update changelog if necessary
