### PR TITLE
require at least one column/option when creating field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Changes since v2.16
 - GA4GH Visa (output by the experimental /api/permissions API) timestamps are now in seconds, instead of milliseconds. (#2554)
 - The REMS `reset` command line command now works even when you have duplicate resource ids in the database. (#2557)
   - In practice, this means that REMS will not recreate the unique constraint on resource ids, even when rolling back to old database schema versions.
+- The form editor now checks that table, option and multiselect fields are created with at least one column/option. (#2564)
 
 ### Additions
 

--- a/resources/translations/en.edn
+++ b/resources/translations/en.edn
@@ -433,6 +433,7 @@
                       :invalid-email "Invalid email address."
                       :invalid-user "Invalid user."
                       :invalid-value "Invalid value."
+                      :options-required "At least one option is required."
                       :required "Field \"%1\" is required."
                       :toolong "Text in field \"%1\" too long."
                       :unsupported "Field \"%1\" is not supported."}}

--- a/resources/translations/en.edn
+++ b/resources/translations/en.edn
@@ -429,6 +429,7 @@
          :upload-extensions "Allowed file types"
          ;; %1 - field name
          :validation {:column-values-missing "All columns must have values."
+                      :columns-required "At least one column is required."
                       :invalid-email "Invalid email address."
                       :invalid-user "Invalid user."
                       :invalid-value "Invalid value."

--- a/resources/translations/fi.edn
+++ b/resources/translations/fi.edn
@@ -390,6 +390,7 @@
                       :invalid-email "Sähköpostiosoite ei kelpaa."
                       :invalid-user "Käyttäjä ei kelpaa."
                       :invalid-value "Arvo ei kelpaa."
+                      :options-required "Vähintään yksi vaihtoehto vaaditaan."
                       :required "Kenttä \"%1\" on pakollinen."
                       :toolong "Kentän \"%1\" sisältö on liian pitkä."
                       :unsupported "Field \"%1\" is not supported."}}

--- a/resources/translations/fi.edn
+++ b/resources/translations/fi.edn
@@ -386,6 +386,7 @@
          :upload "Lisää liitetiedosto"
          :upload-extensions "Sallitut tiedostomuodot"
          :validation {:column-values-missing "Kaikki sarakkeet on täytettävä."
+                      :columns-required "Vähintään yksi sarake vaaditaan."
                       :invalid-email "Sähköpostiosoite ei kelpaa."
                       :invalid-user "Käyttäjä ei kelpaa."
                       :invalid-value "Arvo ei kelpaa."

--- a/resources/translations/sv.edn
+++ b/resources/translations/sv.edn
@@ -390,6 +390,7 @@
                       :invalid-email "Ogiltig e-postadress."
                       :invalid-user "Ogiltig användare."
                       :invalid-value "Ogiltigt värde."
+                      :options-required "Kräv minst ett alternativ." ; TODO check
                       :required " \"%1\" är ett obligatoriskt fält."
                       :toolong "För långt innehåll i fält \"%1\"."
                       :unsupported "Field \"%1\" is not supported."}}

--- a/resources/translations/sv.edn
+++ b/resources/translations/sv.edn
@@ -386,6 +386,7 @@
          :upload "Lägg till bilaga"
          :upload-extensions "Tillåtna filtyper"
          :validation {:column-values-missing "Alla kolumner måste fyllas i."
+                      :columns-required "Kräv minst en kolumn." ; TODO check
                       :invalid-email "Ogiltig e-postadress."
                       :invalid-user "Ogiltig användare."
                       :invalid-value "Ogiltigt värde."

--- a/src/cljc/rems/common/form.cljc
+++ b/src/cljc/rems/common/form.cljc
@@ -153,9 +153,12 @@
 (defn- validate-options [options languages]
   {:field/options (apply merge (mapv #(validate-option %1 %2 languages) options (range)))})
 
-(defn- validate-columns [options languages]
-  ;; columns have the same syntax as options for now
-  {:field/columns (apply merge (mapv #(validate-option %1 %2 languages) options (range)))})
+(defn- validate-columns [columns languages]
+  {:field/columns
+   (if (empty? columns)
+     :t.form.validation/columns-required
+     ;; columns have the same syntax as options for now
+     (apply merge (mapv #(validate-option %1 %2 languages) columns (range))))})
 
 (defn- field-option-keys [field]
   (set (map :key (:field/options field))))
@@ -396,6 +399,11 @@
                           :field/optional false}])]
         (testing "valid form"
           (is (empty? (validate-form-template form languages))))
+
+        (testing "missing columns"
+          (is (= {:form/fields {0 {:field/columns :t.form.validation/columns-required}}}
+                 (validate-form-template (assoc-in form [:form/fields 0 :field/columns] []) languages)
+                 (validate-form-template (update-in form [:form/fields 0] dissoc :field/columns) languages))))
 
         (testing "missing title localization"
           (is (= {:form/fields {0 {:field/title {:en :t.form.validation/required}}}}

--- a/src/cljc/rems/common/form.cljc
+++ b/src/cljc/rems/common/form.cljc
@@ -151,7 +151,10 @@
              (validate-localized-text-field option :label languages))})
 
 (defn- validate-options [options languages]
-  {:field/options (apply merge (mapv #(validate-option %1 %2 languages) options (range)))})
+  {:field/options
+   (if (empty? options)
+     :t.form.validation/options-required
+     (apply merge (mapv #(validate-option %1 %2 languages) options (range))))})
 
 (defn- validate-columns [columns languages]
   {:field/columns
@@ -348,6 +351,11 @@
         (testing "valid form"
           (is (empty? (validate-form-template form languages))))
 
+        (testing "missing options"
+          (is (= {:form/fields {0 {:field/options :t.form.validation/options-required}}}
+                 (validate-form-template (assoc-in form [:form/fields 0 :field/options] []) languages)
+                 (validate-form-template (update-in form [:form/fields 0] dissoc :field/options) languages))))
+
         (testing "missing option key"
           (is (= {:form/fields {0 {:field/options {0 {:key :t.form.validation/required}}}}}
                  (validate-form-template (assoc-in form [:form/fields 0 :field/options 0 :key] "") languages)
@@ -374,6 +382,11 @@
                                                    :fi "Pekonia"}}]}])]
         (testing "valid form"
           (is (empty? (validate-form-template form languages))))
+
+        (testing "missing options"
+          (is (= {:form/fields {0 {:field/options :t.form.validation/options-required}}}
+                 (validate-form-template (assoc-in form [:form/fields 0 :field/options] []) languages)
+                 (validate-form-template (update-in form [:form/fields 0] dissoc :field/options) languages))))
 
         (testing "missing option key"
           (is (= {:form/fields {0 {:field/options {0 {:key :t.form.validation/required}}}}}

--- a/src/cljs/rems/administration/create_form.cljs
+++ b/src/cljs/rems/administration/create_form.cljs
@@ -300,6 +300,7 @@
 
 (defn- add-form-field-option-button [field-index]
   [:a.add-option {:href "#"
+                  :id (str "fields-" field-index "-add-option")
                   :on-click (fn [event]
                               (.preventDefault event)
                               (rf/dispatch [::add-form-field-option field-index]))}
@@ -590,17 +591,21 @@
             (when (-> field-errors :field/visibility :visibility/values)
               [(format-validation-link (str "fields-" field-index "-visibility-value")
                                        (str (text :t.create-form/type-visibility) ": " (text-format (-> field-errors :field/visibility :visibility/values) (text :t.create-form.visibility/has-value))))])
-            (for [[option-id option-errors] (into (sorted-map) (:field/options field-errors))]
-              [:li (text-format :t.create-form/option-n (inc option-id))
-               [:ul
-                (when (:key option-errors)
-                  (format-validation-link (str "fields-" field-index "-options-" option-id "-key")
-                                          (text-format (:key option-errors) (text :t.create-form/option-key))))
-                (into [:<>]
-                      (for [[lang error] (:label option-errors)]
-                        (format-validation-link (str "fields-" field-index "-options-" option-id "-label-" (name lang))
-                                                (text-format error (str (text :t.create-form/option-label)
-                                                                        " (" (.toUpperCase (name lang)) ")")))))]])
+            (if (= :t.form.validation/options-required (:field/options field-errors))
+              [[:li
+                [:a {:href "#" :on-click #(focus/focus-selector (str "#fields-" field-index "-add-option"))}
+                 (text :t.form.validation/options-required)]]]
+              (for [[option-id option-errors] (into (sorted-map) (:field/options field-errors))]
+                [:li (text-format :t.create-form/option-n (inc option-id))
+                 [:ul
+                  (when (:key option-errors)
+                    (format-validation-link (str "fields-" field-index "-options-" option-id "-key")
+                                            (text-format (:key option-errors) (text :t.create-form/option-key))))
+                  (into [:<>]
+                        (for [[lang error] (:label option-errors)]
+                          (format-validation-link (str "fields-" field-index "-options-" option-id "-label-" (name lang))
+                                                  (text-format error (str (text :t.create-form/option-label)
+                                                                          " (" (.toUpperCase (name lang)) ")")))))]]))
             (if (= :t.form.validation/columns-required (:field/columns field-errors))
               [[:li
                 [:a {:href "#" :on-click #(focus/focus-selector (str "#fields-" field-index "-add-column"))}

--- a/src/cljs/rems/administration/create_form.cljs
+++ b/src/cljs/rems/administration/create_form.cljs
@@ -598,6 +598,17 @@
                       (for [[lang error] (:label option-errors)]
                         (format-validation-link (str "fields-" field-index "-options-" option-id "-label-" (name lang))
                                                 (text-format error (str (text :t.create-form/option-label)
+                                                                        " (" (.toUpperCase (name lang)) ")")))))]])
+            (for [[column-id column-errors] (into (sorted-map) (:field/columns field-errors))]
+              [:li (text-format :t.create-form/column-n (inc column-id))
+               [:ul
+                (when (:key column-errors)
+                  (format-validation-link (str "fields-" field-index "-column-" column-id "-key")
+                                          (text-format (:key column-errors) (text :t.create-form/option-key))))
+                (into [:<>]
+                      (for [[lang error] (:label column-errors)]
+                        (format-validation-link (str "fields-" field-index "-column-" column-id "-label-" (name lang))
+                                                (text-format error (str (text :t.create-form/option-label)
                                                                         " (" (.toUpperCase (name lang)) ")")))))]])))]))
 
 (defn format-validation-errors [form-errors form lang]

--- a/src/cljs/rems/focus.cljs
+++ b/src/cljs/rems/focus.cljs
@@ -6,6 +6,9 @@
   (.setAttribute element "tabindex" "-1")
   (.focus element))
 
+(defn focus-selector [selector]
+  (focus (.querySelector js/document selector)))
+
 (defn focus-without-scroll [element]
   (.setAttribute element "tabindex" "-1")
   (.focus element (js-obj "preventScroll" true)))


### PR DESCRIPTION
fixes #2564

# Checklist for author

Remove items that aren't applicable, check items that are done.

## Reviewability
- [x] Link to issue
- [ ] Consider adding screenshots for ease of review

## Backwards compatibility
- [x] API is backwards compatible or completely new
  - create form errors aren't strictly backwards compatible, because
  you can get a keyword where you previously got a map, but we don't
  promise a schema for the validation errors

## Documentation
- [x] Update changelog if necessary

## Testing
- [x] Complex logic is unit tested
- [ ] Valuable features are integration / browser / acceptance tested automatically
  - not covered by form editor tests