### PR TITLE
feat: show previous assigned external id in assign external id ui

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Changes since v2.16
   - The external title is shown to applicants in the application and internal name used throughout the administration.
   - The API supports the old style for now.
 - Answers to conditional fields that are not visible are no longer stored by REMS. The API accepts answers for invisible fields but drops them. The UI does not send answers to invisible fields. (#2574)
+- The "Assign external id" action now shows the previous assigned external id. (#2530)
 
 ### Fixes
 - Searching for applications by the original REMS generated id works, even if another id has been assigned. (#2564)

--- a/src/cljs/rems/actions/assign_external_id.cljs
+++ b/src/cljs/rems/actions/assign_external_id.cljs
@@ -6,8 +6,8 @@
 
 (rf/reg-event-fx
  ::open-form
- (fn [{:keys [db]} _]
-   {:db (assoc db ::external-id "")}))
+ (fn [{:keys [db]} [_ initial-id]]
+   {:db (assoc db ::external-id initial-id)}))
 
 (rf/reg-sub ::external-id (fn [db _] (::external-id db)))
 (rf/reg-event-db ::set-external-id (fn [db [_ value]] (assoc db ::external-id value)))
@@ -25,10 +25,10 @@
               :on-finished on-finished})
    {}))
 
-(defn assign-external-id-button []
+(defn assign-external-id-button [initial-id]
   [action-button {:id action-form-id
                   :text (text :t.actions/assign-external-id)
-                  :on-click #(rf/dispatch [::open-form])}])
+                  :on-click #(rf/dispatch [::open-form initial-id])}])
 
 (defn assign-external-id-view
   [{:keys [external-id on-set-external-id on-send]}]

--- a/src/cljs/rems/actions/assign_external_id.cljs
+++ b/src/cljs/rems/actions/assign_external_id.cljs
@@ -2,7 +2,6 @@
   (:require [clojure.string :as str]
             [re-frame.core :as rf]
             [rems.actions.components :refer [action-button action-form-view button-wrapper command!]]
-            [rems.atoms :refer [textarea]]
             [rems.text :refer [text]]))
 
 (rf/reg-event-fx

--- a/src/cljs/rems/application.cljs
+++ b/src/cljs/rems/application.cljs
@@ -711,7 +711,7 @@
                               :application.command/reject [approve-reject-action-button]
                               :application.command/revoke [revoke-action-button]
                               :application.command/assign-external-id (when (:enable-assign-external-id-ui @(rf/subscribe [:rems.config/config]))
-                                                                        [assign-external-id-button])
+                                                                        [assign-external-id-button (get application :application/assigned-external-id "")])
                               :application.command/close [close-action-button]
                               :application.command/delete [delete-action-button]
                               :application.command/copy-as-new [copy-as-new-button]]]


### PR DESCRIPTION
We could also show the generated-external-id, but I imagine editing the
REMS-generated id will be less common compared to assigning a completely
new id. However once and id has been assigned, it might need to be edited
(due to a typo?).

fixes #2530

# Checklist for author

Remove items that aren't applicable, check items that are done.

## Reviewability
- [x] Link to issue

## Documentation
- [x] Update changelog if necessary

## Testing
- [ ] Valuable features are integration / browser / acceptance tested automatically
  - no browser tests for the assign external id action yet