### PR TITLE
fix: GA4GH JWT timestamps should be in seconds, not milliseconds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Changes since v2.16
 
 ### Fixes
 - Searching for applications by the original REMS generated id works, even if another id has been assigned. (#2564)
+- GA4GH Visa (output by the experimental /api/permissions API) timestamps are now in seconds, instead of milliseconds. (#2554)
 
 ### Additions
 

--- a/src/clj/rems/ga4gh.clj
+++ b/src/clj/rems/ga4gh.clj
@@ -60,13 +60,13 @@
 (defn- entitlement->visa-claims [{:keys [resid _catappid start end _mail userid _approvedby]}]
   {:iss (:public-url env)
    :sub userid
-   :iat (clj-time.coerce/to-long (time/now))
-   :exp (clj-time.coerce/to-long (or end (time/plus (time/now) +default-length+)))
+   :iat (clj-time.coerce/to-epoch (time/now))
+   :exp (clj-time.coerce/to-epoch (or end (time/plus (time/now) +default-length+)))
    :ga4gh_visa_v1 {:type "ControlledAccessGrants"
                    :value (str resid)
                    :source (:public-url env)
                    :by "dac" ; the Data Access Commitee acts via REMS
-                   :asserted (clj-time.coerce/to-long start)}})
+                   :asserted (clj-time.coerce/to-epoch start)}})
 
 (deftest test-entitlement->visa-claims
   (with-redefs [env {:public-url "https://rems.example/"}]
@@ -74,23 +74,23 @@
       (fn []
         (is (= {:iss "https://rems.example/"
                 :sub "user@example.com"
-                :iat (clj-time.coerce/to-long "2010")
-                :exp (clj-time.coerce/to-long "2011")
+                :iat (clj-time.coerce/to-epoch "2010")
+                :exp (clj-time.coerce/to-epoch "2011")
                 :ga4gh_visa_v1 {:type "ControlledAccessGrants"
                                 :value "urn:1234"
                                 :source "https://rems.example/"
                                 :by "dac"
-                                :asserted (clj-time.coerce/to-long "2009")}}
+                                :asserted (clj-time.coerce/to-epoch "2009")}}
                (entitlement->visa-claims {:resid "urn:1234" :start (time/date-time 2009) :userid "user@example.com"})))
         (is (= {:iss "https://rems.example/"
                 :sub "user@example.com"
-                :iat (clj-time.coerce/to-long "2010")
-                :exp (clj-time.coerce/to-long "2010-06-02")
+                :iat (clj-time.coerce/to-epoch "2010")
+                :exp (clj-time.coerce/to-epoch "2010-06-02")
                 :ga4gh_visa_v1 {:type "ControlledAccessGrants"
                                 :value "urn:1234"
                                 :source "https://rems.example/"
                                 :by "dac"
-                                :asserted (clj-time.coerce/to-long "2009")}}
+                                :asserted (clj-time.coerce/to-epoch "2009")}}
                (entitlement->visa-claims {:resid "urn:1234" :start (time/date-time 2009) :end (time/date-time 2010 6 2) :userid "user@example.com"})))))))
 
 (defn- entitlement->visa [entitlement]


### PR DESCRIPTION
fixes #2554

# Checklist for author

Remove items that aren't applicable, check items that are done.

## Reviewability
- [x] Link to issue

## Backwards compatibility
- [ ] API is backwards compatible or completely new
  - a backwards incompatible change in an experimental API

## Documentation
- [x] Update changelog if necessary
- [x] API is documented and shows up in Swagger UI

## Testing
- [x] Complex logic is unit tested