### PR TITLE
Fix multiselect label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Changes since v2.16
 - The REMS `reset` command line command now works even when you have duplicate resource ids in the database. (#2557)
   - In practice, this means that REMS will not recreate the unique constraint on resource ids, even when rolling back to old database schema versions.
 - The form editor now checks that table, option and multiselect fields are created with at least one column/option. (#2564)
+- The multiselect field label wasn't being bolded.
 
 ### Additions
 

--- a/src/clj/rems/css/styles.clj
+++ b/src/clj/rems/css/styles.clj
@@ -703,7 +703,7 @@
    [:.form-group {:text-align "initial"}
     ;; make fieldset legends look the same as normal labels
     [:legend {:font-size "inherit"}]]
-   [:label.application-field-label {:font-weight "bold"}]
+   [:.application-field-label {:font-weight "bold"}]
    [:div.info-collapse {:font-weight "400"
                         :white-space :pre-wrap}]
 


### PR DESCRIPTION
The multiselect field label was not bolded correctly as the selector was too specific.

![bolded](https://user-images.githubusercontent.com/823661/108720080-09980a00-7529-11eb-8b0d-b347c5e4f6ed.png)

# Checklist for author

Remove items that aren't applicable, check items that are done.

## Reviewability
- [ ] Link to issue
- [x] Consider adding screenshots for ease of review

## Documentation
- [x] Update changelog if necessary
