### PR TITLE
don't use database time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ Changes since v2.15
 ### Changes
 - REMS no longer sends the Server: HTTP header to avoid leaking version information. (#2216)
 - Text descriptions of some events in the log were phrased better. The created event also shows the original external id. (#2614)
-- REMS no longer uses the database time when creating rows. Requires migration, but does not change visible behaviour. (#2540)
+- REMS now consistently uses the application server clock when creating timestemps. Previously, database time was used in some situations, leading to minor inconsistencies. Requires migration, but does not change visible behaviour. (#2540)
 
 ### Fixes
 - CSS files are now marked as cacheable by browsers. In v2.15 they were mistakenly marked as uncacheable. (#2484)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Changes since v2.15
 ### Changes
 - REMS no longer sends the Server: HTTP header to avoid leaking version information. (#2216)
 - Text descriptions of some events in the log were phrased better. The created event also shows the original external id. (#2614)
+- REMS no longer uses the database time when creating rows. Requires migration, but does not change visible behaviour. (#2540)
 
 ### Fixes
 - CSS files are now marked as cacheable by browsers. In v2.15 they were mistakenly marked as uncacheable. (#2484)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ Changes since v2.15
 ### Changes
 - REMS no longer sends the Server: HTTP header to avoid leaking version information. (#2216)
 - Text descriptions of some events in the log were phrased better. The created event also shows the original external id. (#2614)
-- REMS now consistently uses the application server clock when creating timestemps. Previously, database time was used in some situations, leading to minor inconsistencies. Requires migration, but does not change visible behaviour. (#2540)
+- REMS now consistently uses the application server clock when creating timestamps. Previously, database time was used in some situations, leading to minor inconsistencies. Requires migration, but does not change visible behaviour. (#2540)
 
 ### Fixes
 - CSS files are now marked as cacheable by browsers. In v2.15 they were mistakenly marked as uncacheable. (#2484)

--- a/docs/architecture/016-database-time.md
+++ b/docs/architecture/016-database-time.md
@@ -1,0 +1,31 @@
+# 016: Database and Time
+
+Authors: @opqdonut
+
+## Problem
+
+Integration tests were failing on macOS due to different clocks being
+used inside the JVM and inside the test database running in a docker
+container.
+
+This clock difference causes problems like this:
+- A catalogue item gets created, and the database current time is used as the `start`
+- The catalogue item is fetched, and the `start` is compared with the JVM time
+- The `start` is in the future for the JVM, so the catalogue item is disabled
+- A test, expecting to use a catalogue item it just created, fails
+
+In production there were no problems like this (that we know of)
+probably due to network & human latencies being greater than the clock
+drift.
+
+This was already noticed back in
+[PR #1430](https://github.com/CSCfi/rems/pull/1430)
+where a workaround was added.
+
+## Solution
+
+Always use the JVM clock. This was accomplished by removing the
+`now()` defaults from timestamp columns. See
+- [Issue #2540](https://github.com/CSCfi/rems/issues/2540)
+- [PR #2543](https://github.com/CSCfi/rems/pull/2543)
+- [PR #2544](https://github.com/CSCfi/rems/pull/2544)

--- a/resources/migrations/20210129065826-remove-timestamp-defaults.down.sql
+++ b/resources/migrations/20210129065826-remove-timestamp-defaults.down.sql
@@ -1,0 +1,10 @@
+ALTER TABLE audit_log ALTER COLUMN time SET DEFAULT now();
+--;;
+ALTER TABLE catalogue_item ALTER COLUMN start SET DEFAULT now();
+--;;
+ALTER TABLE entitlement ALTER COLUMN start SET DEFAULT now();
+--;;
+ALTER TABLE license_attachment ALTER COLUMN start SET DEFAULT now();
+--;;
+ALTER TABLE organization ALTER COLUMN modified SET DEFAULT now();
+--;;

--- a/resources/migrations/20210129065826-remove-timestamp-defaults.up.sql
+++ b/resources/migrations/20210129065826-remove-timestamp-defaults.up.sql
@@ -1,0 +1,10 @@
+ALTER TABLE audit_log ALTER COLUMN time DROP DEFAULT;
+--;;
+ALTER TABLE catalogue_item ALTER COLUMN start DROP DEFAULT;
+--;;
+ALTER TABLE entitlement ALTER COLUMN start DROP DEFAULT;
+--;;
+ALTER TABLE license_attachment ALTER COLUMN start DROP DEFAULT;
+--;;
+ALTER TABLE organization ALTER COLUMN modified DROP DEFAULT;
+--;;

--- a/resources/sql/queries.sql
+++ b/resources/sql/queries.sql
@@ -296,9 +296,9 @@ WHERE id = :id;
 
 -- :name create-license-attachment! :insert
 INSERT INTO license_attachment
-(modifierUserId, filename, type, data)
+(modifierUserId, filename, type, data, start)
 VALUES
-(:user, :filename, :type, :data);
+(:user, :filename, :type, :data, :start);
 
 -- :name remove-license-attachment! :!
 DELETE FROM license_attachment WHERE id = :id;

--- a/resources/sql/queries.sql
+++ b/resources/sql/queries.sql
@@ -214,8 +214,8 @@ DELETE FROM catalogue_item_application
 WHERE id = :application;
 
 -- :name add-entitlement! :!
-INSERT INTO entitlement (catAppId, userId, resId, approvedby, endt)
-VALUES (:application, :user, :resource, :approvedby,
+INSERT INTO entitlement (catAppId, userId, resId, approvedby, start, endt)
+VALUES (:application, :user, :resource, :approvedby, :start,
 /*~ (if (:end params) */ :end /*~*/ NULL /*~ ) ~*/
 );
 

--- a/resources/sql/queries.sql
+++ b/resources/sql/queries.sql
@@ -554,9 +554,6 @@ WHERE prefix = :prefix
 INSERT INTO external_application_id (prefix, suffix)
 VALUES (:prefix, :suffix);
 
--- :name get-database-time :? :1
-SELECT now();
-
 -- :name add-blacklist-event! :!
 INSERT INTO blacklist_event (eventdata)
 VALUES (:eventdata::jsonb);

--- a/src/clj/rems/api/services/licenses.clj
+++ b/src/clj/rems/api/services/licenses.clj
@@ -1,6 +1,7 @@
 (ns rems.api.services.licenses
   "Serving licenses for API."
-  (:require [rems.api.services.dependencies :as dependencies]
+  (:require [clj-time.core :as time]
+            [rems.api.services.dependencies :as dependencies]
             [rems.api.services.util :as util]
             [rems.db.applications :as applications]
             [rems.db.attachments :as attachments]
@@ -38,7 +39,8 @@
      (db/create-license-attachment! {:user user-id
                                      :filename filename
                                      :type content-type
-                                     :data byte-array})
+                                     :data byte-array
+                                     :start (time/now)})
      [:id])))
 
 (defn remove-license-attachment! [attachment-id]

--- a/src/clj/rems/db/entitlements.clj
+++ b/src/clj/rems/db/entitlements.clj
@@ -114,6 +114,7 @@
                           :user user-id
                           :resource resource-id
                           :approvedby actor
+                          :start (time/now) ; TODO should ideally come from the command time
                           :end end})
     ;; TODO could generate only one outbox entry per application. Currently one per user-resource pair.
     (add-to-outbox! :add (db/get-entitlements {:application application-id :user user-id :resource resource-id}))

--- a/src/clj/rems/db/test_data_helpers.clj
+++ b/src/clj/rems/db/test_data_helpers.clj
@@ -95,11 +95,13 @@
   (let [fi-attachment (:id (db/create-license-attachment! {:user (or actor "owner")
                                                            :filename "license-fi.txt"
                                                            :type "text/plain"
-                                                           :data (.getBytes "Suomenkielinen lisenssi.")}))
+                                                           :data (.getBytes "Suomenkielinen lisenssi.")
+                                                           :start (time/now)}))
         en-attachment (:id (db/create-license-attachment! {:user (or actor "owner")
                                                            :filename "license-en.txt"
                                                            :type "text/plain"
-                                                           :data (.getBytes "License in English.")}))]
+                                                           :data (.getBytes "License in English.")
+                                                           :start (time/now)}))]
     (with-user actor
       (create-license! {:actor actor
                         :license/type :attachment

--- a/test/clj/rems/api/test_workflows.clj
+++ b/test/clj/rems/api/test_workflows.clj
@@ -7,7 +7,7 @@
             [rems.db.core :as db]
             [rems.db.test-data-users :refer [+fake-user-data+]]
             [rems.db.test-data-helpers :as test-helpers]
-            [rems.db.testing :refer [sync-with-database-time owners-fixture +test-api-key+]]
+            [rems.db.testing :refer [owners-fixture +test-api-key+]]
             [rems.handler :refer [handler]]
             [rems.testing-util :refer [with-user]]
             [ring.mock.request :refer :all]))
@@ -71,7 +71,6 @@
                 body (create-workflow user-id "organization1" :workflow/default [{:form/id form-id}])
                 id (:id body)]
             (is (number? id))
-            (sync-with-database-time)
             (testing "and fetch"
               (is (= (assoc-in expected [:workflow :forms] [{:form/id form-id :form/title "workflow form"}])
                      (fetch +test-api-key+ user-id id))))))
@@ -95,7 +94,6 @@
           (let [body (create-workflow user-id "organization1" :workflow/decider [])
                 id (:id body)]
             (is (< 0 id))
-            (sync-with-database-time)
             (testing "and fetch"
               (is (= (-> expected
                          (assoc-in [:workflow :type] "workflow/decider"))
@@ -140,7 +138,6 @@
                                  {:id wfid
                                   :archived %1}
                                  +test-api-key+ %2)]
-    (sync-with-database-time)
     (testing "before changes"
       (is (= expected (fetch))))
     (testing "as owner"
@@ -195,7 +192,6 @@
                                                   :actor "tester"})
         application->handler-user-ids
         (fn [app] (set (mapv :userid (get-in app [:application/workflow :workflow.dynamic/handlers]))))]
-    (sync-with-database-time)
     (testing "application is initialized with the correct set of handlers"
       (let [app (applications/get-application app-id)]
         (is (= #{"handler" "carl"}

--- a/test/clj/rems/db/testing.clj
+++ b/test/clj/rems/db/testing.clj
@@ -54,22 +54,3 @@
   (conman/with-transaction [db/*db* {:isolation :serializable}]
     (jdbc/db-set-rollback-only! db/*db*)
     (f)))
-
-(defn get-database-time []
-  (:now (db/get-database-time)))
-
-(defn sync-with-database-time
-  "When the database runs on a different machine or VM than
-   the application (e.g. Docker for Mac), the database clock may be
-   ahead of the application clock, in which case newly created entities
-   may be incorrectly flagged as expired, because their creation time
-   seems to be in the future. This helper method can be called after
-   creating such entities in flaky tests to guarantee that the application
-   clock has caught up with the database clock."
-  []
-  (let [db-time (get-database-time)
-        app-time (time/now)
-        diff (.getMillis (Duration. ^ReadableInstant app-time ^ReadableInstant db-time))]
-    (when (pos? diff)
-      (log/info "The application clock is" diff "ms behind the database")
-      (Thread/sleep (+ 1 diff)))))


### PR DESCRIPTION
- drop all now() defaults from schema
- add (time/now) defaults to code where required

fixes #2540

# Checklist for author

Remove items that aren't applicable, check items that are done.

## Reviewability
- [x] Link to issue

## Backwards compatibility
- [x] API is backwards compatible or completely new

## Documentation
- [x] Update changelog if necessary
- [x] ADR for major architectural decisions or experiments
  - should there be one?

## Testing
- [x] Valuable features are integration / browser / acceptance tested automatically
  - test coverage for this stuff seemed pretty good