### PR TITLE
fix: different schema for internal format and external

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Changes since v2.18
 
 ### Fixes
 - Pdf generation failed for applications that had table fields with no rows. Now fixed.
+- Fix for missing notification-email from user settings
 
 ### Additions
 - Pdf applications now contain license text (for inline licenses), url (for link licenses) or attachment name (for attachment licenses), and license acceptance status for applicant and members. (#2688)

--- a/src/clj/rems/db/user_settings.clj
+++ b/src/clj/rems/db/user_settings.clj
@@ -18,6 +18,11 @@
    :notification-email (s/maybe s/Str)
    (s/optional-key :ega) {:api-key-expiration-date DateTime}})
 
+(s/defschema DbUserSettings
+  {:language s/Keyword
+   (s/optional-key :notification-email) (s/maybe s/Str)
+   (s/optional-key :ega) {:api-key-expiration-date DateTime}})
+
 (def ^:private validate-user-settings
   (s/validator UserSettings))
 
@@ -27,7 +32,7 @@
       json/generate-string))
 
 (def ^:private coerce-user-settings
-  (coerce/coercer! UserSettings json/coercion-matcher))
+  (coerce/coercer! DbUserSettings json/coercion-matcher))
 
 (defn- json->settings [json]
   (when json

--- a/test/clj/rems/db/test_users.clj
+++ b/test/clj/rems/db/test_users.clj
@@ -21,15 +21,27 @@
                                         :organizations [{:organization/id "org"}]})
 
   (testing "survives partial user settings"
-    (db/update-user-settings! {:user "user1" :settings "{\"language\": \"fi\"}"}) ; base with partial data
-
-    (is (= {:success true}
-           (user-settings/update-user-settings! "user1" {:language :en})))
+    (db/update-user-settings! {:user "user1" :settings "{\"language\": \"fi\"}"}) ; missing notification-email
 
     (is (= {:userid "user1"
             :name "What Ever"
             :email nil}
-           (users/get-user "user1"))))
+           (users/get-user "user1")))
+
+    (is (= {:language :fi :notification-email nil} (user-settings/get-user-settings "user1"))
+        "default is returned for notification-email")
+
+    (is (= {:success true}
+           (user-settings/update-user-settings! "user1" {:language :en}))
+        "settings can be updated")
+
+    (is (= {:userid "user1"
+            :name "What Ever"
+            :email nil}
+           (users/get-user "user1")))
+
+    (is (= {:language :en :notification-email nil} (user-settings/get-user-settings "user1"))
+        "default is returned for notification-email"))
 
   (testing "get-raw-user-attributes"
     (is (= {:eppn "whatever"

--- a/test/clj/rems/db/test_users.clj
+++ b/test/clj/rems/db/test_users.clj
@@ -1,8 +1,10 @@
 (ns ^:integration rems.db.test-users
   (:require [clojure.test :refer :all]
+            [rems.db.core :as db]
             [rems.db.roles :as roles]
             [rems.db.testing :refer [rollback-db-fixture test-db-fixture]]
-            [rems.db.users :as users]))
+            [rems.db.users :as users]
+            [rems.db.user-settings :as user-settings]))
 
 (use-fixtures :once test-db-fixture)
 (use-fixtures :each rollback-db-fixture)
@@ -15,7 +17,19 @@
   (users/add-user-raw! "user-with-org" {:eppn "user-with-org"
                                         :commonName "User Org"
                                         :mail "user@org"
+                                        ;;:notification-email "user@alt"
                                         :organizations [{:organization/id "org"}]})
+
+  (testing "survives partial user settings"
+    (db/update-user-settings! {:user "user1" :settings "{\"language\": \"fi\"}"}) ; base with partial data
+
+    (is (= {:success true}
+           (user-settings/update-user-settings! "user1" {:language :en})))
+
+    (is (= {:userid "user1"
+            :name "What Ever"
+            :email nil}
+           (users/get-user "user1"))))
 
   (testing "get-raw-user-attributes"
     (is (= {:eppn "whatever"
@@ -53,6 +67,13 @@
     (roles/add-role! "user1" :owner)
     (is (= ["user1"] (users/get-users-with-role :owner)))
     (is (= [] (users/get-users-with-role :reporter))))
+
+  (testing "get-deciders"
+    (is (= #{{:userid "whatever", :name "What Ever", :email nil}
+             {:userid "user-with-org",
+              :name "User Org",
+              :email "user@org",
+              :organizations [#:organization{:id "org"}]}} (set (users/get-deciders)))))
 
   (testing "update user with add-user-raw!"
     (users/add-user-raw! "user1" {:eppn "user1"


### PR DESCRIPTION
The internal DB may not have `:notification-email` but after merging
with the default-settings it should have. We can separate the internal
and external schemas.

Follow-up:
- [x] changelog
- [x] failing test (happens when fetching deciders but not always it seems)
- [ ] release