### PR TITLE
more consistent organization-field

### DIFF
--- a/src/clj/rems/css/styles.clj
+++ b/src/clj/rems/css/styles.clj
@@ -706,6 +706,11 @@
    [:.application-field-label {:font-weight "bold"}]
    [:div.info-collapse {:font-weight "400"
                         :white-space :pre-wrap}]
+   ;; Bootstrap's has "display: none" on .invalid-feedback by default
+   ;; and overrides that for example when there is a sibling .form-control.is-invalid,
+   ;; but that doesn't work with checkbox groups, dropdowns, etc., and we anyways
+   ;; don't need the feature of hiding this div with CSS when it has no content.
+   [:div.invalid-feedback {:display :block}]
 
    ;; custom checkbox
    [:.readonly-checkbox {:background-color "#ccc"}]

--- a/src/cljs/rems/administration/components.cljs
+++ b/src/cljs/rems/administration/components.cljs
@@ -16,7 +16,10 @@
   (:require [clojure.string :as str]
             [re-frame.core :as rf]
             [rems.atoms :refer [info-field textarea]]
-            [rems.text :refer [text-format]]))
+            [rems.dropdown :as dropdown]
+            [rems.fields :as fields]
+            [rems.common.roles :as roles]
+            [rems.text :refer [text text-format]]))
 
 (defn- key-to-id [key]
   (if (number? key)
@@ -29,7 +32,12 @@
        (str/join "-")))
 
 (defn- field-validation-message [error label]
-  [:div {:class "invalid-feedback"}
+  ;; XXX: Bootstrap's has "display: none" on .invalid-feedback by default
+  ;;      and overrides that for example when there is a sibling .form-control.is-invalid,
+  ;;      but that doesn't work with checkbox groups, dropdowns, etc., and we anyways
+  ;;      don't need the feature of hiding this div with CSS when it has no content.
+  [:div {:class "invalid-feedback"
+         :style {:display "block"}}
    (when error (text-format error label))])
 
 (defn input-field [{:keys [keys label placeholder context type normalizer readonly]}]
@@ -172,3 +180,28 @@
 
 (defn inline-info-field [text value & [opts]]
   [info-field text value (merge {:inline? true} opts)])
+
+(defn organization-field [context {:keys [keys readonly]}]
+  (let [label (text :t.administration/organization)
+        organizations @(rf/subscribe [:owned-organizations])
+        language @(rf/subscribe [:language])
+        form @(rf/subscribe [(:get-form context)])
+        value (get-in form keys)
+        form-errors (when (:get-form-errors context)
+                      @(rf/subscribe [(:get-form-errors context)]))
+        id (keys-to-id keys)
+        item-selected? #(= (:organization/id %) (:organization/id value))
+        disallowed (roles/disallow-setting-organization? @(rf/subscribe [:roles]))]
+    [:div.form-group
+     [:label {:for id} label]
+     (if (or readonly disallowed)
+       [fields/readonly-field {:id id
+                               :value (get-in value [:organization/name language])}]
+       [dropdown/dropdown
+        {:id id
+         :items (->> organizations (filter :enabled) (remove :archived))
+         :item-key :organization/id
+         :item-label (comp language :organization/name)
+         :item-selected? item-selected?
+         :on-change #(rf/dispatch [(:update-form context) keys %])}])
+     [field-validation-message (get-in form-errors keys) label]]))

--- a/src/cljs/rems/administration/components.cljs
+++ b/src/cljs/rems/administration/components.cljs
@@ -32,12 +32,7 @@
        (str/join "-")))
 
 (defn- field-validation-message [error label]
-  ;; XXX: Bootstrap's has "display: none" on .invalid-feedback by default
-  ;;      and overrides that for example when there is a sibling .form-control.is-invalid,
-  ;;      but that doesn't work with checkbox groups, dropdowns, etc., and we anyways
-  ;;      don't need the feature of hiding this div with CSS when it has no content.
-  [:div {:class "invalid-feedback"
-         :style {:display "block"}}
+  [:div {:class "invalid-feedback"}
    (when error (text-format error label))])
 
 (defn input-field [{:keys [keys label placeholder context type normalizer readonly]}]

--- a/src/cljs/rems/administration/create_catalogue_item.cljs
+++ b/src/cljs/rems/administration/create_catalogue_item.cljs
@@ -3,7 +3,7 @@
             [medley.core :refer [find-first map-vals]]
             [re-frame.core :as rf]
             [rems.administration.administration :as administration]
-            [rems.administration.components :refer [text-field]]
+            [rems.administration.components :refer [organization-field text-field]]
             [rems.atoms :as atoms :refer [document-title]]
             [rems.collapsible :as collapsible]
             [rems.dropdown :as dropdown]
@@ -140,18 +140,12 @@
   {:get-form ::form
    :update-form ::set-form-field})
 
-(def ^:private organization-dropdown-id "organization-dropdown")
 (def ^:private workflow-dropdown-id "workflow-dropdown")
 (def ^:private resource-dropdown-id "resource-dropdown")
 (def ^:private form-dropdown-id "form-dropdown")
 
-(rf/reg-sub ::selected-organization (fn [db _] (get-in db [::form :organization])))
-(rf/reg-event-db ::set-selected-organization (fn [db [_ organization]] (assoc-in db [::form :organization] organization)))
-
 (defn- catalogue-item-organization-field []
-  [fields/organization-field {:id "organization-dropdown"
-                              :value @(rf/subscribe [::selected-organization])
-                              :on-change #(rf/dispatch [::set-selected-organization %])}])
+  [organization-field context {:keys [:organization]}])
 
 (defn- catalogue-item-title-field [language]
   [text-field context {:keys [:title language]

--- a/src/cljs/rems/administration/create_form.cljs
+++ b/src/cljs/rems/administration/create_form.cljs
@@ -16,7 +16,7 @@
             [medley.core :refer [find-first]]
             [re-frame.core :as rf]
             [rems.administration.administration :as administration]
-            [rems.administration.components :refer [checkbox localized-text-field radio-button-group text-field]]
+            [rems.administration.components :refer [checkbox localized-text-field organization-field radio-button-group text-field]]
             [rems.administration.items :as items]
             [rems.atoms :as atoms :refer [document-title]]
             [rems.collapsible :as collapsible]
@@ -270,14 +270,8 @@
    :get-form-errors ::form-errors
    :update-form ::set-form-field})
 
-(rf/reg-sub ::selected-organization (fn [db _] (get-in db [::form :data :organization])))
-
-(rf/reg-event-db ::set-selected-organization (fn [db [_ organization]] (assoc-in db [::form :data :organization] organization)))
-
 (defn- form-organization-field []
-  [fields/organization-field {:id "organization-dropdown"
-                              :value @(rf/subscribe [::selected-organization])
-                              :on-change #(rf/dispatch [::set-selected-organization %])}])
+  [organization-field context {:keys [:organization]}])
 
 (defn- form-internal-name-field []
   [text-field context {:keys [:form/internal-name]
@@ -629,7 +623,7 @@
   ;; TODO: deduplicate with field definitions
   (into [:ul
          (when-let [error (:organization form-errors)]
-           (format-validation-link "organization-dropdown"
+           (format-validation-link "organization"
                                    (text-format error (text :t.administration/organization))))
 
          (when-let [error (:form/internal-name form-errors)]

--- a/src/cljs/rems/administration/create_license.cljs
+++ b/src/cljs/rems/administration/create_license.cljs
@@ -2,14 +2,10 @@
   (:require [clojure.string :as str]
             [re-frame.core :as rf]
             [rems.administration.administration :as administration]
-            [rems.administration.components :refer [radio-button-group text-field textarea-autosize]]
+            [rems.administration.components :refer [organization-field radio-button-group text-field textarea-autosize]]
             [rems.atoms :as atoms :refer [file-download document-title]]
             [rems.collapsible :as collapsible]
-            [rems.dropdown :as dropdown]
-            [rems.fields :as fields]
             [rems.flash-message :as flash-message]
-            [rems.common.roles :as roles]
-            [rems.spinner :as spinner]
             [rems.text :refer [text]]
             [rems.util :refer [navigate! post! trim-when-string]]))
 
@@ -112,14 +108,8 @@
 (defn- language-heading [language]
   [:h3 (str/upper-case (name language))])
 
-(rf/reg-sub ::selected-organization (fn [db _] (get-in db [::form :organization])))
-
-(rf/reg-event-db ::set-selected-organization (fn [db [_ organization]] (assoc-in db [::form :organization] organization)))
-
 (defn- license-organization-field []
-  [fields/organization-field {:id "organization-dropdown"
-                              :value @(rf/subscribe [::selected-organization])
-                              :on-change #(rf/dispatch [::set-selected-organization %])}])
+  [organization-field context {:keys [:organization]}])
 
 (defn- license-title-field [language]
   [text-field context {:keys [:localizations language :title]

--- a/src/cljs/rems/administration/create_organization.cljs
+++ b/src/cljs/rems/administration/create_organization.cljs
@@ -11,7 +11,6 @@
             [rems.config :as config]
             [rems.dropdown :as dropdown]
             [rems.fetcher :as fetcher]
-            [rems.fields :as fields]
             [rems.flash-message :as flash-message]
             [rems.spinner :as spinner]
             [rems.text :refer [text text-format]]
@@ -138,16 +137,6 @@
    :update-form ::set-form-field})
 
 (def ^:private owners-dropdown-id "owners-dropdown")
-
-(rf/reg-sub ::selected-organization (fn [db _] (get-in db [::form :organization])))
-
-(rf/reg-event-db ::set-selected-organization (fn [db [_ organization]] (assoc-in db [::form :organization] organization)))
-
-(defn- organization-organization-field []
-  [fields/organization-field {:id "organization-dropdown"
-                              :value @(rf/subscribe [::selected-organization])
-                              :readonly @(rf/subscribe [::editing?])
-                              :on-change #(rf/dispatch [::set-selected-organization %])}])
 
 (defn- organization-id-field []
   [text-field context {:keys [:organization/id]

--- a/src/cljs/rems/administration/create_resource.cljs
+++ b/src/cljs/rems/administration/create_resource.cljs
@@ -2,11 +2,10 @@
   (:require [clojure.string :as str]
             [re-frame.core :as rf]
             [rems.administration.administration :as administration]
-            [rems.administration.components :refer [text-field]]
+            [rems.administration.components :refer [organization-field text-field]]
             [rems.atoms :as atoms :refer [document-title]]
             [rems.collapsible :as collapsible]
             [rems.dropdown :as dropdown]
-            [rems.fields :as fields]
             [rems.fetcher :as fetcher]
             [rems.flash-message :as flash-message]
             [rems.spinner :as spinner]
@@ -62,14 +61,8 @@
 
 (def ^:private licenses-dropdown-id "licenses-dropdown")
 
-(rf/reg-sub ::selected-organization (fn [db _] (get-in db [::form :organization])))
-
-(rf/reg-event-db ::set-selected-organization (fn [db [_ organization]] (assoc-in db [::form :organization] organization)))
-
 (defn- resource-organization-field []
-  [fields/organization-field {:id "organization-dropdown"
-                              :value @(rf/subscribe [::selected-organization])
-                              :on-change #(rf/dispatch [::set-selected-organization %])}])
+  [organization-field context {:keys [:organization]}])
 
 (defn- resource-id-field []
   [text-field context {:keys [:resid]

--- a/src/cljs/rems/administration/create_workflow.cljs
+++ b/src/cljs/rems/administration/create_workflow.cljs
@@ -1,5 +1,6 @@
 (ns rems.administration.create-workflow
   (:require [clojure.string :as str]
+            [medley.core :as medley]
             [re-frame.core :as rf]
             [rems.administration.administration :as administration]
             [rems.administration.components :refer [radio-button-group text-field]]
@@ -15,7 +16,7 @@
             [rems.util :refer [navigate! post! put! trim-when-string]]))
 
 (defn- item-by-id [items id-key id]
-  (medley.core/find-first #(= (id-key %) id) items))
+  (medley/find-first #(= (id-key %) id) items))
 
 (rf/reg-event-fx
  ::enter-page

--- a/src/cljs/rems/administration/create_workflow.cljs
+++ b/src/cljs/rems/administration/create_workflow.cljs
@@ -1,6 +1,6 @@
 (ns rems.administration.create-workflow
   (:require [clojure.string :as str]
-            [medley.core :as medley]
+            [medley.core :refer [find-first]]
             [re-frame.core :as rf]
             [rems.administration.administration :as administration]
             [rems.administration.components :refer [organization-field radio-button-group text-field]]
@@ -16,7 +16,7 @@
             [rems.util :refer [navigate! post! put! trim-when-string]]))
 
 (defn- item-by-id [items id-key id]
-  (medley/find-first #(= (id-key %) id) items))
+  (find-first #(= (id-key %) id) items))
 
 (rf/reg-event-fx
  ::enter-page

--- a/src/cljs/rems/administration/create_workflow.cljs
+++ b/src/cljs/rems/administration/create_workflow.cljs
@@ -3,7 +3,7 @@
             [medley.core :as medley]
             [re-frame.core :as rf]
             [rems.administration.administration :as administration]
-            [rems.administration.components :refer [radio-button-group text-field]]
+            [rems.administration.components :refer [organization-field radio-button-group text-field]]
             [rems.atoms :as atoms :refer [enrich-user document-title]]
             [rems.collapsible :as collapsible]
             [rems.config :as config]
@@ -130,14 +130,8 @@
 
 (def ^:private handlers-dropdown-id "handlers-dropdown")
 
-(rf/reg-sub ::selected-organization (fn [db _] (get-in db [::form :organization])))
-
-(rf/reg-event-db ::set-selected-organization (fn [db [_ organization]] (assoc-in db [::form :organization] organization)))
-
 (defn- workflow-organization-field []
-  [fields/organization-field {:id "organization-dropdown"
-                              :value @(rf/subscribe [::selected-organization])
-                              :on-change #(rf/dispatch [::set-selected-organization %])}])
+  [organization-field context {:keys [:organization]}])
 
 (defn- workflow-title-field []
   [text-field context {:keys [:title]

--- a/src/cljs/rems/fields.cljs
+++ b/src/cljs/rems/fields.cljs
@@ -157,12 +157,7 @@
        :else editor-component)
      (when validation
        [:div.invalid-feedback
-        {:id (str (field-name opts) "-error")
-         ;; XXX: Bootstrap's has "display: none" on .invalid-feedback by default
-         ;;      and overrides that for example when there is a sibling .form-control.is-invalid,
-         ;;      but that doesn't work with checkbox groups nor attachments, and we anyways
-         ;;      don't need the feature of hiding this div with CSS when it has no content.
-         :style {:display "block"}}
+        {:id (str (field-name opts) "-error")}
         (text-format (:type validation) raw-title)])]))
 
 (defn- non-field-wrapper [opts children]

--- a/src/cljs/rems/fields.cljs
+++ b/src/cljs/rems/fields.cljs
@@ -1,13 +1,10 @@
 (ns rems.fields
   "UI components for form fields"
   (:require [clojure.string :as str]
-            [re-frame.core :as rf]
             [rems.administration.items :as items]
-            [rems.atoms :refer [add-symbol attachment-link close-symbol textarea success-symbol]]
+            [rems.atoms :refer [add-symbol attachment-link close-symbol textarea]]
             [rems.common.attachment-types :as attachment-types]
-            [rems.common.roles :as roles]
             [rems.common.util :refer [build-index getx]]
-            [rems.dropdown :as dropdown]
             [rems.guide-utils :refer [lipsum-short lipsum-paragraphs]]
             [rems.text :refer [localized text text-format]]
             [rems.util :refer [encode-option-keys decode-option-keys focus-when-collapse-opened linkify]])
@@ -374,24 +371,6 @@
 (defn header-field [opts]
   (let [title (localized (:field/title opts))]
     [non-field-wrapper opts [:h3 title]]))
-
-(defn organization-field [{:keys [id value on-change readonly]}]
-  (let [organizations @(rf/subscribe [:owned-organizations])
-        language @(rf/subscribe [:language])
-        item-selected? #(= (:organization/id %) (:organization/id value))
-        disallowed (roles/disallow-setting-organization? @(rf/subscribe [:roles]))]
-    [:div.form-group
-     [:label {:for id} (text :t.administration/organization)]
-     (if (or readonly disallowed)
-       [readonly-field {:id id
-                        :value (get-in value [:organization/name language])}]
-       [dropdown/dropdown
-        {:id id
-         :items (->> organizations (filter :enabled) (remove :archived))
-         :item-key :organization/id
-         :item-label (comp language :organization/name)
-         :item-selected? item-selected?
-         :on-change on-change}])]))
 
 (defn- table-view [{:keys [id readonly columns rows on-change]}]
   [:table.table.table-sm.table-borderless

--- a/src/cljs/rems/fields.cljs
+++ b/src/cljs/rems/fields.cljs
@@ -5,10 +5,10 @@
             [rems.administration.items :as items]
             [rems.atoms :refer [add-symbol attachment-link close-symbol textarea success-symbol]]
             [rems.common.attachment-types :as attachment-types]
+            [rems.common.roles :as roles]
             [rems.common.util :refer [build-index getx]]
             [rems.dropdown :as dropdown]
             [rems.guide-utils :refer [lipsum-short lipsum-paragraphs]]
-            [rems.common.roles :as roles]
             [rems.text :refer [localized text text-format]]
             [rems.util :refer [encode-option-keys decode-option-keys focus-when-collapse-opened linkify]])
   (:require-macros [rems.guide-macros :refer [component-info example]]))

--- a/test/clj/rems/test_browser.clj
+++ b/test/clj/rems/test_browser.clj
@@ -1484,7 +1484,7 @@
       (btu/wait-page-loaded)
       (btu/scroll-and-click :create-resource)
       (btu/wait-page-loaded)
-      (btu/wait-visible :organization-dropdown)
+      (btu/wait-visible :organization)
       (btu/fill-human :resid (str "resource for " (btu/context-get :organization-name)))
       (select-option* "Organization" (btu/context-get :organization-name))
       (btu/scroll-and-click :save)


### PR DESCRIPTION
a follow-up to #2579, related to #2578

- show validation errors next to field in create-form
- use rems.administration.components infrastructure

# Checklist for author

Remove items that aren't applicable, check items that are done.

## Reviewability
- [x] Link to issue

## Testing
- [x] Valuable features are integration / browser / acceptance tested automatically