### PR TITLE
test: use JVM time when creating catalogue item, not DB time

### DIFF
--- a/resources/sql/queries.sql
+++ b/resources/sql/queries.sql
@@ -68,11 +68,13 @@ WHERE id = :id;
 -- :name create-catalogue-item! :insert
 -- :doc Create a single catalogue item
 INSERT INTO catalogue_item
-(formid, resid, wfid, organization, enabled, archived)
+(formid, resid, wfid, organization, enabled, archived, start)
 VALUES (:form, :resid, :wfid, :organization,
 --~ (if (contains? params :enabled) ":enabled" "true")
 ,
 --~ (if (contains? params :archived) ":archived" "false")
+,
+--~ (if (contains? params :start) ":start" "now()")
 );
 
 -- :name get-resources :? :*

--- a/src/clj/rems/api/services/catalogue.clj
+++ b/src/clj/rems/api/services/catalogue.clj
@@ -9,7 +9,7 @@
 (defn create-catalogue-item! [{:keys [localizations organization] :as command}]
   (util/check-allowed-organization! organization)
   (let [id (:id (db/create-catalogue-item! (merge {:organization (:organization/id organization "default")}
-                                                  (select-keys command [:form :resid :wfid :enabled :archived]))))
+                                                  (select-keys command [:form :resid :wfid :enabled :archived :start]))))
         loc-ids
         (doall
          (for [[langcode localization] localizations]

--- a/src/clj/rems/db/test_data_helpers.clj
+++ b/src/clj/rems/db/test_data_helpers.clj
@@ -151,7 +151,7 @@
     (assert (:success result) {:command command :result result})
     (:id result)))
 
-(defn create-catalogue-item! [{:keys [actor title resource-id form-id workflow-id infourl organization]
+(defn create-catalogue-item! [{:keys [actor title resource-id form-id workflow-id infourl organization start]
                                :as command}]
   (let [actor (or actor (create-owner!))
         localizations (into {}
@@ -160,7 +160,8 @@
                                      :infourl (get infourl lang)}]))
         result (with-user actor
                  (catalogue/create-catalogue-item!
-                  {:resid (or resource-id (create-resource! {:organization organization}))
+                  {:start (or start (time/now))
+                   :resid (or resource-id (create-resource! {:organization organization}))
                    :form (or form-id (create-form! {:organization organization}))
                    :organization (or organization (ensure-default-organization!))
                    :wfid (or workflow-id (create-workflow! {:organization organization}))

--- a/test/clj/rems/api/test_over_http.clj
+++ b/test/clj/rems/api/test_over_http.clj
@@ -1,7 +1,6 @@
 (ns ^:integration rems.api.test-over-http
   "API tests that use a full HTTP server."
   (:require [clj-http.client :as http]
-            [clj-time.core]
             [clojure.test :refer :all]
             [rems.api.testing :refer [standalone-fixture]]
             [rems.config]
@@ -9,7 +8,6 @@
             [rems.db.test-data-helpers :as test-helpers]
             [rems.json :as json]
             [rems.event-notification :as event-notification]
-            [rems.testing-util]
             [stub-http.core :as stub])
   (:import [java.net URL]))
 

--- a/test/clj/rems/api/test_over_http.clj
+++ b/test/clj/rems/api/test_over_http.clj
@@ -1,6 +1,7 @@
 (ns ^:integration rems.api.test-over-http
   "API tests that use a full HTTP server."
   (:require [clj-http.client :as http]
+            [clj-time.core]
             [clojure.test :refer :all]
             [rems.api.testing :refer [standalone-fixture]]
             [rems.config]
@@ -8,6 +9,7 @@
             [rems.db.test-data-helpers :as test-helpers]
             [rems.json :as json]
             [rems.event-notification :as event-notification]
+            [rems.testing-util]
             [stub-http.core :as stub])
   (:import [java.net URL]))
 


### PR DESCRIPTION
... to avoid problems when DB time is slightly ahead of JVM time. This
makes the catalogue item seem disabled since we check the item :start
against the JVM time.

for #2540

# Checklist for author

Remove items that aren't applicable, check items that are done.

## Reviewability
- [x] Link to issue

## Documentation
- [ ] ADR for major architectural decisions or experiments
  - could consider an ADR about database time later

## Testing
- [x] Valuable features are integration / browser / acceptance tested automatically
  - however, we don't have a test that simulates a db time difference