### PR TITLE
fix: linkify to return nil for empty string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ Changes since v2.16
   - In practice, this means that REMS will not recreate the unique constraint on resource ids, even when rolling back to old database schema versions.
 - The form editor now checks that table, option and multiselect fields are created with at least one column/option. (#2564)
 - The multiselect field label wasn't being bolded.
+- Info text icon could appear even though the field description was empty.
 
 ### Additions
 

--- a/src/cljs/rems/util.cljs
+++ b/src/cljs/rems/util.cljs
@@ -150,7 +150,7 @@
   original string, except that all substrings that resemble a link have
   been changed to hiccup links."
   [s]
-  (when s
+  (when-not (str/blank? s)
     (let [splitted (-> s
                        (str/replace link-regex #(str "\t" %1 "\t"))
                        (str/split "\t"))

--- a/test/cljs/rems/test_util.cljs
+++ b/test/cljs/rems/test_util.cljs
@@ -66,4 +66,6 @@
       (is (= (linkify "(See www-page at www.abc.com.)")
              ["(See www-page at "
               [:a {:target :_blank :href "http://www.abc.com"} "www.abc.com"]
-              ".)"])))))
+              ".)"])))
+    (testing "returns nil for empty"
+      (is (= nil (linkify ""))))))


### PR DESCRIPTION
This also fixes info text icon appearing for empty field description.

# Checklist for author

Remove items that aren't applicable, check items that are done.

## Reviewability
- [ ] Link to issue
- [ ] Consider adding screenshots for ease of review

## Documentation
- [x] Update changelog if necessary

## Testing
- [x] Complex logic is unit tested
