### PR TITLE
fix: path whitelist validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ Changes since v2.16
 - The multiselect field label wasn't being bolded.
 - Info text icon could appear even though the field description was empty.
 - Changes to the default translation for the required form field: does not include an asterisk sign anymore.
+- Fixed occasional "Invalid path whitelist entry" error when adding/updating api keys.
 
 ### Additions
 - The example-theme now uses the Lato font.

--- a/src/clj/rems/db/api_key.clj
+++ b/src/clj/rems/db/api_key.clj
@@ -51,7 +51,7 @@
 
 (defn add-api-key! [key & [{:keys [comment users paths]}]]
   (doseq [entry paths]
-    (assert (= [:method :path] (keys entry))
+    (assert (= #{:method :path} (set (keys entry)))
             (str "Invalid path whitelist entry: " (pr-str entry)))
     (assert (contains? #{"get" "put" "post" "patch" "delete" "head" "options" "any"} (:method entry))
             (str "Invalid method: " (pr-str entry))))

--- a/test/clj/rems/api/test_api.clj
+++ b/test/clj/rems/api/test_api.clj
@@ -69,8 +69,8 @@
     (api-key/add-api-key! "45" {:comment "all paths" :paths nil})
     (api-key/add-api-key! "46" {:comment "limited paths" :paths [{:method "any"
                                                                   :path "/api/applications"}
-                                                                 {:method "any"
-                                                                  :path "/api/my-applications"}]})
+                                                                 {:path "/api/my-applications"
+                                                                  :method "any"}]})
     (api-key/add-api-key! "47" {:comment "regex path" :paths [{:method "any"
                                                                :path "/api/c.*"}
                                                               {:method "get"


### PR DESCRIPTION
the ordering of clojure map keys shouldn't be relied on

# Checklist for author

Remove items that aren't applicable, check items that are done.

## Reviewability
- [ ] Link to issue

## Documentation
- [ ] Update changelog if necessary

## Testing
- [x] Valuable features are integration / browser / acceptance tested automatically