### PR TITLE
form editor styling

### DIFF
--- a/src/clj/rems/css/styles.clj
+++ b/src/clj/rems/css/styles.clj
@@ -253,16 +253,19 @@
    [:.text-highlight {:color (get-theme-attribute :color3)
                       :font-weight "bold"}]))
 
-(defn- generate-dashed-form-group []
+(defn- generate-form-group []
   {:position "relative"
-   :border "2px dashed #ccc"
    :border-radius (u/rem 0.4)
    :padding (u/px 10)
    :margin-top 0
    :margin-bottom (u/px 16)})
 
+(defn- generate-dashed-form-group []
+  (assoc (generate-form-group)
+         :border "2px dashed #ccc"))
+
 (defn- generate-solid-form-group []
-  (assoc (generate-dashed-form-group)
+  (assoc (generate-form-group)
          :border "2px solid #eee"))
 
 (defn- remove-nil-vals

--- a/src/clj/rems/css/styles.clj
+++ b/src/clj/rems/css/styles.clj
@@ -262,12 +262,8 @@
    :margin-bottom (u/px 16)})
 
 (defn- generate-solid-form-group []
-  {:position "relative"
-   :border "2px solid #eee"
-   :margin 0
-   :padding (u/rem 1)
-   :padding-right (u/rem 2)
-   :border-radius (u/rem 0.4)})
+  (assoc (generate-dashed-form-group)
+         :border "2px solid #eee"))
 
 (defn- remove-nil-vals
   "Recursively removes all keys with nil values from a map."

--- a/src/clj/rems/css/styles.clj
+++ b/src/clj/rems/css/styles.clj
@@ -696,18 +696,6 @@
    [:.dashed-group (generate-dashed-form-group)]
    [:.solid-group (generate-solid-form-group)]
 
-   ;; workflow editor
-   [:.workflow-round (generate-dashed-form-group)
-    [:h2 {:font-weight 400
-          :font-size (u/rem 1.4)}]]
-   [:.next-workflow-arrow {:position "absolute"
-                           :font-size (u/px 40)
-                           :left (u/percent 50)
-                           :transform "translate(-50%, -1%)"
-                           :z-index 1}]
-   [:.new-workflow-round {:text-align "center"}]
-   [:.remove-workflow-round {:float "right"}]
-
    ;; form editor
    [:#main-content.page-create-form {:max-width :unset}]
    [:.form-field (generate-solid-form-group)]

--- a/src/clj/rems/css/styles.clj
+++ b/src/clj/rems/css/styles.clj
@@ -710,7 +710,7 @@
 
    ;; form editor
    [:#main-content.page-create-form {:max-width :unset}]
-   [:.form-field (generate-dashed-form-group)]
+   [:.form-field (generate-solid-form-group)]
    [:.form-field-header {:margin-bottom (u/rem 0.5)}
     [:h4 {:display "inline"
           :font-weight "bold"
@@ -719,15 +719,17 @@
     {:float "right"
      :font-size (u/rem 1.2)}
     [:* {:margin-left (u/em 0.25)}]]
-   [:.new-form-field {:text-align "center"}]
+   [:.new-form-field (assoc (generate-dashed-form-group)
+                            :text-align "center")]
 
-   [:.form-field-visibility (assoc (generate-dashed-form-group)
+   [:.form-field-visibility (assoc (generate-solid-form-group)
                                    :margin-left 0
                                    :margin-right 0)]
-   [:.form-field-option (assoc (generate-dashed-form-group)
+   [:.form-field-option (assoc (generate-solid-form-group)
                                :margin-left 0
                                :margin-right 0)]
-   [:.new-form-field-option {:text-align "center"}]
+   [:.new-form-field-option (assoc (generate-dashed-form-group)
+                                   :text-align "center")]
 
    [:#preview-form {:position :sticky ;; TODO seems to work on Chrome and Firefox. check Edge?
                     :top "100px"}

--- a/src/cljs/rems/administration/create_form.cljs
+++ b/src/cljs/rems/administration/create_form.cljs
@@ -666,49 +666,47 @@
            [:div.form-field {:id (field-editor-id (:field/id field))
                              :key index
                              :data-field-index index}
-            [:div.form-field-header.d-flex
-             [:h3 (text-format :t.create-form/field-n (inc index) (localized-field-title field @(rf/subscribe [:language])))]
-             [:div.form-field-controls.text-nowrap.ml-auto
-              [remove-form-field-button index]
-              [move-form-field-up-button index]
-              [move-form-field-down-button index]
-              [collapsible/controls
-               (str (field-editor-id (:field/id field)) "-contents")
-               [atoms/expand-symbol]
-               [atoms/collapse-symbol]
-               true]]]
-
-            [:div.collapse.show
-             {:id (str (field-editor-id (:field/id field)) "-contents")
-              :tab-index "-1"}
-             [form-field-title-field index]
-             [form-field-type-radio-group index]
-             (when (common-form/supports-optional? field)
-               (if (= :table (:field/type field))
-                 [form-field-table-optional-checkbox field]
-                 [form-field-optional-checkbox field]))
-             (when (common-form/supports-info-text? field)
-               [form-field-info-text index])
-             (when (common-form/supports-placeholder? field)
-               [form-field-placeholder-field index])
-             (let [id (str "fields-" index "-additional")]
-               [:div.form-group.field
-                [:label
-                 (text :t.create-form/additional-settings)
-                 " "
-                 [collapsible/controls id (text :t.collapse/show) (text :t.collapse/hide) false]]
-                [:div.collapse.solid-group {:id id}
-                 [form-field-id-field index]
-                 (when (common-form/supports-max-length? field)
-                   [form-field-max-length-field index])
-                 (when (common-form/supports-privacy? field)
-                   [form-field-privacy index])
-                 (when (common-form/supports-visibility? field)
-                   [form-field-visibility index])]])
-             (when (common-form/supports-options? field)
-               [form-field-option-fields index])
-             (when (common-form/supports-columns? field)
-               [form-field-column-fields index])]]
+            [collapsible/minimal
+             {:id (field-editor-id (:field/id field))
+              :always
+              [:div.form-field-header.d-flex
+               [:h3 (text-format :t.create-form/field-n (inc index) (localized-field-title field @(rf/subscribe [:language])))]
+               [:div.form-field-controls.text-nowrap.ml-auto
+                [remove-form-field-button index]
+                [move-form-field-up-button index]
+                [move-form-field-down-button index]]]
+              :collapse
+              [:div
+               {:id (str (field-editor-id (:field/id field)) "-contents")
+                :tab-index "-1"}
+               [form-field-title-field index]
+               [form-field-type-radio-group index]
+               (when (common-form/supports-optional? field)
+                 (if (= :table (:field/type field))
+                   [form-field-table-optional-checkbox field]
+                   [form-field-optional-checkbox field]))
+               (when (common-form/supports-info-text? field)
+                 [form-field-info-text index])
+               (when (common-form/supports-placeholder? field)
+                 [form-field-placeholder-field index])
+               (let [id (str "fields-" index "-additional")]
+                 [:div.form-group.field
+                  [:label
+                   (text :t.create-form/additional-settings)
+                   " "
+                   [collapsible/controls id (text :t.collapse/show) (text :t.collapse/hide) false]]
+                  [:div.collapse.solid-group {:id id}
+                   [form-field-id-field index]
+                   (when (common-form/supports-max-length? field)
+                     [form-field-max-length-field index])
+                   (when (common-form/supports-privacy? field)
+                     [form-field-privacy index])
+                   (when (common-form/supports-visibility? field)
+                     [form-field-visibility index])]])
+               (when (common-form/supports-options? field)
+                 [form-field-option-fields index])
+               (when (common-form/supports-columns? field)
+                 [form-field-column-fields index])]}]]
 
            [:div.form-field.new-form-field
             [add-form-field-button (inc index)]]])))

--- a/src/cljs/rems/administration/create_organization.cljs
+++ b/src/cljs/rems/administration/create_organization.cljs
@@ -211,7 +211,7 @@
 
 
 (defn- organization-review-email-field [field-index]
-  [:div.form-field.dashed-group
+  [:div.form-field
    [:div.form-field-header
     [:h4 (text-format :t.administration/review-email-n (inc field-index))]
     [:div.form-field-controls [remove-review-email-button field-index]]]

--- a/src/cljs/rems/atoms.cljs
+++ b/src/cljs/rems/atoms.cljs
@@ -100,14 +100,10 @@
 
   Additional options:
   `:inline?` - puts the label and value on the same row
-  `:box?`    - wrap the value into a field value box (default true)
-  `:dashed?` - wrap the value into a dashed box (default false)
-  `:border?` - wrap the value into a solid border (default false)"
-  [title value & [{:keys [inline? box? dashed? solid?] :or {box? true dashed? false solid? false} :as _opts}]]
+  `:box?`    - wrap the value into a field value box (default true)"
+  [title value & [{:keys [inline? box?] :or {box? true} :as _opts}]]
   (let [values (if (list? value) value (list value))
         style (cond box? {:class "form-control"}
-                    dashed? {:class "dashed-group"}
-                    solid? {:class "solid-group"}
                     :else {:style {:padding-left 0}})]
     (if inline?
       [:div.form-group.row

--- a/src/cljs/rems/collapsible.cljs
+++ b/src/cljs/rems/collapsible.cljs
@@ -60,13 +60,13 @@
 
 (defn- block [id open? on-open content-always content-hideable content-footer top-less-button? bottom-less-button? class]
   (let [always? (not-empty content-always)
-        show-more [:div.mb-3.collapse-toggle
+        show-more [:div.collapse-toggle
                    [show-more-button
                     (if always?
                       (text :t.collapse/show-more)
                       (text :t.collapse/show))
                     id open? on-open]]
-        show-less [:div.mb-3.collapse-toggle
+        show-less [:div.collapse-toggle
                    [show-less-button
                     (if always?
                       (text :t.collapse/show-less)

--- a/test/clj/rems/test_browser.clj
+++ b/test/clj/rems/test_browser.clj
@@ -1071,6 +1071,7 @@
       (fill-form-field "FI" "Form Editor Test (FI)")
       (fill-form-field "SV" "Form Editor Test (SV)")
       (btu/scroll-and-click {:class :add-form-field})
+      (btu/scroll-and-click :field-editor-fld1-collapse-more-link)
       ;; using ids to fill the fields because the label structure is complicated
       (btu/wait-visible :fields-0-title-en)
       (btu/fill-human :fields-0-title-en "Text area (EN)")
@@ -1092,6 +1093,7 @@
       (btu/fill-human :fields-0-max-length "127")
 
       (btu/scroll-and-click-el (last (btu/query-all {:class :add-form-field})))
+      (btu/scroll-and-click :field-editor-fld2-collapse-more-link)
       (btu/wait-visible :fields-1-title-en)
       (btu/fill-human :fields-1-title-en "Option list (EN)")
       (btu/fill-human :fields-1-title-fi "Option list (FI)")
@@ -1168,6 +1170,8 @@
 
       (testing "add description field"
         (btu/scroll-and-click {:class :add-form-field})
+        ;; we're predicting the field ids here, a bit fragile
+        (btu/scroll-and-click :field-editor-fld2-collapse-more-link)
         (btu/scroll-and-click :fields-0-type-description)
         (btu/fill-human :fields-0-title-en "Description (EN)")
         (btu/fill-human :fields-0-title-fi "Description (FI)")
@@ -1183,6 +1187,7 @@
         (btu/wait-page-loaded)
         (btu/wait-visible {:tag :h1 :fn/text "Edit form"})
 
+        (btu/scroll-and-click :field-editor-fld2-collapse-more-link)
         (btu/scroll-and-click :fields-0-type-description)
         (btu/scroll-and-click :fields-0-info-text-more-link)
         (btu/wait-visible :fields-0-info-text-en)


### PR DESCRIPTION
- collapse fields by default
- make expand/collapse button more prominent
- use less dashed lines

for #2608

# Checklist for author

Remove items that aren't applicable, check items that are done.

## Reviewability
- [x] Link to issue
- [x] Consider adding screenshots for ease of review

## Documentation
- [x] Update changelog if necessary
  - the existing entry covers this
- [ ] Update manual/ (if applicable)
  - to be done once styling is finalized

## Testing
- [x] Valuable features are integration / browser / acceptance tested automatically