### PR TITLE
refactor: move organization schemas to rems.schema-base

### DIFF
--- a/docs/architecture/012-layers.md
+++ b/docs/architecture/012-layers.md
@@ -136,7 +136,7 @@ when they are shared.
 
 In particular:
 
-- `rems.api.schema` should only be used from `rems.api.*` namespaces. It should be used for common schema fragments that many APIs share. Also big or importat schemas can live in `rems.api.schema` for discoverability.
+- `rems.api.schema` should only be used from `rems.api.*` namespaces. It should be used for common schema fragments that many APIs share. Also big or important schemas can live in `rems.api.schema` for discoverability.
 - `rems.api.*` namespaces that define APIs can also contain schemas for those APIs, if the schemas don't need to be shared.
 - `rems.schema-base` contains common schemas that can be used everywhere.
 - `rems.schema-base` and `rems.api.schema` shouldn't depend on any api, db or service components.

--- a/docs/architecture/012-layers.md
+++ b/docs/architecture/012-layers.md
@@ -124,3 +124,20 @@ Notable pieces of code that don't fit into the API-Services-DB layering (and don
 - Database migrations (`rems.migrations.*`)
 - Supporting API implementation like `rems.auth.*`, `rems.middleware`
   etc.
+
+## Amendment: Schemas
+
+Date: 2021-02-15
+Authors: @opqdonut @Macroz
+
+This layering should also apply to schemas. We want to make it
+possible to separate DB schemas from API schemas, and make it apparent
+when they are shared.
+
+In particular:
+
+- `rems.api.schema` should only be used from `rems.api.*` namespaces. It should be used for common schema fragments that many APIs share. Also big or importat schemas can live in `rems.api.schema` for discoverability.
+- `rems.api.*` namespaces that define APIs can also contain schemas for those APIs, if the schemas don't need to be shared.
+- `rems.schema-base` contains common schemas that can be used everywhere.
+- `rems.schema-base` and `rems.api.schema` shouldn't depend on any api, db or service components.
+- Schemas used for JSON in the DB should be in `rems.schema-base` or the `rems.db.*` namespace for that feature.

--- a/src/clj/rems/api/applications.clj
+++ b/src/clj/rems/api/applications.clj
@@ -21,6 +21,7 @@
             [rems.db.users :as users]
             [rems.experimental.pdf :as experimental-pdf]
             [rems.pdf :as pdf]
+            [rems.schema-base :as schema-base]
             [rems.text :refer [with-language]]
             [rems.util :refer [getx-user-id update-present]]
             [ring.middleware.multipart-params :as multipart]
@@ -39,16 +40,16 @@
          (s/optional-key :application-id) s/Int))
 
 (s/defschema Applicant
-  schema/UserWithAttributes)
+  schema-base/UserWithAttributes)
 
 (s/defschema Reviewer
-  schema/UserWithAttributes)
+  schema-base/UserWithAttributes)
 
 (s/defschema Reviewers
   [Reviewer])
 
 (s/defschema Decider
-  schema/UserWithAttributes)
+  schema-base/UserWithAttributes)
 
 (s/defschema Deciders
   [Decider])

--- a/src/clj/rems/api/blacklist.clj
+++ b/src/clj/rems/api/blacklist.clj
@@ -22,7 +22,7 @@
 (s/defschema BlacklistEntryWithDetails
   (assoc schema/BlacklistEntry
          :blacklist/comment s/Str
-         :blacklist/added-by schema/UserWithAttributes
+         :blacklist/added-by schema-base/UserWithAttributes
          :blacklist/added-at DateTime))
 
 (defn- format-blacklist-entry [entry]
@@ -50,7 +50,7 @@
     (GET "/users" []
       :summary "Existing REMS users available for adding to the blacklist"
       :roles  #{:owner :handler}
-      :return [schema/UserWithAttributes]
+      :return [schema-base/UserWithAttributes]
       (ok (users/get-users)))
 
     ;; TODO write access to blacklist for organization-owner

--- a/src/clj/rems/api/catalogue_items.clj
+++ b/src/clj/rems/api/catalogue_items.clj
@@ -6,6 +6,7 @@
             [rems.api.util :refer [not-found-json-response check-user]] ; required for route :roles
             [rems.common.roles :refer [+admin-write-roles+]]
             [rems.db.core :as db]
+            [rems.schema-base :as schema-base]
             [ring.swagger.json-schema :as rjs]
             [ring.util.http-response :refer :all]
             [schema.core :as s]))
@@ -19,7 +20,7 @@
    (s/optional-key :infourl) (s/maybe s/Str)})
 
 (s/defschema WriteCatalogueItemLocalizations
-  (rjs/field {schema/Language CatalogueItemLocalization}
+  (rjs/field {schema-base/Language CatalogueItemLocalization}
              {:description "Localizations keyed by language"
               :example {:fi {:title "Title in Finnish"
                              :infourl "http://example.fi"}
@@ -32,14 +33,14 @@
   {:form s/Int
    :resid s/Int
    :wfid s/Int
-   :organization schema/OrganizationId
+   :organization schema-base/OrganizationId
    :localizations WriteCatalogueItemLocalizations
    (s/optional-key :enabled) s/Bool
    (s/optional-key :archived) s/Bool})
 
 (s/defschema EditCatalogueItemCommand
   {:id s/Int
-   (s/optional-key :organization) schema/OrganizationId
+   (s/optional-key :organization) schema-base/OrganizationId
    :localizations WriteCatalogueItemLocalizations})
 
 (s/defschema CreateCatalogueItemResponse

--- a/src/clj/rems/api/forms.clj
+++ b/src/clj/rems/api/forms.clj
@@ -4,6 +4,7 @@
             [rems.api.schema :as schema]
             [rems.api.util :refer [not-found-json-response]] ; required for route :roles
             [rems.common.roles :refer [+admin-read-roles+ +admin-write-roles+]]
+            [rems.schema-base :as schema-base]
             [rems.util :refer [getx-user-id]]
             [ring.util.http-response :refer :all]
             [schema.core :as s]))
@@ -14,7 +15,7 @@
      (select-keys form [:form/id :organization :form/title :form/errors :enabled :archived]))))
 
 (s/defschema CreateFormCommand
-  {:organization schema/OrganizationId
+  {:organization schema-base/OrganizationId
    :form/title s/Str
    :form/fields [schema/NewFieldTemplate]})
 

--- a/src/clj/rems/api/licenses.clj
+++ b/src/clj/rems/api/licenses.clj
@@ -5,6 +5,7 @@
             [rems.api.services.licenses :as licenses]
             [rems.api.util :refer [not-found-json-response]] ; required for route :roles
             [rems.common.roles :refer [+admin-read-roles+ +admin-write-roles+]]
+            [rems.schema-base :as schema-base]
             [rems.util :refer [getx-user-id]]
             [ring.middleware.multipart-params :as multipart]
             [ring.swagger.json-schema :as rjs]
@@ -18,7 +19,7 @@
    (s/optional-key :attachment-id) (rjs/describe (s/maybe s/Int) "For licenses of type attachment")})
 
 (s/defschema LicenseLocalizations
-  (rjs/field {schema/Language LicenseLocalization}
+  (rjs/field {schema-base/Language LicenseLocalization}
              {:description "Licence localizations keyed by language"
               :example {:en {:title "English title"
                              :textcontent "English content"}
@@ -27,7 +28,7 @@
 
 (s/defschema CreateLicenseCommand
   {:licensetype (s/enum "link" "text" "attachment")
-   :organization schema/OrganizationId
+   :organization schema-base/OrganizationId
    :localizations LicenseLocalizations})
 
 (s/defschema AttachmentMetadata

--- a/src/clj/rems/api/organizations.clj
+++ b/src/clj/rems/api/organizations.clj
@@ -9,7 +9,7 @@
             [schema.core :as s]))
 
 (s/defschema CreateOrganizationCommand
-  (-> schema/OrganizationFull
+  (-> schema-base/OrganizationFull
       (dissoc :organization/modifier
               :organization/last-modifier)
       (assoc (s/optional-key :organization/owners) [schema-base/User])))
@@ -27,7 +27,7 @@
    (s/optional-key :errors) [s/Any]})
 
 ;; TODO: deduplicate or decouple with /api/applications/reviewers API?
-(s/defschema AvailableOwner schema/UserWithAttributes)
+(s/defschema AvailableOwner schema-base/UserWithAttributes)
 (s/defschema AvailableOwners [AvailableOwner])
 
 (def organizations-api
@@ -40,7 +40,7 @@
       :query-params [{owner :- (describe s/Str "return only organizations that are owned by owner") nil}
                      {disabled :- (describe s/Bool "whether to include disabled organizations") false}
                      {archived :- (describe s/Bool "whether to include archived organizations") false}]
-      :return [schema/OrganizationFull]
+      :return [schema-base/OrganizationFull]
       (ok (organizations/get-organizations (merge {:userid (getx-user-id)
                                                    :owner owner}
                                                   (when-not disabled {:enabled true})
@@ -85,7 +85,7 @@
       :summary "Get an organization. Returns more information for owners and handlers."
       :roles #{:logged-in}
       :path-params [organization-id :- (describe s/Str "organization id")]
-      :return schema/OrganizationFull
+      :return schema-base/OrganizationFull
       (if-let [org (organizations/get-organization (getx-user-id) {:organization/id organization-id})]
         (ok org)
         (not-found-json-response)))))

--- a/src/clj/rems/api/resources.clj
+++ b/src/clj/rems/api/resources.clj
@@ -4,6 +4,7 @@
             [rems.api.services.resource :as resource]
             [rems.api.util :refer [not-found-json-response]] ; required for route :roles
             [rems.common.roles :refer [+admin-read-roles+ +admin-write-roles+]]
+            [rems.schema-base :as schema-base]
             [rems.util :refer [getx-user-id]]
             [ring.util.http-response :refer :all]
             [schema.core :as s]))
@@ -13,7 +14,7 @@
   {:id s/Int
    :owneruserid s/Str
    :modifieruserid s/Str
-   :organization schema/OrganizationOverview
+   :organization schema-base/OrganizationOverview
    :resid s/Str
    :enabled s/Bool
    :archived s/Bool
@@ -24,7 +25,7 @@
 
 (s/defschema CreateResourceCommand
   {:resid s/Str
-   :organization schema/OrganizationId
+   :organization schema-base/OrganizationId
    :licenses [s/Int]})
 
 (s/defschema CreateResourceResponse

--- a/src/clj/rems/api/schema.clj
+++ b/src/clj/rems/api/schema.clj
@@ -6,49 +6,6 @@
             [schema.core :as s])
   (:import (org.joda.time DateTime)))
 
-(s/defschema Language
-  (rjs/field s/Keyword
-             {:description "A language code"
-              :example "en"}))
-
-(s/defschema LocalizedString
-  (rjs/field {Language s/Str}
-             {:example {:fi "text in Finnish"
-                        :en "text in English"}
-              :description "Text values keyed by languages"}))
-
-(s/defschema LocalizedInt
-  (rjs/field {Language s/Int}
-             {:example {:fi 1
-                        :en 2}
-              :description "Integers keyed by languages"}))
-
-(s/defschema OrganizationId {:organization/id s/Str})
-
-(s/defschema UserWithAttributes
-  {:userid schema-base/UserId
-   :name (s/maybe s/Str)
-   :email (s/maybe s/Str)
-   (s/optional-key :organizations) [OrganizationId]
-   (s/optional-key :notification-email) (s/maybe s/Str)
-   (s/optional-key :researcher-status-by) s/Str
-   s/Keyword s/Any})
-
-(s/defschema OrganizationOverview
-  (merge OrganizationId
-         {:organization/short-name LocalizedString
-          :organization/name LocalizedString}))
-
-(s/defschema OrganizationFull
-  (merge OrganizationOverview
-         {(s/optional-key :organization/modifier) UserWithAttributes
-          (s/optional-key :organization/last-modified) DateTime
-          (s/optional-key :organization/owners) [UserWithAttributes]
-          (s/optional-key :organization/review-emails) [{:name LocalizedString
-                                                         :email s/Str}]
-          (s/optional-key :enabled) s/Bool
-          (s/optional-key :archived) s/Bool}))
-
 (s/defschema CatalogueItemLocalizations
   {s/Keyword {;; TODO :id (it's the catalogue item id) and :langcode
               ;; fields are redundant. If we remove them we can reuse
@@ -67,7 +24,7 @@
    (s/optional-key :form-name) s/Str
    :resid s/Str
    :resource-id s/Int
-   :organization OrganizationOverview
+   :organization schema-base/OrganizationOverview
    (s/optional-key :resource-name) s/Str
    :start DateTime
    :end (s/maybe DateTime)
@@ -79,7 +36,7 @@
 (s/defschema License
   {:id s/Int
    :licensetype (s/enum "text" "link" "attachment")
-   :organization OrganizationOverview
+   :organization schema-base/OrganizationOverview
    :enabled s/Bool
    :archived s/Bool
    :localizations {s/Keyword {:title s/Str
@@ -93,12 +50,12 @@
 
 (s/defschema Event
   (assoc schema-base/EventBase
-         :event/actor-attributes UserWithAttributes
+         :event/actor-attributes schema-base/UserWithAttributes
          s/Keyword s/Any))
 
 (s/defschema Entitlement
   {:resource s/Str
-   :user UserWithAttributes
+   :user schema-base/UserWithAttributes
    :application-id s/Int
    :start DateTime
    :end (s/maybe DateTime)
@@ -122,11 +79,11 @@
    :archived s/Bool})
 
 (s/defschema OrganizationEnabledCommand
-  (merge OrganizationId
+  (merge schema-base/OrganizationId
          {:enabled s/Bool}))
 
 (s/defschema OrganizationArchivedCommand
-  (merge OrganizationId
+  (merge schema-base/OrganizationId
          {:archived s/Bool}))
 
 (s/defschema SuccessResponse
@@ -137,8 +94,8 @@
   {:resource/id s/Int
    :resource/ext-id s/Str
    :catalogue-item/id s/Int
-   :catalogue-item/title LocalizedString
-   :catalogue-item/infourl LocalizedString
+   :catalogue-item/title schema-base/LocalizedString
+   :catalogue-item/infourl schema-base/LocalizedString
    :catalogue-item/start DateTime
    :catalogue-item/end (s/maybe DateTime)
    :catalogue-item/enabled s/Bool
@@ -148,17 +105,17 @@
 (s/defschema V2License
   {:license/id s/Int
    :license/type (s/enum :text :link :attachment)
-   :license/title LocalizedString
-   (s/optional-key :license/link) LocalizedString
-   (s/optional-key :license/text) LocalizedString
-   (s/optional-key :license/attachment-id) LocalizedInt
-   (s/optional-key :license/attachment-filename) LocalizedString
+   :license/title schema-base/LocalizedString
+   (s/optional-key :license/link) schema-base/LocalizedString
+   (s/optional-key :license/text) schema-base/LocalizedString
+   (s/optional-key :license/attachment-id) schema-base/LocalizedInt
+   (s/optional-key :license/attachment-filename) schema-base/LocalizedString
    :license/enabled s/Bool
    :license/archived s/Bool})
 
 (s/defschema Workflow
   {:id s/Int
-   :organization OrganizationOverview
+   :organization schema-base/OrganizationOverview
    :owneruserid schema-base/UserId
    :modifieruserid schema-base/UserId
    :title s/Str
@@ -173,13 +130,13 @@
 (s/defschema FieldTemplate
   {:field/id schema-base/FieldId
    :field/type (s/enum :attachment :date :description :email :header :label :multiselect :option :text :texta :table)
-   :field/title LocalizedString
-   (s/optional-key :field/placeholder) LocalizedString
+   :field/title schema-base/LocalizedString
+   (s/optional-key :field/placeholder) schema-base/LocalizedString
    :field/optional s/Bool
    (s/optional-key :field/options) [{:key s/Str
-                                     :label LocalizedString}]
+                                     :label schema-base/LocalizedString}]
    (s/optional-key :field/columns) [{:key s/Str
-                                     :label LocalizedString}]
+                                     :label schema-base/LocalizedString}]
    (s/optional-key :field/max-length) (s/maybe (s/constrained s/Int not-neg?))
    (s/optional-key :field/privacy) (rjs/field
                                     (s/enum :public :private)
@@ -189,7 +146,7 @@
                                         (s/optional-key :visibility/field) {:field/id schema-base/FieldId}
                                         (s/optional-key :visibility/values) [s/Str]}
                                        {:description "Always visible by default"})
-   (s/optional-key :field/info-text) LocalizedString})
+   (s/optional-key :field/info-text) schema-base/LocalizedString})
 
 (s/defschema NewFieldTemplate
   (-> FieldTemplate
@@ -205,7 +162,7 @@
 
 (s/defschema FormTemplate
   {:form/id s/Int
-   :organization OrganizationOverview
+   :organization schema-base/OrganizationOverview
    :form/title s/Str
    :form/fields [FieldTemplate]
    (s/optional-key :form/errors) (s/maybe {(s/optional-key :organization) s/Any
@@ -230,14 +187,14 @@
    :attachment/type s/Str})
 
 (s/defschema BlacklistEntry
-  {:blacklist/user UserWithAttributes
+  {:blacklist/user schema-base/UserWithAttributes
    :blacklist/resource {:resource/ext-id s/Str}})
 
 (s/defschema Blacklist
   [BlacklistEntry])
 
 (s/defschema Handler
-  (assoc UserWithAttributes
+  (assoc schema-base/UserWithAttributes
          (s/optional-key :handler/active?) s/Bool))
 
 (s/defschema Permissions
@@ -267,8 +224,8 @@
    (s/optional-key :application/copied-to) [{:application/id s/Int
                                              :application/external-id s/Str}]
    :application/last-activity DateTime
-   :application/applicant UserWithAttributes
-   :application/members #{UserWithAttributes}
+   :application/applicant schema-base/UserWithAttributes
+   :application/members #{schema-base/UserWithAttributes}
    :application/invited-members #{{:name s/Str
                                    :email s/Str}}
    (s/optional-key :application/blacklist) (rjs/field

--- a/src/clj/rems/api/users.clj
+++ b/src/clj/rems/api/users.clj
@@ -15,7 +15,7 @@
   {:userid schema-base/UserId
    :name (s/maybe s/Str)
    :email (s/maybe s/Str)
-   (s/optional-key :organizations) [schema/OrganizationId]
+   (s/optional-key :organizations) [schema-base/OrganizationId]
    s/Keyword s/Any})
 
 (def users-api
@@ -33,5 +33,5 @@
     (GET "/active" []
       :summary "List active users"
       :roles #{:owner}
-      :return [schema/UserWithAttributes]
+      :return [schema-base/UserWithAttributes]
       (ok (middleware/get-active-users)))))

--- a/src/clj/rems/api/workflows.clj
+++ b/src/clj/rems/api/workflows.clj
@@ -11,7 +11,7 @@
             [schema.core :as s]))
 
 (s/defschema CreateWorkflowCommand
-  {:organization schema/OrganizationId
+  {:organization schema-base/OrganizationId
    :title s/Str
    (s/optional-key :forms) [{:form/id s/Int}]
    :type (apply s/enum events/workflow-types) ; TODO: exclude master workflow?
@@ -19,7 +19,7 @@
 
 (s/defschema EditWorkflowCommand
   {:id s/Int
-   (s/optional-key :organization) schema/OrganizationId
+   (s/optional-key :organization) schema-base/OrganizationId
    ;; type can't change
    (s/optional-key :title) s/Str
    (s/optional-key :handlers) [schema-base/UserId]})
@@ -30,7 +30,7 @@
    (s/optional-key :errors) [s/Any]})
 
 ; TODO: deduplicate or decouple with /api/applications/reviewers API?
-(s/defschema AvailableActor schema/UserWithAttributes)
+(s/defschema AvailableActor schema-base/UserWithAttributes)
 (s/defschema AvailableActors [AvailableActor])
 
 (def workflows-api

--- a/src/clj/rems/db/organizations.clj
+++ b/src/clj/rems/db/organizations.clj
@@ -1,9 +1,9 @@
 (ns rems.db.organizations
   (:require [medley.core :refer [update-existing]]
-            [rems.api.schema :as schema]
             [rems.db.core :as db]
             [rems.json :as json]
             [rems.db.users :as users]
+            [rems.schema-base :as schema-base]
             [schema.coerce :as coerce]
             [clj-time.core :as time-core])
   (:import [org.joda.time DateTime]
@@ -21,10 +21,10 @@
                                                               (dissoc :organization/id)))})))
 
 (def ^:private coerce-organization-overview
-  (coerce/coercer! schema/OrganizationOverview json/coercion-matcher))
+  (coerce/coercer! schema-base/OrganizationOverview json/coercion-matcher))
 
 (def ^:private coerce-organization-full
-  (coerce/coercer! schema/OrganizationFull json/coercion-matcher))
+  (coerce/coercer! schema-base/OrganizationFull json/coercion-matcher))
 
 (defn- parse-organization [raw]
   (merge

--- a/src/clj/rems/db/user_settings.clj
+++ b/src/clj/rems/db/user_settings.clj
@@ -12,6 +12,7 @@
   {:language (:default-language env)
    :notification-email nil})
 
+;; TODO should this be in schema-base?
 (s/defschema UserSettings
   {:language s/Keyword
    :notification-email (s/maybe s/Str)})

--- a/src/clj/rems/schema_base.clj
+++ b/src/clj/rems/schema_base.clj
@@ -16,6 +16,25 @@
 
 (def FormId s/Int)
 
+(s/defschema OrganizationId {:organization/id s/Str})
+
+(s/defschema Language
+  (rjs/field s/Keyword
+             {:description "A language code"
+              :example "en"}))
+
+(s/defschema LocalizedString
+  (rjs/field {Language s/Str}
+             {:example {:fi "text in Finnish"
+                        :en "text in English"}
+              :description "Text values keyed by languages"}))
+
+(s/defschema LocalizedInt
+  (rjs/field {Language s/Int}
+             {:example {:fi 1
+                        :en 2}
+              :description "Integers keyed by languages"}))
+
 ;; cond-pre generates a x-oneOf schema, which is
 ;; correct, but swagger-ui doesn't render it. We would need
 ;; to switch from Swagger 2.0 specs to OpenAPI 3 specs to get
@@ -35,3 +54,27 @@
    :event/time DateTime
    :event/actor UserId
    :application/id s/Int})
+
+(s/defschema UserWithAttributes
+  {:userid UserId
+   :name (s/maybe s/Str)
+   :email (s/maybe s/Str)
+   (s/optional-key :organizations) [OrganizationId]
+   (s/optional-key :notification-email) (s/maybe s/Str)
+   (s/optional-key :researcher-status-by) s/Str
+   s/Keyword s/Any})
+
+(s/defschema OrganizationOverview
+  (merge OrganizationId
+         {:organization/short-name LocalizedString
+          :organization/name LocalizedString}))
+
+(s/defschema OrganizationFull
+  (merge OrganizationOverview
+         {(s/optional-key :organization/modifier) UserWithAttributes
+          (s/optional-key :organization/last-modified) DateTime
+          (s/optional-key :organization/owners) [UserWithAttributes]
+          (s/optional-key :organization/review-emails) [{:name LocalizedString
+                                                         :email s/Str}]
+          (s/optional-key :enabled) s/Bool
+          (s/optional-key :archived) s/Bool}))


### PR DESCRIPTION
to avoid depending on rems.api.schema from rems.db.*

follow-up to #2559

# Checklist for author

Remove items that aren't applicable, check items that are done.

## Reviewability
- [ ] Link to issue

## Backwards compatibility
- [x] API is backwards compatible or completely new
- [x] Events are backwards compatible _or_ have migrations

## Documentation
- [x] ADR for major architectural decisions or experiments

## Testing
- [x] Valuable features are integration / browser / acceptance tested automatically