### PR TITLE
Add handler earlier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Changes since v2.17
 
 ### Fixes
 - Errors for invalid inputs (field values that are too long, invalid email addresses, etc.) are now rendered nicely. Previously the applicant just saw a "Save draft: Failed" message. (#2611)
+- A handler is now considered a handler even before first application comes in.
 
 ### Additions
 

--- a/src/clj/rems/db/organizations.clj
+++ b/src/clj/rems/db/organizations.clj
@@ -76,4 +76,4 @@
 (defn get-all-organization-roles [userid]
   (when (some #(contains? (set (map :userid (:organization/owners %))) userid)
               (get-organizations-raw))
-    [:organization-owner]))
+    #{:organization-owner}))

--- a/src/clj/rems/db/workflow.clj
+++ b/src/clj/rems/db/workflow.clj
@@ -52,3 +52,8 @@
 
 (defn join-workflow-licenses [workflow]
   (assoc workflow :licenses (get-workflow-licenses (:id workflow))))
+
+(defn get-all-workflow-roles [userid]
+  (when (some #(contains? (set (map :userid (get-in % [:workflow :handlers]))) userid)
+              (get-workflows nil))
+    #{:handler}))

--- a/src/clj/rems/middleware.clj
+++ b/src/clj/rems/middleware.clj
@@ -16,6 +16,7 @@
             [rems.db.roles :as roles]
             [rems.db.user-settings :as user-settings]
             [rems.db.users :as users]
+            [rems.db.workflow :as workflows]
             [rems.layout :refer [error-page]]
             [rems.logging :refer [with-mdc]]
             [rems.middleware.dev :refer [wrap-dev]]
@@ -73,6 +74,7 @@
                                (when context/*user*
                                  (set/union (roles/get-roles (getx-user-id))
                                             (organizations/get-all-organization-roles (getx-user-id))
+                                            (workflows/get-all-workflow-roles (getx-user-id))
                                             (applications/get-all-application-roles (getx-user-id))))
                                (when (:uses-valid-api-key? request)
                                  #{:api-key}))]

--- a/test/clj/rems/db/test_workflow.clj
+++ b/test/clj/rems/db/test_workflow.clj
@@ -1,0 +1,16 @@
+(ns ^:integration rems.db.test-workflow
+  (:require [clojure.test :refer :all]
+            [rems.db.testing :refer [rollback-db-fixture test-db-fixture]]
+            [rems.db.workflow :as workflow]
+            [rems.db.test-data-helpers :as test-helpers]))
+
+(use-fixtures :once test-db-fixture)
+(use-fixtures :each rollback-db-fixture)
+
+(deftest test-get-all-workflow-roles
+  (is (= nil (workflow/get-all-workflow-roles "anyone")))
+
+  (testing "handler role"
+    (test-helpers/create-user! {:eppn "handler-user"})
+    (test-helpers/create-workflow! {:handlers ["handler-user"]})
+    (is (= #{:handler} (workflow/get-all-workflow-roles "handler-user")))))


### PR DESCRIPTION
I noticed that the `:handler` role is added only from the applications so there needs to be an application before a person is a handler.

# Checklist for author

Remove items that aren't applicable, check items that are done.

## Reviewability
- [ ] Link to issue

## Documentation
- [x] Update changelog if necessary

## Testing
- [x] Complex logic is unit tested
- [x] Valuable features are integration / browser / acceptance tested automatically

## Follow-up
- [ ] New tasks are created for pending or remaining tasks
