### PR TITLE
fix: horizontal overflow for inline info-field

### DIFF
--- a/src/cljs/rems/atoms.cljs
+++ b/src/cljs/rems/atoms.cljs
@@ -106,10 +106,11 @@
         style (cond box? {:class "form-control"}
                     :else {:style {:padding-left 0}})]
     (if inline?
-      [:div.form-group.row
-       [:label.col-sm-3.col-form-label title]
-       (into [:div.col-sm-9 style]
-             values)]
+      [:div.container-fluid
+       [:div.form-group.row
+        [:label.col-sm-3.col-form-label title]
+        (into [:div.col-sm-9 style]
+              values)]]
       [:div.form-group
        [:label title]
        (into [:div style] values)])))


### PR DESCRIPTION
the style change from #2623 (issue #2621) made this overflow visible,
but it was there already before it

# Checklist for author

Remove items that aren't applicable, check items that are done.

## Reviewability
- [x] Link to issue
- [ ] Consider adding screenshots for ease of review

## Documentation
- [x] Update changelog if necessary
  - not necessary IMO