### PR TITLE
feat: always fetch oidc public keys upon login

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Changes since v2.15
 ### Fixes
 
 - CSS files are now marked as cacheable by browsers. In v2.15 they were mistakenly marked as uncacheable. (#2484)
+- OIDC signing keys are now always fetched on login, fixing issues with OIDC key rotation requiring a REMS restart. (#2497)
 
 ### Additions
 - The browser tests will now fail if there are any accessibility violations. (#2463)

--- a/test/clj/rems/test_jwt.clj
+++ b/test/clj/rems/test_jwt.clj
@@ -28,7 +28,7 @@
            (jwt/sign {:name "123"} "secret")))))
 
 (deftest test-jwt-validate
-  (binding [jwt/oidc-public-keys jwks]
+  (with-redefs [jwt/fetch-jwks (constantly jwks)]
     (testing "decodes valid tokens"
       (is (= {:name "Esko Luontola"}
              (select-keys (jwt/validate token jwt-issuer jwt-audience now) [:name]))))


### PR DESCRIPTION
instead of just once at startup

fixes #2497

# Checklist for author

Remove items that aren't applicable, check items that are done.

## Reviewability
- [x] Link to issue

## Documentation
- [x] Update changelog if necessary

## Testing
- [x] Complex logic is unit tested
- [ ] Valuable features are integration / browser / acceptance tested automatically
  - no integration tests for OIDC login, but I tested this manually with Auth0