### PR TITLE
Edit workflow organization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Changes since v2.14.1
 - Fixed link in the "You will need to add an email address to your settings" notificaiton. (#2503)
 
 ### Additions
+- Workflow organization can now be edited (#2333)
 
 ## v2.14.1 "Itätuulentie 2" 2020-12-15
 

--- a/manual/owner.md
+++ b/manual/owner.md
@@ -106,7 +106,7 @@ Assign handlers for a workflow by searching the user by their username or locati
 
 Handlers do not get notified when they have been assigned as a handler but they receive emails about new applications.
 
-:exclamation: Note! After saving a workflow, you cannot edit anything else than its name and the handlers.  
+:exclamation: Note! After saving a workflow, you cannot edit anything else than its name, organization and the handlers.  
 
 #### Adding a form to a workflow
 
@@ -152,7 +152,7 @@ Give your catalogue item a descriptive name. Thus, it will be easier for the app
 
 #### Editing catalogue items
 
-You can edit the catalogue item’s name and links to additional information by selecting edit.
+You can edit the catalogue item’s name, organization and links to additional information by selecting edit.
 
 :exclamation: Note! After saving, you cannot edit form, workflow or resource connected to the catalogue item. Editing is also not possible when some part of the catalogue item is disabled.
 

--- a/resources/sql/queries.sql
+++ b/resources/sql/queries.sql
@@ -343,6 +343,9 @@ SET
 /*~ (when (:workflow params) */
   workflowBody = :workflow::jsonb,
 /*~ ) ~*/
+/*~ (when (:organization params) */
+  organization = :organization,
+/*~ ) ~*/
   id = id
 WHERE id = :id;
 

--- a/src/clj/rems/api/services/workflow.clj
+++ b/src/clj/rems/api/services/workflow.clj
@@ -39,13 +39,16 @@
     (update-in workflow [:workflow :handlers] #(map :userid %))
     workflow))
 
-(defn edit-workflow! [{:keys [id title handlers]}]
+(defn edit-workflow! [{:keys [id organization title handlers]}]
   (let [workflow (unrich-workflow (workflow/get-workflow id))
         workflow-body (cond-> (:workflow workflow)
                         handlers (assoc :handlers handlers))]
     (util/check-allowed-organization! (:organization workflow))
+    (when organization
+      (util/check-allowed-organization! organization))
     (db/edit-workflow! {:id id
                         :title title
+                        :organization (:organization/id organization)
                         :workflow (json/generate-string workflow-body)}))
   (applications/reload-cache!)
   {:success true})

--- a/src/clj/rems/api/workflows.clj
+++ b/src/clj/rems/api/workflows.clj
@@ -18,6 +18,7 @@
 
 (s/defschema EditWorkflowCommand
   {:id s/Int
+   (s/optional-key :organization) OrganizationId
    ;; type can't change
    (s/optional-key :title) s/Str
    (s/optional-key :handlers) [UserId]})

--- a/src/cljs/rems/administration/create_workflow.cljs
+++ b/src/cljs/rems/administration/create_workflow.cljs
@@ -80,10 +80,12 @@
 (defn- valid-edit-request? [request]
   (and (number? (:id request))
        (seq (:handlers request))
+       (not (str/blank? (get-in request [:organization :organization/id])))
        (not (str/blank? (:title request)))))
 
 (defn build-edit-request [id form]
-  (let [request {:id id
+  (let [request {:organization {:organization/id (get-in form [:organization :organization/id])}
+                 :id id
                  :title (:title form)
                  :handlers (map :userid (:handlers form))}]
     (when (valid-edit-request? request)
@@ -134,7 +136,6 @@
 (defn- workflow-organization-field []
   [fields/organization-field {:id "organization-dropdown"
                               :value @(rf/subscribe [::selected-organization])
-                              :readonly @(rf/subscribe [::editing?])
                               :on-change #(rf/dispatch [::set-selected-organization %])}])
 
 (defn- workflow-title-field []

--- a/test/clj/rems/api/test_workflows.clj
+++ b/test/clj/rems/api/test_workflows.clj
@@ -190,6 +190,19 @@
         (is (= #{"handler" "carl"}
                (application->handler-user-ids app)))))
 
+    (testing "change organization, temporarily"
+      (assert-success (api-call :put "/api/workflows/edit"
+                                {:id wfid :organization {:organization/id "organization2"}}
+                                api-key user-id))
+      (is (= (assoc expected
+                    :organization {:organization/id "organization2"
+                                   :organization/short-name {:en "ORG 2" :fi "ORG 2" :sv "ORG 2"}
+                                   :organization/name {:en "Organization 2" :fi "Organization 2" :sv "Organization 2"}})
+             (fetch api-key user-id wfid)))
+      (assert-success (api-call :put "/api/workflows/edit"
+                                {:id wfid :organization {:organization/id "organization1"}}
+                                api-key user-id)))
+
     (testing "change title"
       (is (true? (:success (api-call :put "/api/workflows/edit"
                                      {:id wfid :title "x"}

--- a/test/clj/rems/test_browser.clj
+++ b/test/clj/rems/test_browser.clj
@@ -1182,11 +1182,12 @@
     (login-as "owner")
     (go-to-admin "Workflows")
     (testing "create workflow"
+      (btu/context-assoc! :workflow-title (str "test-workflow-create-edit " (btu/get-seed)))
       (btu/scroll-and-click :create-workflow)
       (btu/wait-visible {:tag :h1 :fn/text "Create workflow"})
       (btu/wait-page-loaded)
       (select-option "Organization" "nbn")
-      (fill-form-field "Title" "test-workflow-create-edit")
+      (fill-form-field "Title" (btu/context-get :workflow-title))
       (btu/scroll-and-click :type-decider)
       (btu/wait-page-loaded)
       (select-option "Handlers" "handler")
@@ -1200,7 +1201,7 @@
       (btu/screenshot "test-workflow-create-edit-2.png")
       (is (str/includes? (btu/get-element-text {:css ".alert-success"}) "Success"))
       (is (= {"Organization" "NBN"
-              "Title" "test-workflow-create-edit"
+              "Title" (btu/context-get :workflow-title)
               "Type" "Decider workflow"
               "Handlers" "Carl Reviewer (carl@example.com), Hannah Handler (handler@example.com)"
               "Forms" "Simple form"
@@ -1212,7 +1213,7 @@
       (btu/wait-page-loaded)
       (btu/screenshot "test-workflow-create-edit-3.png")
       (is (= "NBN" (btu/get-element-text {:tag :div :id :organization-dropdown}))) ; readonly field
-      (fill-form-field "Title" "-v2") ;; fill-form-field appends text to existing value
+      (fill-form-field "Title" " v2") ;; fill-form-field appends text to existing value
       (is (btu/disabled? :type-default)) ;; can't change type
       ;; removing an item is hard to script reliably, so let's just add one
       (select-option "Handlers" "reporter")
@@ -1225,7 +1226,7 @@
       (btu/screenshot "test-workflow-create-edit-5.png")
       (is (str/includes? (btu/get-element-text {:css ".alert-success"}) "Success"))
       (is (= {"Organization" "NBN"
-              "Title" "test-workflow-create-edit-v2"
+              "Title" (str (btu/context-get :workflow-title) " v2")
               "Type" "Decider workflow"
               "Handlers" "Carl Reviewer (carl@example.com), Hannah Handler (handler@example.com), Reporter (reporter@example.com)"
               "Forms" "Simple form"

--- a/test/clj/rems/test_browser.clj
+++ b/test/clj/rems/test_browser.clj
@@ -1212,7 +1212,7 @@
       (btu/wait-visible {:tag :h1 :fn/text "Edit workflow"})
       (btu/wait-page-loaded)
       (btu/screenshot "test-workflow-create-edit-3.png")
-      (is (= "NBN" (btu/get-element-text {:tag :div :id :organization-dropdown}))) ; readonly field
+      (select-option "Organization" "Default")
       (fill-form-field "Title" " v2") ;; fill-form-field appends text to existing value
       (is (btu/disabled? :type-default)) ;; can't change type
       ;; removing an item is hard to script reliably, so let's just add one
@@ -1225,7 +1225,7 @@
       (btu/wait-page-loaded)
       (btu/screenshot "test-workflow-create-edit-5.png")
       (is (str/includes? (btu/get-element-text {:css ".alert-success"}) "Success"))
-      (is (= {"Organization" "NBN"
+      (is (= {"Organization" "The Default Organization"
               "Title" (str (btu/context-get :workflow-title) " v2")
               "Type" "Decider workflow"
               "Handlers" "Carl Reviewer (carl@example.com), Hannah Handler (handler@example.com), Reporter (reporter@example.com)"

--- a/test/cljs/rems/administration/test_create_workflow.cljs
+++ b/test/cljs/rems/administration/test_create_workflow.cljs
@@ -68,8 +68,9 @@
         (is (nil? (build-create-request (assoc-in form [:handlers] []))))))))
 
 (deftest build-edit-request-test
-  (is (= {:id 3 :title "t" :handlers ["a" "b"]}
-         (build-edit-request 3 {:title "t" :handlers [{:userid "a"} {:userid "b"}]})))
+  (is (= {:id 3 :organization {:organization/id "o"} :title "t" :handlers ["a" "b"]}
+         (build-edit-request 3 {:organization {:organization/id "o"} :title "t" :handlers [{:userid "a"} {:userid "b"}]})))
   (is (nil? (build-edit-request nil {:title "t" :handlers [{:userid "a"} {:userid "b"}]})))
-  (is (nil? (build-edit-request 3 {:title "" :handlers [{:userid "a"} {:userid "b"}]})))
-  (is (nil? (build-edit-request 3 {:title "t" :handlers []}))))
+  (is (nil? (build-edit-request 3 {:title "t" :handlers [{:userid "a"} {:userid "b"}]})))
+  (is (nil? (build-edit-request 3 {:organization {:organization/id "o"} :title "" :handlers [{:userid "a"} {:userid "b"}]})))
+  (is (nil? (build-edit-request 3 {:organization {:organization/id "o"} :title "t" :handlers []}))))


### PR DESCRIPTION
Closes #2333 

Allows editing workflow organization. Updated the manual about the change too.

# Checklist for author

Remove items that aren't applicable, check items that are done.

## Reviewability
- [x] Link to issue

## Backwards compatibility
- [x] API is backwards compatible or completely new

## Documentation
- [x] Update changelog if necessary
- [x] API is documented and shows up in Swagger UI
- [x] Update manual/ (if applicable)

## Testing
- [x] Complex logic is unit tested
- [x] Valuable features are integration / browser / acceptance tested automatically
