### PR TITLE
remove test-data-fixture from rest of the API tests

### DIFF
--- a/test/clj/rems/api/test_administration.clj
+++ b/test/clj/rems/api/test_administration.clj
@@ -7,7 +7,7 @@
 
 (use-fixtures
   :once
-  api-fixture-without-data
+  api-fixture
   owners-fixture)
 
 (def user-id "owner")

--- a/test/clj/rems/api/test_administration.clj
+++ b/test/clj/rems/api/test_administration.clj
@@ -1,90 +1,88 @@
 (ns ^:integration rems.api.test-administration
   "Tests for invariants across administration APIs."
   (:require [clojure.test :refer :all]
+            [rems.api.testing :refer :all]
             [rems.db.core :as db]
-            [rems.api.testing :refer :all]))
+            [rems.db.testing :refer [owners-fixture +test-api-key+]]))
 
 (use-fixtures
   :once
-  api-fixture)
+  api-fixture-without-data
+  owners-fixture)
 
-(def api-key "42")
 (def user-id "owner")
 
-
 (deftest test-archiving-disabling
-  (let [api-key "42"
-        user-id "owner"
-        license-id (:id (api-call :post "/api/licenses/create" {:licensetype "text" :organization {:organization/id "abc"} :localizations {}}
-                                  api-key user-id))
-        resource-id (:id (api-call :post "/api/resources/create" {:resid "test" :organization {:organization/id "abc"} :licenses [license-id]}
-                                   api-key user-id))
-        form-id (:id (api-call :post "/api/forms/create" {:organization {:organization/id "abc"} :form/title "form update test" :form/fields []}
-                               api-key user-id))
-        wf-form-id (:id (api-call :post "/api/forms/create" {:organization {:organization/id "abc"} :form/title "workflow form update test" :form/fields []}
-                                  api-key user-id))
+  (let [license-id (:id (api-call :post "/api/licenses/create" {:licensetype "text" :organization {:organization/id "organization2"} :localizations {}}
+                                  +test-api-key+ user-id))
+        resource-id (:id (api-call :post "/api/resources/create" {:resid "test" :organization {:organization/id "organization2"} :licenses [license-id]}
+                                   +test-api-key+ user-id))
+        form-id (:id (api-call :post "/api/forms/create" {:organization {:organization/id "organization2"} :form/title "form update test" :form/fields []}
+                               +test-api-key+ user-id))
+        wf-form-id (:id (api-call :post "/api/forms/create" {:organization {:organization/id "organization2"} :form/title "workflow form update test" :form/fields []}
+                                  +test-api-key+ user-id))
         workflow-id (:id (api-call :post "/api/workflows/create"
-                                   {:organization {:organization/id "abc"} :title "default workflow"
+                                   {:organization {:organization/id "organization2"} :title "default workflow"
                                     :forms [{:form/id wf-form-id}]
                                     :type :workflow/default :handlers [user-id]}
-                                   api-key user-id))
+                                   +test-api-key+ user-id))
         catalogue-id (:id (api-call :post "/api/catalogue-items/create"
                                     {:form form-id
                                      :resid resource-id
                                      :wfid workflow-id
-                                     :organization {:organization/id "abc"}
+                                     :organization {:organization/id "organization2"}
                                      :localizations {}}
-                                    api-key user-id))
+                                    +test-api-key+ user-id))
 
         resource-archived! #(api-call :put "/api/resources/archived"
                                       {:id resource-id
                                        :archived %}
-                                      api-key user-id)
+                                      +test-api-key+ user-id)
 
         resource-enabled! #(api-call :put "/api/resources/enabled"
                                      {:id resource-id
                                       :enabled %}
-                                     api-key user-id)
+                                     +test-api-key+ user-id)
 
         catalogue-item-archived! #(api-call :put "/api/catalogue-items/archived"
                                             {:id catalogue-id
                                              :archived %}
-                                            api-key user-id)
+                                            +test-api-key+ user-id)
 
         catalogue-item-enabled! #(api-call :put "/api/catalogue-items/enabled"
                                            {:id catalogue-id
                                             :enabled %}
-                                           api-key user-id)
+                                           +test-api-key+ user-id)
 
         form-archived! #(api-call :put "/api/forms/archived"
                                   {:id %1
                                    :archived %2}
-                                  api-key user-id)
+                                  +test-api-key+ user-id)
 
         form-enabled! #(api-call :put "/api/forms/enabled"
                                  {:id %1
                                   :enabled %2}
-                                 api-key user-id)
+                                 +test-api-key+ user-id)
 
         license-archived! #(api-call :put "/api/licenses/archived"
                                      {:id license-id
                                       :archived %}
-                                     api-key user-id)
+                                     +test-api-key+ user-id)
 
         license-enabled! #(api-call :put "/api/licenses/enabled"
                                     {:id license-id
                                      :enabled %}
-                                    api-key user-id)
+                                    +test-api-key+ user-id)
 
         workflow-archived! #(api-call :put "/api/workflows/archived"
                                       {:id workflow-id
                                        :archived %}
-                                      api-key user-id)
+                                      +test-api-key+ user-id)
 
         workflow-enabled! #(api-call :put "/api/workflows/enabled"
                                      {:id workflow-id
                                       :enabled %}
-                                     api-key user-id)]
+                                     +test-api-key+ user-id)]
     (is license-id)
     (is resource-id)
     (is form-id)

--- a/test/clj/rems/api/test_administration.clj
+++ b/test/clj/rems/api/test_administration.clj
@@ -10,79 +10,77 @@
   api-fixture
   owners-fixture)
 
-(def user-id "owner")
-
 (deftest test-archiving-disabling
   (let [license-id (:id (api-call :post "/api/licenses/create" {:licensetype "text" :organization {:organization/id "organization2"} :localizations {}}
-                                  +test-api-key+ user-id))
+                                  +test-api-key+ "owner"))
         resource-id (:id (api-call :post "/api/resources/create" {:resid "test" :organization {:organization/id "organization2"} :licenses [license-id]}
-                                   +test-api-key+ user-id))
+                                   +test-api-key+ "owner"))
         form-id (:id (api-call :post "/api/forms/create" {:organization {:organization/id "organization2"} :form/title "form update test" :form/fields []}
-                               +test-api-key+ user-id))
+                               +test-api-key+ "owner"))
         wf-form-id (:id (api-call :post "/api/forms/create" {:organization {:organization/id "organization2"} :form/title "workflow form update test" :form/fields []}
-                                  +test-api-key+ user-id))
+                                  +test-api-key+ "owner"))
         workflow-id (:id (api-call :post "/api/workflows/create"
                                    {:organization {:organization/id "organization2"} :title "default workflow"
                                     :forms [{:form/id wf-form-id}]
-                                    :type :workflow/default :handlers [user-id]}
-                                   +test-api-key+ user-id))
+                                    :type :workflow/default :handlers ["owner"]}
+                                   +test-api-key+ "owner"))
         catalogue-id (:id (api-call :post "/api/catalogue-items/create"
                                     {:form form-id
                                      :resid resource-id
                                      :wfid workflow-id
                                      :organization {:organization/id "organization2"}
                                      :localizations {}}
-                                    +test-api-key+ user-id))
+                                    +test-api-key+ "owner"))
 
         resource-archived! #(api-call :put "/api/resources/archived"
                                       {:id resource-id
                                        :archived %}
-                                      +test-api-key+ user-id)
+                                      +test-api-key+ "owner")
 
         resource-enabled! #(api-call :put "/api/resources/enabled"
                                      {:id resource-id
                                       :enabled %}
-                                     +test-api-key+ user-id)
+                                     +test-api-key+ "owner")
 
         catalogue-item-archived! #(api-call :put "/api/catalogue-items/archived"
                                             {:id catalogue-id
                                              :archived %}
-                                            +test-api-key+ user-id)
+                                            +test-api-key+ "owner")
 
         catalogue-item-enabled! #(api-call :put "/api/catalogue-items/enabled"
                                            {:id catalogue-id
                                             :enabled %}
-                                           +test-api-key+ user-id)
+                                           +test-api-key+ "owner")
 
         form-archived! #(api-call :put "/api/forms/archived"
                                   {:id %1
                                    :archived %2}
-                                  +test-api-key+ user-id)
+                                  +test-api-key+ "owner")
 
         form-enabled! #(api-call :put "/api/forms/enabled"
                                  {:id %1
                                   :enabled %2}
-                                 +test-api-key+ user-id)
+                                 +test-api-key+ "owner")
 
         license-archived! #(api-call :put "/api/licenses/archived"
                                      {:id license-id
                                       :archived %}
-                                     +test-api-key+ user-id)
+                                     +test-api-key+ "owner")
 
         license-enabled! #(api-call :put "/api/licenses/enabled"
                                     {:id license-id
                                      :enabled %}
-                                    +test-api-key+ user-id)
+                                    +test-api-key+ "owner")
 
         workflow-archived! #(api-call :put "/api/workflows/archived"
                                       {:id workflow-id
                                        :archived %}
-                                      +test-api-key+ user-id)
+                                      +test-api-key+ "owner")
 
         workflow-enabled! #(api-call :put "/api/workflows/enabled"
                                      {:id workflow-id
                                       :enabled %}
-                                     +test-api-key+ user-id)]
+                                     +test-api-key+ "owner")]
     (is license-id)
     (is resource-id)
     (is form-id)

--- a/test/clj/rems/api/test_api.clj
+++ b/test/clj/rems/api/test_api.clj
@@ -7,7 +7,7 @@
             [rems.handler :refer [handler]]
             [ring.mock.request :refer :all]))
 
-(use-fixtures :once api-fixture-without-data)
+(use-fixtures :once api-fixture)
 
 (deftest test-api-not-found
   (testing "unknown endpoint"

--- a/test/clj/rems/api/test_applications.clj
+++ b/test/clj/rems/api/test_applications.clj
@@ -19,7 +19,7 @@
 
 (use-fixtures
   :each
-  api-fixture-without-data
+  api-fixture
   ;; TODO should this fixture have a name?
   (fn [f]
     (test-data/create-test-api-key!)

--- a/test/clj/rems/api/test_applications.clj
+++ b/test/clj/rems/api/test_applications.clj
@@ -8,6 +8,7 @@
             [rems.db.applications]
             [rems.db.blacklist :as blacklist]
             [rems.db.core :as db]
+            [rems.db.test-data :as test-data]
             [rems.db.test-data-helpers :as test-helpers]
             [rems.handler :refer [handler]]
             [rems.json]
@@ -17,8 +18,13 @@
            java.util.zip.ZipInputStream))
 
 (use-fixtures
-  :once
-  api-fixture)
+  :each
+  api-fixture-without-data
+  ;; TODO should this fixture have a name?
+  (fn [f]
+    (test-data/create-test-api-key!)
+    (test-data/create-test-users-and-roles!)
+    (f)))
 
 ;;; shared helpers
 

--- a/test/clj/rems/api/test_audit_log.clj
+++ b/test/clj/rems/api/test_audit_log.clj
@@ -7,7 +7,7 @@
             [rems.handler :refer [handler]]
             [ring.mock.request :refer :all]))
 
-(use-fixtures :each api-fixture-without-data)
+(use-fixtures :each api-fixture)
 
 (deftest test-audit-log
   (api-key/add-api-key! "42" {})

--- a/test/clj/rems/api/test_blacklist.clj
+++ b/test/clj/rems/api/test_blacklist.clj
@@ -10,7 +10,7 @@
 
 (use-fixtures
   :once
-  api-fixture-without-data
+  api-fixture
   (fn [f]
     ;; TODO this needs to be in the future so that we can use the
     ;; catalogue item we create. The DB time isn't overridden and

--- a/test/clj/rems/api/test_catalogue.clj
+++ b/test/clj/rems/api/test_catalogue.clj
@@ -9,7 +9,7 @@
 
 (use-fixtures
   :once
-  api-fixture-without-data)
+  api-fixture)
 
 (deftest catalogue-api-test
   (test-data/create-test-api-key!)

--- a/test/clj/rems/api/test_catalogue_items.clj
+++ b/test/clj/rems/api/test_catalogue_items.clj
@@ -10,7 +10,7 @@
 
 (use-fixtures
   :each
-  api-fixture-without-data
+  api-fixture
   owners-fixture)
 
 (deftest catalogue-items-api-test

--- a/test/clj/rems/api/test_email.clj
+++ b/test/clj/rems/api/test_email.clj
@@ -12,8 +12,6 @@
   :each
   api-fixture)
 
-(def user-id "developer")
-
 (defn- create-application-in-review! []
   (let [app-id (test-helpers/create-application! {:actor "alice"})]
     (test-helpers/command! {:type :application.command/submit
@@ -42,7 +40,7 @@
       (with-redefs [outbox/put! (fn [email]
                                   (swap! outbox-emails conj email))]
         (let [body (-> (request :post "/api/email/send-handler-reminder")
-                       (authenticate test-data/+test-api-key+ user-id)
+                       (authenticate test-data/+test-api-key+ "developer")
                        handler
                        read-ok-body)]
           (is (= "OK" body))
@@ -54,7 +52,7 @@
 
   (testing "requires API key"
     (let [response (-> (request :post "/api/email/send-handler-reminder")
-                       (add-login-cookies user-id)
+                       (add-login-cookies "developer")
                        handler)]
       (is (response-is-forbidden? response))
       (is (logged-in? response)))))
@@ -69,7 +67,7 @@
       (with-redefs [outbox/put! (fn [email]
                                   (swap! outbox-emails conj email))]
         (let [body (-> (request :post "/api/email/send-reviewer-reminder")
-                       (authenticate test-data/+test-api-key+ user-id)
+                       (authenticate test-data/+test-api-key+ "developer")
                        handler
                        read-ok-body)]
           (is (= "OK" body))
@@ -80,7 +78,7 @@
 
   (testing "requires API key"
     (let [response (-> (request :post "/api/email/send-reviewer-reminder")
-                       (add-login-cookies user-id)
+                       (add-login-cookies "developer")
                        handler)]
       (is (response-is-forbidden? response))
       (is (logged-in? response)))))
@@ -96,7 +94,7 @@
       (with-redefs [outbox/put! (fn [email]
                                   (swap! outbox-emails conj email))]
         (let [body (-> (request :post "/api/email/send-reminders")
-                       (authenticate test-data/+test-api-key+ user-id)
+                       (authenticate test-data/+test-api-key+ "developer")
                        handler
                        read-ok-body)]
           (is (= "OK" body))
@@ -109,7 +107,7 @@
 
   (testing "requires API key"
     (let [response (-> (request :post "/api/email/send-reminders")
-                       (add-login-cookies user-id)
+                       (add-login-cookies "developer")
                        handler)]
       (is (response-is-forbidden? response))
       (is (logged-in? response)))))

--- a/test/clj/rems/api/test_email.clj
+++ b/test/clj/rems/api/test_email.clj
@@ -10,7 +10,7 @@
 
 (use-fixtures
   :each
-  api-fixture-without-data)
+  api-fixture)
 
 (def user-id "developer")
 

--- a/test/clj/rems/api/test_end_to_end.clj
+++ b/test/clj/rems/api/test_end_to_end.clj
@@ -14,7 +14,7 @@
             [rems.json :as json]
             [stub-http.core :as stub]))
 
-(use-fixtures :each api-fixture-without-data)
+(use-fixtures :each api-fixture)
 
 (defn extract-id [resp]
   (assert-success resp)

--- a/test/clj/rems/api/test_entitlements.clj
+++ b/test/clj/rems/api/test_entitlements.clj
@@ -12,7 +12,7 @@
 
 (use-fixtures
   :once
-  api-fixture-without-data)
+  api-fixture)
 
 (deftest entitlements-test
   (testing "set up data"

--- a/test/clj/rems/api/test_extra_pages.clj
+++ b/test/clj/rems/api/test_extra_pages.clj
@@ -6,7 +6,7 @@
 
 (use-fixtures
   :once
-  api-fixture)
+  api-fixture-without-data)
 
 (deftest extra-pages-api-test
   (let [api-key "42"

--- a/test/clj/rems/api/test_extra_pages.clj
+++ b/test/clj/rems/api/test_extra_pages.clj
@@ -6,7 +6,7 @@
 
 (use-fixtures
   :once
-  api-fixture-without-data)
+  api-fixture)
 
 (deftest extra-pages-api-test
   (let [api-key "42"

--- a/test/clj/rems/api/test_forms.clj
+++ b/test/clj/rems/api/test_forms.clj
@@ -13,7 +13,7 @@
 
 (use-fixtures
   :each
-  api-fixture-without-data
+  api-fixture
   owners-fixture)
 
 (defn- fixup-field-visible-type [field]

--- a/test/clj/rems/api/test_licenses.clj
+++ b/test/clj/rems/api/test_licenses.clj
@@ -7,7 +7,7 @@
 
 (use-fixtures
   :each
-  api-fixture-without-data
+  api-fixture
   owners-fixture)
 
 (def testfile (clojure.java.io/file "./test-data/test.txt"))

--- a/test/clj/rems/api/test_organizations.clj
+++ b/test/clj/rems/api/test_organizations.clj
@@ -14,7 +14,7 @@
 
 (use-fixtures
   :each
-  api-fixture-without-data
+  api-fixture
   (fixed-time-fixture test-time1))
 
 (deftest organizations-api-test

--- a/test/clj/rems/api/test_permissions.clj
+++ b/test/clj/rems/api/test_permissions.clj
@@ -14,7 +14,7 @@
 
 (use-fixtures
   :once
-  api-fixture-without-data)
+  api-fixture)
 
 (deftest jwk-api
   (let [data (api-call :get "/api/jwk" nil nil nil)]

--- a/test/clj/rems/api/test_public.clj
+++ b/test/clj/rems/api/test_public.clj
@@ -6,7 +6,7 @@
 
 (use-fixtures
   :once
-  api-fixture-without-data)
+  api-fixture)
 
 (deftest service-translations-test
   (let [api-key "42"

--- a/test/clj/rems/api/test_public.clj
+++ b/test/clj/rems/api/test_public.clj
@@ -6,7 +6,7 @@
 
 (use-fixtures
   :once
-  api-fixture)
+  api-fixture-without-data)
 
 (deftest service-translations-test
   (let [api-key "42"

--- a/test/clj/rems/api/test_resources.clj
+++ b/test/clj/rems/api/test_resources.clj
@@ -9,7 +9,7 @@
 
 (use-fixtures
   :each
-  api-fixture-without-data
+  api-fixture
   owners-fixture)
 
 (defn- create-resource! [command api-key user-id]

--- a/test/clj/rems/api/test_user_settings.clj
+++ b/test/clj/rems/api/test_user_settings.clj
@@ -1,6 +1,7 @@
 (ns ^:integration rems.api.test-user-settings
   (:require [clojure.test :refer :all]
             [rems.api.testing :refer :all]
+            [rems.db.test-data :as test-data]
             [rems.db.test-data-helpers :as test-helpers]
             [rems.handler :refer [handler]]
             [ring.mock.request :refer :all])
@@ -8,9 +9,10 @@
 
 (use-fixtures
   :once
-  api-fixture)
+  api-fixture-without-data)
 
 (deftest user-settings-api-test
+  (test-data/create-test-api-key!)
   (let [user-id (str (UUID/randomUUID))]
     (test-helpers/create-user! {:eppn user-id})
 

--- a/test/clj/rems/api/test_user_settings.clj
+++ b/test/clj/rems/api/test_user_settings.clj
@@ -9,7 +9,7 @@
 
 (use-fixtures
   :once
-  api-fixture-without-data)
+  api-fixture)
 
 (deftest user-settings-api-test
   (test-data/create-test-api-key!)

--- a/test/clj/rems/api/test_users.clj
+++ b/test/clj/rems/api/test_users.clj
@@ -1,15 +1,18 @@
 (ns ^:integration rems.api.test-users
   (:require [clojure.test :refer :all]
+            [rems.api.testing :refer :all]
             [rems.db.api-key :as api-key]
             [rems.db.roles :as roles]
+            [rems.db.test-data :as test-data]
+            [rems.db.testing :refer [owners-fixture +test-api-key+]]
             [rems.db.users :as users]
             [rems.handler :refer [handler]]
-            [rems.api.testing :refer :all]
             [ring.mock.request :refer :all]))
 
 (use-fixtures
   :each ;; active-api-test needs a fresh session store
-  api-fixture)
+  api-fixture-without-data
+  owners-fixture)
 
 (deftest users-api-test
   (let [new-user {:userid "david"
@@ -20,7 +23,7 @@
       (is (= nil (:name (users/get-user userid))))
       (-> (request :post (str "/api/users/create"))
           (json-body new-user)
-          (authenticate "42" "owner")
+          (authenticate +test-api-key+ "owner")
           handler
           assert-response-is-ok)
       (is (= {:userid "david"
@@ -32,7 +35,7 @@
           (json-body (assoc new-user
                             :email "new email"
                             :name "new name"))
-          (authenticate "42" "owner")
+          (authenticate +test-api-key+ "owner")
           handler
           assert-response-is-ok)
       (is (= {:userid "david"
@@ -48,7 +51,7 @@
                       :nickname "Orger"
                       :email nil
                       :organizations [{:organization/id "abc"}]})
-          (authenticate "42" "owner")
+          (authenticate +test-api-key+ "owner")
           handler
           assert-response-is-ok)
       (is (= {:userid userid
@@ -74,7 +77,7 @@
                          (json-body {:userid "test1"
                                      :email "test1@example.com"
                                      :name "Test 1"})
-                         (authenticate "42" "alice")
+                         (authenticate +test-api-key+ "alice")
                          handler)]
         (is (response-is-forbidden? response))
         (is (= "forbidden" (read-body response))))))
@@ -86,33 +89,32 @@
         (json-body {:userid "test1"
                     :email "test1@example.com"
                     :name "Test 1"})
-        (authenticate "42" "user-owner")
+        (authenticate +test-api-key+ "user-owner")
         handler
         assert-response-is-ok)))
 
 (deftest active-api-test
-  (let [api-key "42"
-        owner "owner"]
-    (testing "no users yet"
-      (is (= []
+  (test-data/create-test-users-and-roles!)
+  (testing "no users yet"
+    (is (= []
+           (api-call :get "/api/users/active" nil
+                     +test-api-key+ "owner"))))
+  (testing "log in elsa"
+    (let [cookie (login-with-cookies "elsa")]
+      (-> (request :get "/api/keepalive")
+          (header "Cookie" cookie)
+          handler
+          assert-response-is-ok)
+      (is (= [{:userid "elsa" :name "Elsa Roleless" :email "elsa@example.com"}]
              (api-call :get "/api/users/active" nil
-                       api-key owner))))
-    (testing "log in elsa"
-      (let [cookie (login-with-cookies "elsa")]
-        (-> (request :get "/api/keepalive")
-            (header "Cookie" cookie)
-            handler
-            assert-response-is-ok)
-        (is (= [{:userid "elsa" :name "Elsa Roleless" :email "elsa@example.com"}]
-               (api-call :get "/api/users/active" nil
-                         api-key owner)))))
-    (testing "log in frank"
-      (let [cookie (login-with-cookies "frank")]
-        (-> (request :get "/api/keepalive")
-            (header "Cookie" cookie)
-            handler
-            assert-response-is-ok)
-        (is (= #{{:userid "elsa" :name "Elsa Roleless" :email "elsa@example.com"}
-                 {:userid "frank" :name "Frank Roleless" :email "frank@example.com" :organizations [{:organization/id "frank"}]}}
-               (set (api-call :get "/api/users/active" nil
-                              api-key owner))))))))
+                       +test-api-key+ "owner")))))
+  (testing "log in frank"
+    (let [cookie (login-with-cookies "frank")]
+      (-> (request :get "/api/keepalive")
+          (header "Cookie" cookie)
+          handler
+          assert-response-is-ok)
+      (is (= #{{:userid "elsa" :name "Elsa Roleless" :email "elsa@example.com"}
+               {:userid "frank" :name "Frank Roleless" :email "frank@example.com" :organizations [{:organization/id "frank"}]}}
+             (set (api-call :get "/api/users/active" nil
+                            +test-api-key+ "owner")))))))

--- a/test/clj/rems/api/test_users.clj
+++ b/test/clj/rems/api/test_users.clj
@@ -11,7 +11,7 @@
 
 (use-fixtures
   :each ;; active-api-test needs a fresh session store
-  api-fixture-without-data
+  api-fixture
   owners-fixture)
 
 (deftest users-api-test

--- a/test/clj/rems/api/test_workflows.clj
+++ b/test/clj/rems/api/test_workflows.clj
@@ -13,7 +13,7 @@
             [ring.mock.request :refer :all]))
 
 (use-fixtures :each
-  api-fixture-without-data
+  api-fixture
   owners-fixture)
 
 ;; this is a subset of what we expect to get from the api

--- a/test/clj/rems/api/testing.clj
+++ b/test/clj/rems/api/testing.clj
@@ -32,7 +32,7 @@
    #'rems.middleware/session-store
    #'rems.handler/handler))
 
-(def api-fixture-without-data
+(def api-fixture
   (join-fixtures [test-db-fixture
                   rollback-db-fixture
                   handler-fixture

--- a/test/clj/rems/api/testing.clj
+++ b/test/clj/rems/api/testing.clj
@@ -39,10 +39,6 @@
                   search-index-fixture
                   caches-fixture]))
 
-(def api-fixture
-  (join-fixtures [api-fixture-without-data
-                  test-data-fixture]))
-
 (defn authenticate [request api-key user-id]
   (-> request
       (assoc-in [:headers "x-rems-api-key"] api-key)

--- a/test/clj/rems/api/testing.clj
+++ b/test/clj/rems/api/testing.clj
@@ -6,7 +6,7 @@
             [clojure.test :refer :all]
             [mount.core :as mount]
             [muuntaja.core :as muuntaja]
-            [rems.db.testing :refer [reset-db-fixture rollback-db-fixture test-data-fixture test-db-fixture caches-fixture search-index-fixture]]
+            [rems.db.testing :refer [reset-db-fixture rollback-db-fixture test-db-fixture caches-fixture search-index-fixture]]
             [rems.handler :refer :all]
             [rems.middleware]
             [rems.standalone]

--- a/test/clj/rems/db/testing.clj
+++ b/test/clj/rems/db/testing.clj
@@ -44,18 +44,6 @@
   (mount/start #'rems.db.applications/all-applications-cache)
   (f))
 
-(defn test-data-fixture [f]
-  ;; no specific teardown for test-data-fixture. tests rely on the
-  ;; teardown of reset-db-fixture or rollback-db-fixture to keep a
-  ;; clean db
-  (try
-    (test-data/create-test-data!)
-    ;; kaocha is bad at reporting errors in fixtures, so let's catch and print errors here
-    (catch Throwable t
-      (println "ERROR: Generating test data failed!")
-      (.printStackTrace t)))
-  (f))
-
 (def +test-api-key+ test-data/+test-api-key+) ;; re-exported for convenience
 
 (defn owners-fixture [f]

--- a/test/clj/rems/test_event_notification.clj
+++ b/test/clj/rems/test_event_notification.clj
@@ -4,7 +4,7 @@
             [medley.core :refer [dissoc-in]]
             [rems.config]
             [rems.api.services.command :as command]
-            [rems.api.testing :refer [api-fixture-without-data api-call]]
+            [rems.api.testing :refer [api-fixture api-call]]
             [rems.db.events]
             [rems.db.test-data :as test-data]
             [rems.db.test-data-helpers :as test-helpers]
@@ -14,7 +14,7 @@
 
 (use-fixtures
   :each
-  api-fixture-without-data)
+  api-fixture)
 
 (deftest test-notify!
   (with-open [server (stub/start! {"/ok" {:status 200}

--- a/test/clj/rems/test_handler.clj
+++ b/test/clj/rems/test_handler.clj
@@ -1,7 +1,7 @@
 (ns ^:integration rems.test-handler
   (:require [clojure.test :refer :all]
             [mount.core :as mount]
-            [rems.api.testing :refer [api-fixture-without-data read-ok-body]]
+            [rems.api.testing :refer [api-fixture read-ok-body]]
             [rems.common.git :as git]
             [rems.config :refer [env]]
             [rems.handler :refer :all]
@@ -9,7 +9,7 @@
 
 ;; we shouldn't need the db here, but there is no handler-without-db
 ;; fixture at the moment
-(use-fixtures :once api-fixture-without-data)
+(use-fixtures :once api-fixture)
 
 (deftest test-caching
   (with-redefs [git/+version+ {:version "0.0.0" :revision "abcd1234"}]

--- a/test/clj/rems/test_redirects.clj
+++ b/test/clj/rems/test_redirects.clj
@@ -11,7 +11,7 @@
 
 (use-fixtures
   :once
-  api-fixture-without-data
+  api-fixture
   (fn [f]
     ;; need to set an explicit public-url since dev and test configs use different ports
     (with-redefs [rems.config/env (assoc rems.config/env :public-url "https://public.url/")]


### PR DESCRIPTION
Now api-fixture creates no data, instead the test namespaces
explicitly create their test data.

Closes #2298

# Checklist for author

Remove items that aren't applicable, check items that are done.

## Reviewability
- [x] Link to issue

## Testing
- [x] Complex logic is unit tested
- [x] Valuable features are integration / browser / acceptance tested automatically