### PR TITLE
fix: empty read-only fields should be rendered

### DIFF
--- a/src/cljs/rems/fields.cljs
+++ b/src/cljs/rems/fields.cljs
@@ -111,7 +111,7 @@
         value (:field/value opts)
         previous-value (:field/previous-value opts)
         max-length (:field/max-length opts)
-        info-text (linkify (localized (:field/info-text opts)))
+        info-text (localized (:field/info-text opts))
         collapse-aria-label (str (text :t.create-form/collapse-aria-label) raw-title)]
     ;; TODO: simplify fieldset code
     [(if fieldset
@@ -136,12 +136,12 @@
       (if optional
         (text :t.form/optional)
         (text :t.form/required))
-      (when info-text
+      (when-not (str/blank? info-text)
         [info-collapse
          {:info-id (field-name opts)
           :aria-label-text collapse-aria-label
           :focus-when-collapse-opened focus-when-collapse-opened
-          :body-text info-text}])]
+          :body-text (linkify info-text)}])]
      (when (and previous-value
                 (not= value previous-value))
        [toggle-diff-button diff on-toggle-diff])

--- a/src/cljs/rems/util.cljs
+++ b/src/cljs/rems/util.cljs
@@ -153,7 +153,7 @@
   original string, except that all substrings that resemble a link have
   been changed to hiccup links."
   [s]
-  (when-not (str/blank? s)
+  (when s
     (let [splitted (-> s
                        (str/replace link-regex #(str "\t" %1 "\t"))
                        (str/split "\t"))

--- a/test/cljs/rems/test_util.cljs
+++ b/test/cljs/rems/test_util.cljs
@@ -66,6 +66,4 @@
       (is (= (linkify "(See www-page at www.abc.com.)")
              ["(See www-page at "
               [:a {:target :_blank :href "http://www.abc.com"} "www.abc.com"]
-              ".)"])))
-    (testing "returns nil for empty"
-      (is (= nil (linkify ""))))))
+              ".)"])))))


### PR DESCRIPTION
needed to rework the info-text fix from #2576

# Checklist for author

Remove items that aren't applicable, check items that are done.

## Reviewability
- [x] Link to issue
  - linked to original PR
- [ ] Consider adding screenshots for ease of review

## Documentation
- [ ] Update changelog if necessary
  - the original fix is already noted there, and the bug fixed here was never released

## Testing
- [ ] Valuable features are integration / browser / acceptance tested automatically