### PR TITLE
migrations: don't recreate unique constraint on resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Changes since v2.16
 ### Fixes
 - Searching for applications by the original REMS generated id works, even if another id has been assigned. (#2564)
 - GA4GH Visa (output by the experimental /api/permissions API) timestamps are now in seconds, instead of milliseconds. (#2554)
+- The REMS `reset` command line command now works even when you have duplicate resource ids in the database. (#2557)
 
 ### Additions
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Changes since v2.16
 - Searching for applications by the original REMS generated id works, even if another id has been assigned. (#2564)
 - GA4GH Visa (output by the experimental /api/permissions API) timestamps are now in seconds, instead of milliseconds. (#2554)
 - The REMS `reset` command line command now works even when you have duplicate resource ids in the database. (#2557)
+  - In practice, this means that REMS will not recreate the unique constraint on resource ids, even when rolling back to old database schema versions.
 
 ### Additions
 

--- a/resources/migrations/20190103155509-unique-resid.down.sql
+++ b/resources/migrations/20190103155509-unique-resid.down.sql
@@ -1,1 +1,1 @@
-drop index resource_resid_u;
+drop index if exists resource_resid_u;

--- a/resources/migrations/20191010114000-drop-start-end-from-form-template-resource-workflow.down.sql
+++ b/resources/migrations/20191010114000-drop-start-end-from-form-template-resource-workflow.down.sql
@@ -10,6 +10,7 @@ ALTER TABLE form_template
 ADD COLUMN start timestamp with time zone NOT NULL DEFAULT CURRENT_TIMESTAMP,
 ADD COLUMN endt timestamp with time zone NULL DEFAULT NULL;
 --;;
-DROP INDEX resource_resid_u;
+DROP INDEX IF EXISTS resource_resid_u;
 --;;
-CREATE UNIQUE INDEX resource_resid_u ON resource (organization, resid, coalesce(endt, '10000-01-01'));
+-- We used to create a better resource_resid_u constraint here, but don't anymore.
+-- See rationale in 20200204064800-drop-unique-resid.down.sql

--- a/resources/migrations/20200204064800-drop-unique-resid.down.sql
+++ b/resources/migrations/20200204064800-drop-unique-resid.down.sql
@@ -1,2 +1,3 @@
--- NB! this might fail if db contains duplicate resids.
-CREATE UNIQUE INDEX resource_resid_u ON resource (organization, resid);
+-- We can't recreate the unique constraint since it would fail if the db contains duplicate resources.
+-- We basically can't support rolling back this migration in general.
+-- Luckily nothing really breaks if the constraint is missing.


### PR DESCRIPTION
... in down migrations.

This is so that we can run a `lein reset` even after adding multiple
resources with the same resid.

This is fine becuase a) we don't really support or need to rollback to
versions from 2019 and b) the code for those versions actually works
fine even without the unique constraint in the db.

fixes #2557

# Checklist for author

Remove items that aren't applicable, check items that are done.

## Reviewability
- [x] Link to issue

## Documentation
- [x] Update changelog if necessary