### PR TITLE
Fix bad option name in config-defaults.edn

### DIFF
--- a/resources/config-defaults.edn
+++ b/resources/config-defaults.edn
@@ -253,9 +253,9 @@
  ;;               ;; The files are searched under :extra-pages-path (see below).
  ;;               {:id "about"
  ;;                :translations {:fi {:title "Info"
- ;;                                    :file "about-fi.md"}
+ ;;                                    :filename "about-fi.md"}
  ;;                               :en {:title "About"
- ;;                                    :file "about-en.md"}}}]
+ ;;                                    :filename "about-en.md"}}}]
  :extra-pages []
 
  ;; Path to the markdown files for the extra pages.


### PR DESCRIPTION
The `:file` option has the wrong name in the example configuration. It should be `:filename`. 

It's great that you report the schema in the logs, otherwise I'd never find it.