### PR TITLE
Copy draft

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Changes since v2.14.1
 
 ### Changes
 - The actions area has been adjusted to work better on small screens. (#2501)
+- Copying a draft application will now create a new draft but without a link to the previous (draft) application. (#2496)
 
 ### Fixes
 - Various HTTP caching issues resolved. Users should no longer get an old app.js from their browser cache. (#2484)


### PR DESCRIPTION
Fixes #2496 by making copying a draft application only copy the answers and not link to the previous (draft) application.

# Checklist for author

Remove items that aren't applicable, check items that are done.

## Reviewability
- [x] Link to issue

## Backwards compatibility
- [x] API is backwards compatible or completely new
- [x] Events are backwards compatible _or_ have migrations

## Documentation
- [x] Update changelog if necessary

## Testing
- [x] Complex logic is unit tested
- [ ] Valuable features are integration / browser / acceptance tested automatically