### PR TITLE
Fix the reference to :oidc-metadata-url

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -19,8 +19,8 @@ Currently the only real authentication method is OpenId Connect (e.g. Auth0). Th
 
 The `:oidc` authentication method has the following configuration options:
 
-: `:oidc-metadata-url` - URL of the OAuth Server Metadata JSON document. See [RFC 8414](https://tools.ietf.org/html/rfc8414). Typically of the form `https://my.oidc.service/.well-known/openid-configuration`.
-* `:oidc-domain` – DEPRECATED, prefer `:oidc-configuration-url`. The openid connect configration is fetched from `https://{oidc-domain}/.well-known/openid-configuration`
+* `:oidc-metadata-url` - URL of the OAuth Server Metadata JSON document. See [RFC 8414](https://tools.ietf.org/html/rfc8414). Typically of the form `https://my.oidc.service/.well-known/openid-configuration`.
+* `:oidc-domain` – DEPRECATED, prefer `:oidc-metadata-url`. The openid connect configration is fetched from `https://{oidc-domain}/.well-known/openid-configuration`
 * `:oidc-client-id`
 * `:oidc-client-secret`
 * `:oidc-scopes` - which scopes to request, defaults to `"openid profile email"`

--- a/resources/config-defaults.edn
+++ b/resources/config-defaults.edn
@@ -39,7 +39,7 @@
  :alternative-login-url nil
 
  ;; For :oidc authentication
- ;; DEPRECATED, prefer :oidc-configuration-url instead
+ ;; DEPRECATED, prefer :oidc-metadata-url instead
  :oidc-domain nil
  ;; URL to OAuth Server Metadata metadata JSON, e.g.
  ;;  :oidc-metadata-url "https://my.oidc.service/.well-known/openid-configuration"


### PR DESCRIPTION
Fix the inaccurate configuration option references I mentioned in #2506.
Also fix for the bullet point for the `oidc-metadata-url` option.