### PR TITLE
Fix previous applications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Changes since v2.14.1
 ### Fixes
 - Various HTTP caching issues resolved. Users should no longer get an old app.js from their browser cache. (#2484)
 - Fixed link in the "You will need to add an email address to your settings" notificaiton. (#2503)
+- Previous application history shown to the handler is now correctly limited to the members of the application (#2470)
 
 ### Additions
 - Workflow organization can now be edited (#2333)

--- a/src/cljs/rems/administration/create_form.cljs
+++ b/src/cljs/rems/administration/create_form.cljs
@@ -39,7 +39,7 @@
                ::form-errors nil
                ::form-id form-id
                ::edit-form? edit-form?)
-    :dispatch-n [(when form-id [::form form-id])]}))
+    :dispatch-n [(when form-id [::form])]}))
 
 (fetcher/reg-fetcher ::form "/api/forms/:id" {:path-params (fn [db] {:id (::form-id db)})})
 

--- a/src/cljs/rems/application.cljs
+++ b/src/cljs/rems/application.cljs
@@ -785,7 +785,7 @@
 (defn- previous-applications [applicant]
   ;; print mode forces the collapsible open, so fetch the content proactively
   ;; TODO figure out a better solution
-  (rf/dispatch [::previous-applications (str "(applicant:\"" applicant "\" OR member:\"" applicant "\") AND -state:draft")])
+  (rf/dispatch [::previous-applications {:query (str "(applicant:\"" applicant "\" OR member:\"" applicant "\") AND -state:draft")}])
   [collapsible/component
    {:id "previous-applications"
     :title (text :t.form/previous-applications)

--- a/src/cljs/rems/fetcher.cljs
+++ b/src/cljs/rems/fetcher.cljs
@@ -76,6 +76,7 @@
     (rf/reg-event-fx
      id
      (fn [{:keys [db]} [_ query]]
+       (assert (or (nil? query) (map? query)) (pr-str query))
        ;; do only one fetch at a time - will retry after the pending fetch is finished
        (when-not (get-in db [id :fetching?])
          (fetch (process-path-params url (path-params db))


### PR DESCRIPTION
Closes #2470.

Apparently a refactoring I did in May broke this because I forgot to change this one place. (See https://github.com/CSCfi/rems/pull/2187/commits/4d9a0003aa3564b6e07af62d39551b3d4346d427)

I added an assertion to check this a bit better in the future and discovered one extra parameter in the form editor. There is no direct test for this previous applications functionality but I guess we can live without it for now.

# Checklist for author

Remove items that aren't applicable, check items that are done.

## Reviewability
- [x] Link to issue

## Documentation
- [x] Update changelog if necessary

## Testing
- [ ] Complex logic is unit tested
- [ ] Valuable features are integration / browser / acceptance tested automatically
