### PR TITLE
fix: formatting of /api/permissions swagger docs

### DIFF
--- a/src/clj/rems/api/util.clj
+++ b/src/clj/rems/api/util.clj
@@ -17,13 +17,14 @@
 (defn add-roles-documentation [summary roles]
   (when (nil? summary)
     (throw (IllegalArgumentException. "Route must have a :summary when using :roles and it must be specified before :roles")))
-  (str summary
-       " (roles: "
-       (->> roles
-            (map name)
-            (sort)
-            (str/join ", "))
-       ")"))
+  (let [role-str (->> roles
+                      (map name)
+                      (sort)
+                      (str/join ", "))]
+    `(str ~summary
+          " (roles: "
+          ~role-str
+          ")")))
 
 (defmethod restructure-param :roles [_ roles acc]
   (-> acc


### PR DESCRIPTION
follow-up to #2631 #2649

# Checklist for author

Remove items that aren't applicable, check items that are done.

## Reviewability
- [x] Link to issue

## Documentation
- [x] API is documented and shows up in Swagger UI