### PR TITLE
i18n: fix link to profile in :t.profile/warning-about-missing-email

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Changes since v2.14.1
 
 ### Fixes
 - Various HTTP caching issues resolved. Users should no longer get an old app.js from their browser cache. (#2484)
+- Fixed link in the "You will need to add an email address to your settings" notificaiton. (#2503)
 
 ### Additions
 

--- a/resources/translations/en.edn
+++ b/resources/translations/en.edn
@@ -473,7 +473,7 @@
             :notification-email "Use another email address for notifications"
             :save "Save"
             :settings "Settings"
-            :warning-about-missing-email [:<> "You will need to " [:a {:href "/settings"} "add an email address to your settings"] ", so that you can receive notifications about your applications."]
+            :warning-about-missing-email [:<> "You will need to " [:a {:href "/profile"} "add an email address to your settings"] ", so that you can receive notifications about your applications."]
             :your-details "Your user details"}
   :search {:clear-search "Clear search"
            :example-searches "Example searches"

--- a/resources/translations/fi.edn
+++ b/resources/translations/fi.edn
@@ -430,7 +430,7 @@
             :notification-email "Käytä toista sähköpostiosoitetta ilmoituksille"
             :save "Tallenna"
             :settings "Asetukset"
-            :warning-about-missing-email [:<> "Sinun on " [:a {:href "/settings"} "lisättävä sähköpostiosoite asetuksiisi"] ", jotta voisit vastaanottaa ilmoituksia hakemuksistasi."]
+            :warning-about-missing-email [:<> "Sinun on " [:a {:href "/profile"} "lisättävä sähköpostiosoite asetuksiisi"] ", jotta voisit vastaanottaa ilmoituksia hakemuksistasi."]
             :your-details "Käyttäjätietosi"}
   :search {:clear-search "Tyhjennä hakuehdot"
            :example-searches "Esimerkkihakuja"

--- a/resources/translations/sv.edn
+++ b/resources/translations/sv.edn
@@ -430,7 +430,7 @@
             :notification-email "Använd en annan e-postadress för att ta emot meddelanden"
             :save "Spara"
             :settings "Inställningar"
-            :warning-about-missing-email [:<> "Du måste " [:a {:href "/settings"} "lägga till din e-postadress i dina inställningar"] ", för att kunna ta emot meddelanden om din ansökan."]
+            :warning-about-missing-email [:<> "Du måste " [:a {:href "/profile"} "lägga till din e-postadress i dina inställningar"] ", för att kunna ta emot meddelanden om din ansökan."]
             :your-details "Dina användardetaljer"} ; TODO check
   :search {:clear-search "Töm söktermer"
            :example-searches "Exempel på sökningar"


### PR DESCRIPTION
fixes #2503

# Checklist for author

Remove items that aren't applicable, check items that are done.

## Reviewability
- [x] Link to issue

## Documentation
- [x] Update changelog if necessary