### PR TITLE
fix: don't jump to top of page after adding application attachment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Changes since v2.17
 
 ### Fixes
 - Errors for invalid inputs (field values that are too long, invalid email addresses, etc.) are now rendered nicely. Previously the applicant just saw a "Save draft: Failed" message. (#2611)
+- The application page no longer jumps to the top after adding an attachment. (#2616)
 
 ### Additions
 

--- a/src/cljs/rems/application.cljs
+++ b/src/cljs/rems/application.cljs
@@ -748,7 +748,7 @@
                                          (navigate! "/catalogue"))]]]]
     (when (seq actions)
       [collapsible/component
-       {:id "actions"
+       {:id "actions-collapse"
         :title (text :t.form/actions)
         :always (into [:div (into [:div#action-commands]
                                   actions)]
@@ -812,8 +812,9 @@
      [:div.my-3 [application-licenses application userid]]
      [:div.mt-3 [application-fields application edit-application]]]
     [:div.col-lg-4.spaced-vertically-3
-     [flash-message/component :actions]
-     [actions-form application]]]])
+     [:div#actions
+      [flash-message/component :actions]
+      [actions-form application]]]]])
 
 ;;;; Entrypoint
 


### PR DESCRIPTION
... by making the :actions flash message float with the actions-form

for #2616

# Checklist for author

Remove items that aren't applicable, check items that are done.

## Reviewability
- [x] Link to issue

## Documentation
- [x] Update changelog if necessary

## Testing
- [x] Valuable features are integration / browser / acceptance tested automatically
  - no test for the screen not jumping, but the browser side of the
  attachments is tested otherwise