### PR TITLE
privacy additions 1/2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@
 /browsertest-errors/
 /browsertest-downloads/
 /browsertest-accessibility-report/
+/.calva/
+/.lsp/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ Changes since v2.20
 - Handlers can be invited to a workflow by email using the API (#2650)
 - Entitlement expiration field in application actions will now accept only future dates (#2674)
 
+### Changes
+- Reviewers are no longer able to see private field questions in generated application pdf. Forms are also no longer rendered in application page if they contain only private fields (#2161)
+
 ## v2.20 "Vattuniemenkatu" 2021-08-24
 
 ### Fixes

--- a/src/clj/rems/application/model.clj
+++ b/src/clj/rems/application/model.clj
@@ -7,7 +7,7 @@
             [rems.application.master-workflow :as master-workflow]
             [rems.common.application-util :as application-util]
             [rems.common.form :as form]
-            [rems.common.util :refer [build-index conj-vec getx]]
+            [rems.common.util :refer [conj-vec getx]]
             [rems.permissions :as permissions]))
 
 ;;;; Application

--- a/src/clj/rems/db/test_data.clj
+++ b/src/clj/rems/db/test_data.clj
@@ -962,6 +962,41 @@
         form (create-all-field-types-example-form! owner {:organization/id "nbn"} "Example form with all field types" {:en "Example form with all field types"
                                                                                                                        :fi "Esimerkkilomake kaikin kenttätyypein"
                                                                                                                        :sv "Exempelblankett med alla fälttyper"})
+
+        form-with-public-and-private-fields (create-form! {:actor owner
+                                                           :organization {:organization/id "nbn"}
+                                                           :form/internal-name "Public and private fields form"
+                                                           :form/external-title {:en "Form"
+                                                                                 :fi "Lomake"
+                                                                                 :sv "Blankett"}
+                                                           :form/fields [{:field/title {:en "Simple text field"
+                                                                                        :fi "Yksinkertainen tekstikenttä"
+                                                                                        :sv "Textfält"}
+                                                                          :field/optional false
+                                                                          :field/type :text
+                                                                          :field/max-length 100}
+                                                                         {:field/title {:en "Private text field"
+                                                                                        :fi "Yksityinen tekstikenttä"
+                                                                                        :sv "Privat textfält"}
+                                                                          :field/optional false
+                                                                          :field/type :text
+                                                                          :field/max-length 100
+                                                                          :field/privacy :private}]})
+
+        form-private-nbn (create-form! {:actor owner
+                                        :organization {:organization/id "nbn"}
+                                        :form/internal-name "Simple form"
+                                        :form/external-title {:en "Form"
+                                                              :fi "Lomake"
+                                                              :sv "Blankett"}
+                                        :form/fields [{:field/title {:en "Simple text field"
+                                                                     :fi "Yksinkertainen tekstikenttä"
+                                                                     :sv "Textfält"}
+                                                       :field/optional false
+                                                       :field/type :text
+                                                       :field/max-length 100
+                                                       :field/privacy :private}]})
+
         form-private-thl (create-form! {:actor owner
                                         :organization {:organization/id "thl"}
                                         :form/internal-name "Simple form"
@@ -1129,7 +1164,36 @@
                              :resource-id res-organization-owner
                              :form-id form-organization-owner
                              :organization {:organization/id "organization1"}
-                             :workflow-id (:organization-owner workflows)})))
+                             :workflow-id (:organization-owner workflows)})
+
+    (let [applicant (users :applicant1)
+          handler (users :approver2)
+          reviewer (users :reviewer)
+          catid-1 (create-catalogue-item! {:actor owner
+                                           :title {:en "Test workflow"
+                                                   :fi "Testityövuo"
+                                                   :sv "Test arbetsflöde"}
+                                           :resource-id res1
+                                           :form-id form-with-public-and-private-fields
+                                           :organization {:organization/id "nbn"}
+                                           :workflow-id (:default workflows)})
+          catid-2 (create-catalogue-item! {:actor owner
+                                           :title {:en "Test workflow with private form"
+                                                   :fi "Testityövuo yksityisellä lomakkeella"
+                                                   :sv "Test arbetsflöde med privat blankett"}
+                                           :resource-id res2
+                                           :form-id form-private-nbn
+                                           :organization {:organization/id "nbn"}
+                                           :workflow-id (:default workflows)})
+          app-id (create-draft! applicant [catid-1 catid-2] "two-form draft application")]
+      (command! {:type :application.command/submit
+                 :application-id app-id
+                 :actor applicant})
+      (command! {:type :application.command/request-review
+                 :application-id app-id
+                 :actor handler
+                 :reviewers [reviewer]
+                 :comment "please have a look"}))))
 
 (defn create-organizations! [users]
   (let [owner (users :owner)

--- a/src/clj/rems/db/test_data.clj
+++ b/src/clj/rems/db/test_data.clj
@@ -1170,17 +1170,17 @@
           handler (users :approver2)
           reviewer (users :reviewer)
           catid-1 (create-catalogue-item! {:actor owner
-                                           :title {:en "Test workflow"
-                                                   :fi "Testityövuo"
-                                                   :sv "Test arbetsflöde"}
+                                           :title {:en "Default workflow with public and private fields"
+                                                   :fi "Testityövuo julkisilla ja yksityisillä lomakekentillä"
+                                                   :sv "Standard arbetsflöde med publika och privata textfält"}
                                            :resource-id res1
                                            :form-id form-with-public-and-private-fields
                                            :organization {:organization/id "nbn"}
                                            :workflow-id (:default workflows)})
           catid-2 (create-catalogue-item! {:actor owner
-                                           :title {:en "Test workflow with private form"
-                                                   :fi "Testityövuo yksityisellä lomakkeella"
-                                                   :sv "Test arbetsflöde med privat blankett"}
+                                           :title {:en "Default workflow with private form"
+                                                   :fi "Oletustyövuo yksityisellä lomakkeella"
+                                                   :sv "Standard arbetsflöde med privat blankett"}
                                            :resource-id res2
                                            :form-id form-private-nbn
                                            :organization {:organization/id "nbn"}

--- a/src/clj/rems/pdf.clj
+++ b/src/clj/rems/pdf.clj
@@ -132,9 +132,12 @@
   (let [filenames (attachment-filenames application)]
     (doall
      (for [form (getx application :application/forms)]
-       (list [:heading heading-style (or (get-in form [:form/external-title context/*lang*]) (text :t.form/application))]
-             (doall (for [field (getx form :form/fields)]
-                      (render-field filenames field))))))))
+       (let [fields (->> (getx form :form/fields)
+                         (remove :field/private))]
+         (when (seq fields)
+           (list [:heading heading-style (or (get-in form [:form/external-title context/*lang*]) (text :t.form/application))]
+                 (doall (for [field fields]
+                          (render-field filenames field))))))))))
 
 (def license-title-style {:style :bold})
 

--- a/src/clj/rems/pdf.clj
+++ b/src/clj/rems/pdf.clj
@@ -131,13 +131,13 @@
 (defn- render-fields [application]
   (let [filenames (attachment-filenames application)]
     (doall
-     (for [form (getx application :application/forms)]
-       (let [fields (->> (getx form :form/fields)
-                         (remove :field/private))]
-         (when (seq fields)
-           (list [:heading heading-style (or (get-in form [:form/external-title context/*lang*]) (text :t.form/application))]
-                 (doall (for [field fields]
-                          (render-field filenames field))))))))))
+     (for [form (getx application :application/forms)
+           :let [fields (->> (getx form :form/fields)
+                             (remove :field/private))]
+           :when (seq fields)]
+       (list [:heading heading-style (or (get-in form [:form/external-title context/*lang*]) (text :t.form/application))]
+             (doall (for [field fields]
+                      (render-field filenames field))))))))
 
 (def license-title-style {:style :bold})
 

--- a/src/cljc/rems/common/form.cljc
+++ b/src/cljc/rems/common/form.cljc
@@ -4,7 +4,7 @@
   Includes functions for both forms and form templates."
   (:require  [clojure.string :as str]
              [clojure.test :refer [deftest is testing]]
-             [com.rpl.specter :refer [ALL select transform]]
+             [com.rpl.specter :refer [ALL transform]]
              [medley.core :refer [assoc-some find-first]]
              [rems.common.util :refer [build-index parse-int remove-empty-keys]]))
 

--- a/src/cljs/rems/application.cljs
+++ b/src/cljs/rems/application.cljs
@@ -402,8 +402,7 @@
                            (remove :field/private)
                            seq)]
             [collapsible/component
-             {:id "application-fields"
-              :class "mb-3"
+             {:class "application-fields mb-3"
               :title (or (get-in form [:form/external-title language]) (text :t.form/application))
               :always (into [:div.fields]
                             (for [field (:form/fields form)

--- a/src/cljs/rems/application.cljs
+++ b/src/cljs/rems/application.cljs
@@ -397,7 +397,10 @@
         language @(rf/subscribe [:language])]
     (into [:div]
           (for [form (:application/forms application)
-                :let [form-id (:form/id form)]]
+                :let [form-id (:form/id form)]
+                :when (->> (:form/fields form)
+                           (remove :field/private)
+                           seq)]
             [collapsible/component
              {:id "application-fields"
               :class "mb-3"

--- a/src/cljs/rems/application.cljs
+++ b/src/cljs/rems/application.cljs
@@ -402,7 +402,7 @@
                            (remove :field/private)
                            seq)]
             [collapsible/component
-             {:class "application-fields mb-3"
+             {:class "mb-3"
               :title (or (get-in form [:form/external-title language]) (text :t.form/application))
               :always (into [:div.fields]
                             (for [field (:form/fields form)

--- a/test/clj/rems/browser_test_util.clj
+++ b/test/clj/rems/browser_test_util.clj
@@ -209,8 +209,11 @@
                                                                 :field/max-length 100
                                                                 :field/privacy :private}]})
         res-id1 (test-helpers/create-resource! nil)
+        res-id2 (test-helpers/create-resource! nil)
         item-id1 (test-helpers/create-catalogue-item! {:form-id form :workflow-id wfid :title {:en "Default workflow" :fi "Oletustyövuo"
-                                                                                               :sv "sv"} :resource-id res-id1})
+                                                                                               :sv "Standard arbetsflöde"} :resource-id res-id1})
+        item-id2 (test-helpers/create-catalogue-item! {:form-id _simple-form :workflow-id wfid :title {:en "Private form workflow" :fi "Yksityinen lomaketyövuo"
+                                                                                                       :sv "Private blankettarbetsflöde"} :resource-id res-id2})
         app-id (test-helpers/create-draft! "applicant" [item-id1] "draft")]
     (test-helpers/create-workflow-licence! wfid link)
     (test-helpers/create-workflow-licence! wfid text)

--- a/test/clj/rems/test_browser.clj
+++ b/test/clj/rems/test_browser.clj
@@ -572,7 +572,7 @@
     (btu/context-assoc! :form-id (test-helpers/create-form! {:form/fields [{:field/title {:en "description" :fi "kuvaus" :sv "rubrik"}
                                                                             :field/optional false
                                                                             :field/type :description}
-                                                                           {:field/title {:en "private" :fi "fi" :sv "sv"}
+                                                                           {:field/title {:en "private en" :fi "private fi" :sv "private sv"}
                                                                             :field/optional false
                                                                             :field/type :text
                                                                             :field/privacy :private}]}))
@@ -623,7 +623,7 @@
              (slurp-fields :applicant-info))))
     (testing "handler should see all form fields"
       (is (= {"description" "test-handling"
-              "private" "test-handling"}
+              "private en" "test-handling"}
              (slurp-fields {:css ".fields"}))))
 
     (testing "remove the disabled catalogue item"

--- a/test/clj/rems/test_browser.clj
+++ b/test/clj/rems/test_browser.clj
@@ -350,7 +350,7 @@
         (fill-form-field "Phone number" "+358450000100")
         (fill-form-field "IP address" "142.250.74.110")
 
-        (fill-form-field "Private text field" "Private field answer" {:form-index 2})
+        (fill-form-field "Simple text field" "Private field answer" {:form-index 2})
 
         (testing "save draft succesfully"
           (btu/scroll-and-click :save)

--- a/test/clj/rems/test_browser.clj
+++ b/test/clj/rems/test_browser.clj
@@ -692,9 +692,9 @@
                                                                     [(btu/context-get :catalogue-id)]
                                                                     "test-invite-decider"))
     (test-helpers/submit-application (btu/context-get :application-id) "alice")
-    (test-helpers/create-user! {:eppn "new-reviewer" :commonName "New Reviewer"}))
+    (test-helpers/create-user! {:eppn "new-decider" :commonName "New Decider"}))
   (btu/with-postmortem
-    (testing "handler invites reviewer"
+    (testing "handler invites decider"
       (login-as "developer")
       (go-to-application (btu/context-get :application-id))
       (is (btu/eventually-visible? {:tag :h1 :fn/has-text "test-invite-decider"}))
@@ -723,13 +723,13 @@
       (btu/go (str (btu/get-server-url) "application/accept-invitation/" (btu/context-get :token)))
       (is (btu/eventually-visible? {:css ".login-btn"}))
       (btu/scroll-and-click {:css ".login-btn"})
-      (is (btu/eventually-visible? [{:css ".users"} {:tag :a :fn/text "new-reviewer"}]))
-      (btu/scroll-and-click [{:css ".users"} {:tag :a :fn/text "new-reviewer"}])
+      (is (btu/eventually-visible? [{:css ".users"} {:tag :a :fn/text "new-decider"}]))
+      (btu/scroll-and-click [{:css ".users"} {:tag :a :fn/text "new-decider"}])
       (btu/wait-page-loaded)
       (is (btu/eventually-visible? {:tag :h1 :fn/has-text "test-invite-decider"})))
     (testing "check decider-joined event"
       (is (= {:event/type :application.event/decider-joined
-              :event/actor "new-reviewer"}
+              :event/actor "new-decider"}
              (-> (btu/context-get :application-id)
                  applications/get-application-internal
                  :application/events
@@ -745,7 +745,7 @@
     (testing "check decision event"
       (is (= {:application/decision :approved
               :application/comment "ok"
-              :event/actor "new-reviewer"
+              :event/actor "new-decider"
               :event/type :application.event/decided}
              (-> (btu/context-get :application-id)
                  applications/get-application-internal

--- a/test/clj/rems/test_pdf.clj
+++ b/test/clj/rems/test_pdf.clj
@@ -40,7 +40,7 @@
                    (#'pdf/render-fields data)))))))
     (is (some? (with-language :en #(pdf/application-to-pdf-bytes data))))))
 
-(deftest test-pdf-privacy
+(deftest test-pdf-private-form-fields
   (test-helpers/create-user! {:eppn "alice" :commonName "Alice Applicant" :mail "alice@example.com"})
   (test-helpers/create-user! {:eppn "carl" :commonName "Carl Reviewer" :mail "carl@example.com"})
   (test-helpers/create-user! {:eppn "david" :commonName "David Decider" :mail "david@example.com"})

--- a/test/clj/rems/test_pdf.clj
+++ b/test/clj/rems/test_pdf.clj
@@ -62,8 +62,9 @@
                                                                             :fi "Täyteteksti"
                                                                             :sv "Textexempel"}}]})
         catalogue-item (test-helpers/create-catalogue-item! {:resource-id resource
-                                                             :title {:en "Catalogue item"
-                                                                     :fi "Katalogi-itemi"}
+                                                             :title {:en "Resouce"
+                                                                     :fi "Resurssi"
+                                                                     :sv "Resurs"}
                                                              :form-id form})
         applicant "alice"
         handler "developer"
@@ -89,22 +90,22 @@
                               :comment "please have a look"}))
     (testing "pdf contents"
       (is (= [{}
-              [[:heading {:spacing-before 20} "Application 2000/1: "]
-               [:paragraph "This PDF generated at" " " "2010-01-01 00:00"]
-               [:paragraph "State" [:phrase ": " "Applied"]]
-               [:heading {:spacing-before 20} "Applicants"]
-               [:paragraph "Applicant" ": " "Alice Applicant (alice) <alice@example.com>. Accepted terms of use: Yes"]
+              [[:heading {:spacing-before 20} "Ansökan 2000/1: "]
+               [:paragraph "Denna pdf skapades" " " "2010-01-01 00:00"]
+               [:paragraph "Status" [:phrase ": " "Inlämnad"]]
+               [:heading {:spacing-before 20} "Sökande"]
+               [:paragraph "Sökande" ": " "Alice Applicant (alice) <alice@example.com>. Licenserna har accepterats: Ja"]
                []
-               [:heading {:spacing-before 20} "Resources"]
-               [:list [[:phrase "Catalogue item" " (" "pdf-resource-ext" ")"]]]]
-              [[:heading {:spacing-before 20} "Terms of use"] []]
-              [nil]
-              [[:heading {:spacing-before 20} "Events"]
+               [:heading {:spacing-before 20} "Resurser"]
+               [:list [[:phrase "Resurs" " (" "pdf-resource-ext" ")"]]]]
+              [[:heading {:spacing-before 20} "Licenser"] []]
+              []
+              [[:heading {:spacing-before 20} "Händelser"]
                [:list
-                [[:phrase "2000-01-01 00:00" " " "Alice Applicant created application 2000/1." nil nil nil]
-                 [:phrase "2001-01-01 00:00" " " "Alice Applicant submitted the application for review." nil nil nil]
-                 [:phrase "2003-01-01 00:00" " " "Developer requested a review from Carl Reviewer." nil "\nComment: please have a look" nil]]]]]
-             (with-language :en
+                [[:phrase "2000-01-01 00:00" " " "Alice Applicant skapade ansökan 2000/1." nil nil nil]
+                 [:phrase "2001-01-01 00:00" " " "Alice Applicant lämnade in ansökan." nil nil nil]
+                 [:phrase "2003-01-01 00:00" " " "Developer begärde granskning av Carl Reviewer." nil "\nKommentar: please have a look" nil]]]]]
+             (with-language :sv
                (fn []
                  (with-fixed-time (time/date-time 2010)
                    (fn []

--- a/test/clj/rems/test_pdf.clj
+++ b/test/clj/rems/test_pdf.clj
@@ -120,104 +120,126 @@
                               :decision :approved
                               :actor "david"}))
 
-    (let [all-form-fields [[[:heading {:spacing-before 20} "Blankett"]
-                            [[[:paragraph {:spacing-before 8, :style :bold} "Offentligt textfält"]
-                              [:paragraph "pdf test"]]
-                             [[:paragraph {:spacing-before 8, :style :bold} "Privat textfält"]
-                              [:paragraph "pdf test"]]]]
-                           [[:heading {:spacing-before 20} "Privat blankett"]
-                            [[[:paragraph {:spacing-before 8, :style :bold} "Privat textfält"]
-                              [:paragraph "pdf test"]]]]]
-          only-public-fields [[[:heading {:spacing-before 20} "Blankett"]
-                               [[[:paragraph {:spacing-before 8, :style :bold} "Offentligt textfält"]
-                                 [:paragraph "pdf test"]]]]]
-          all-events [[:heading {:spacing-before 20} "Händelser"]
-                      [:list
-                       [[:phrase "2000-01-01 00:00" " " "Alice Applicant skapade ansökan 2000/1." nil nil nil]
-                        [:phrase "2001-01-01 00:00" " " "Alice Applicant lämnade in ansökan." nil nil nil]
-                        [:phrase "2003-01-01 00:00" " " "Developer begärde granskning av Carl Reviewer." nil "\nKommentar: please have a look" nil]
-                        [:phrase "2003-01-01 00:00" " " "Developer begärde beslut från användare David Decider." nil "\nKommentar: please decide" nil]
-                        [:phrase "2003-01-01 00:00" " " "David Decider behandlade ansökan." "\nDavid Decider godkände ansökan." "\nKommentar: I have decided" nil]]]]
-          only-applicant-events [[:heading {:spacing-before 20} "Händelser"]
-                                 [:list
-                                  [[:phrase "2000-01-01 00:00" " " "Alice Applicant skapade ansökan 2000/1." nil nil nil]
-                                   [:phrase "2001-01-01 00:00" " " "Alice Applicant lämnade in ansökan." nil nil nil]]]]]
-      (testing "alice should not see reviewer and decider actions"
-        (is (= [{}
-                [[:heading {:spacing-before 20} "Ansökan 2000/1: "]
-                 [:paragraph "Denna pdf skapades" " " "2010-01-01 00:00"]
-                 [:paragraph "Status" [:phrase ": " "Inlämnad"]]
-                 [:heading {:spacing-before 20} "Sökande"]
-                 [:paragraph "Sökande" ": " "Alice Applicant (alice) <alice@example.com>. Licenserna har accepterats: Ja"]
-                 []
-                 [:heading {:spacing-before 20} "Resurser"]
-                 [:list [[:phrase "Resurs" " (" "pdf-resource-ext" ")"]
-                         [:phrase "Resurs 2" " (" "pdf-resource-2-ext" ")"]]]]
-                [[:heading {:spacing-before 20} "Licenser"] []]
-                all-form-fields
-                only-applicant-events]
-               (with-language :sv
-                 (fn []
-                   (with-fixed-time (time/date-time 2010)
-                     (fn []
-                       (#'pdf/render-application (applications/get-application-for-user "alice" application-id)))))))))
-      (testing "handler should see complete application"
-        (is (= [{}
-                [[:heading {:spacing-before 20} "Ansökan 2000/1: "]
-                 [:paragraph "Denna pdf skapades" " " "2010-01-01 00:00"]
-                 [:paragraph "Status" [:phrase ": " "Inlämnad"]]
-                 [:heading {:spacing-before 20} "Sökande"]
-                 [:paragraph "Sökande" ": " "Alice Applicant (alice) <alice@example.com>. Licenserna har accepterats: Ja"]
-                 []
-                 [:heading {:spacing-before 20} "Resurser"]
-                 [:list [[:phrase "Resurs" " (" "pdf-resource-ext" ")"]
-                         [:phrase "Resurs 2" " (" "pdf-resource-2-ext" ")"]]]]
-                [[:heading {:spacing-before 20} "Licenser"] []]
-                all-form-fields
-                all-events]
-               (with-language :sv
-                 (fn []
-                   (with-fixed-time (time/date-time 2010)
-                     (fn []
-                       (#'pdf/render-application (applications/get-application-for-user "developer" application-id)))))))))
-      (testing "decider should see complete application"
-        (is (= [{}
-                [[:heading {:spacing-before 20} "Ansökan 2000/1: "]
-                 [:paragraph "Denna pdf skapades" " " "2010-01-01 00:00"]
-                 [:paragraph "Status" [:phrase ": " "Inlämnad"]]
-                 [:heading {:spacing-before 20} "Sökande"]
-                 [:paragraph "Sökande" ": " "Alice Applicant (alice) <alice@example.com>. Licenserna har accepterats: Ja"]
-                 []
-                 [:heading {:spacing-before 20} "Resurser"]
-                 [:list [[:phrase "Resurs" " (" "pdf-resource-ext" ")"]
-                         [:phrase "Resurs 2" " (" "pdf-resource-2-ext" ")"]]]]
-                [[:heading {:spacing-before 20} "Licenser"] []]
-                all-form-fields
-                all-events]
-               (with-language :sv
-                 (fn []
-                   (with-fixed-time (time/date-time 2010)
-                     (fn []
-                       (#'pdf/render-application (applications/get-application-for-user "david" application-id)))))))))
-      (testing "reviewer should not see private fields"
-        (is (= [{}
-                [[:heading {:spacing-before 20} "Ansökan 2000/1: "]
-                 [:paragraph "Denna pdf skapades" " " "2010-01-01 00:00"]
-                 [:paragraph "Status" [:phrase ": " "Inlämnad"]]
-                 [:heading {:spacing-before 20} "Sökande"]
-                 [:paragraph "Sökande" ": " "Alice Applicant (alice) <alice@example.com>. Licenserna har accepterats: Ja"]
-                 []
-                 [:heading {:spacing-before 20} "Resurser"]
-                 [:list [[:phrase "Resurs" " (" "pdf-resource-ext" ")"]
-                         [:phrase "Resurs 2" " (" "pdf-resource-2-ext" ")"]]]]
-                [[:heading {:spacing-before 20} "Licenser"] []]
-                only-public-fields
-                all-events]
-               (with-language :sv
-                 (fn []
-                   (with-fixed-time (time/date-time 2010)
-                     (fn []
-                       (#'pdf/render-application (applications/get-application-for-user "carl" application-id))))))))))))
+    (testing "alice should not see reviewer and decider actions"
+      (is (= [{}
+              [[:heading {:spacing-before 20} "Ansökan 2000/1: "]
+               [:paragraph "Denna pdf skapades" " " "2010-01-01 00:00"]
+               [:paragraph "Status" [:phrase ": " "Inlämnad"]]
+               [:heading {:spacing-before 20} "Sökande"]
+               [:paragraph "Sökande" ": " "Alice Applicant (alice) <alice@example.com>. Licenserna har accepterats: Ja"]
+               []
+               [:heading {:spacing-before 20} "Resurser"]
+               [:list [[:phrase "Resurs" " (" "pdf-resource-ext" ")"]
+                       [:phrase "Resurs 2" " (" "pdf-resource-2-ext" ")"]]]]
+              [[:heading {:spacing-before 20} "Licenser"] []]
+              [[[:heading {:spacing-before 20} "Blankett"]
+                [[[:paragraph {:spacing-before 8, :style :bold} "Offentligt textfält"]
+                  [:paragraph "pdf test"]]
+                 [[:paragraph {:spacing-before 8, :style :bold} "Privat textfält"]
+                  [:paragraph "pdf test"]]]]
+               [[:heading {:spacing-before 20} "Privat blankett"]
+                [[[:paragraph {:spacing-before 8, :style :bold} "Privat textfält"]
+                  [:paragraph "pdf test"]]]]]
+              [[:heading {:spacing-before 20} "Händelser"]
+               [:list
+                [[:phrase "2000-01-01 00:00" " " "Alice Applicant skapade ansökan 2000/1." nil nil nil]
+                 [:phrase "2001-01-01 00:00" " " "Alice Applicant lämnade in ansökan." nil nil nil]]]]]
+             (with-language :sv
+               (fn []
+                 (with-fixed-time (time/date-time 2010)
+                   (fn []
+                     (#'pdf/render-application (applications/get-application-for-user "alice" application-id)))))))))
+    (testing "handler should see complete application"
+      (is (= [{}
+              [[:heading {:spacing-before 20} "Application 2000/1: "]
+               [:paragraph "This PDF generated at" " " "2010-01-01 00:00"]
+               [:paragraph "State" [:phrase ": " "Applied"]]
+               [:heading {:spacing-before 20} "Applicants"]
+               [:paragraph "Applicant" ": " "Alice Applicant (alice) <alice@example.com>. Accepted terms of use: Yes"]
+               []
+               [:heading {:spacing-before 20} "Resources"]
+               [:list [[:phrase "Resource" " (" "pdf-resource-ext" ")"]
+                       [:phrase "Resource 2" " (" "pdf-resource-2-ext" ")"]]]]
+              [[:heading {:spacing-before 20} "Terms of use"] []]
+              [[[:heading {:spacing-before 20} "Form"]
+                [[[:paragraph {:spacing-before 8, :style :bold} "Public text field"]
+                  [:paragraph "pdf test"]]
+                 [[:paragraph {:spacing-before 8, :style :bold} "Private text field"]
+                  [:paragraph "pdf test"]]]]
+               [[:heading {:spacing-before 20} "Private form"]
+                [[[:paragraph {:spacing-before 8, :style :bold} "Private text field"]
+                  [:paragraph "pdf test"]]]]]
+              [[:heading {:spacing-before 20} "Events"]
+               [:list
+                [[:phrase "2000-01-01 00:00" " " "Alice Applicant created application 2000/1." nil nil nil]
+                 [:phrase "2001-01-01 00:00" " " "Alice Applicant submitted the application for review." nil nil nil]
+                 [:phrase "2003-01-01 00:00" " " "Developer requested a review from Carl Reviewer." nil "\nComment: please have a look" nil]
+                 [:phrase "2003-01-01 00:00" " " "Developer requested a decision from David Decider." nil "\nComment: please decide" nil]
+                 [:phrase "2003-01-01 00:00" " " "David Decider filed a decision for the application." "\nDavid Decider approved the application." "\nComment: I have decided" nil]]]]]
+             (with-language :en
+               (fn []
+                 (with-fixed-time (time/date-time 2010)
+                   (fn []
+                     (#'pdf/render-application (applications/get-application-for-user "developer" application-id)))))))))
+    (testing "decider should see complete application"
+      (is (= [{}
+              [[:heading {:spacing-before 20} "Hakemus 2000/1: "]
+               [:paragraph "Tämä PDF luotu" " " "2010-01-01 00:00"]
+               [:paragraph "Tila" [:phrase ": " "Haettu"]]
+               [:heading {:spacing-before 20} "Hakijat"]
+               [:paragraph "Hakija" ": " "Alice Applicant (alice) <alice@example.com>. Käyttöehdot hyväksytty: Kyllä"]
+               []
+               [:heading {:spacing-before 20} "Resurssit"]
+               [:list [[:phrase "Resurssi" " (" "pdf-resource-ext" ")"]
+                       [:phrase "Resurssi 2" " (" "pdf-resource-2-ext" ")"]]]]
+              [[:heading {:spacing-before 20} "Käyttöehdot"] []]
+              [[[:heading {:spacing-before 20} "Lomake"]
+                [[[:paragraph {:spacing-before 8, :style :bold} "Julkinen tekstikenttä"]
+                  [:paragraph "pdf test"]]
+                 [[:paragraph {:spacing-before 8, :style :bold} "Yksityinen tekstikenttä"]
+                  [:paragraph "pdf test"]]]]
+               [[:heading {:spacing-before 20} "Yksityinen lomake"]
+                [[[:paragraph {:spacing-before 8, :style :bold} "Yksityinen tekstikenttä"]
+                  [:paragraph "pdf test"]]]]]
+              [[:heading {:spacing-before 20} "Tapahtumat"]
+               [:list
+                [[:phrase "2000-01-01 00:00" " " "Alice Applicant loi hakemuksen 2000/1." nil nil nil]
+                 [:phrase "2001-01-01 00:00" " " "Alice Applicant lähetti hakemuksen käsiteltäväksi." nil nil nil]
+                 [:phrase "2003-01-01 00:00" " " "Developer pyysi katselmointia käyttäjältä Carl Reviewer." nil "\nKommentti: please have a look" nil]
+                 [:phrase "2003-01-01 00:00" " " "Developer pyysi päätöstä käyttäjältä David Decider." nil "\nKommentti: please decide" nil]
+                 [:phrase "2003-01-01 00:00" " " "David Decider teki päätöksen hakemukselle." "\nDavid Decider hyväksyi hakemuksen." "\nKommentti: I have decided" nil]]]]]
+             (with-language :fi
+               (fn []
+                 (with-fixed-time (time/date-time 2010)
+                   (fn []
+                     (#'pdf/render-application (applications/get-application-for-user "david" application-id)))))))))
+    (testing "reviewer should not see private fields"
+      (is (= [{}
+              [[:heading {:spacing-before 20} "Ansökan 2000/1: "]
+               [:paragraph "Denna pdf skapades" " " "2010-01-01 00:00"]
+               [:paragraph "Status" [:phrase ": " "Inlämnad"]]
+               [:heading {:spacing-before 20} "Sökande"]
+               [:paragraph "Sökande" ": " "Alice Applicant (alice) <alice@example.com>. Licenserna har accepterats: Ja"]
+               []
+               [:heading {:spacing-before 20} "Resurser"]
+               [:list [[:phrase "Resurs" " (" "pdf-resource-ext" ")"]
+                       [:phrase "Resurs 2" " (" "pdf-resource-2-ext" ")"]]]]
+              [[:heading {:spacing-before 20} "Licenser"] []]
+              [[[:heading {:spacing-before 20} "Blankett"]
+                [[[:paragraph {:spacing-before 8, :style :bold} "Offentligt textfält"]
+                  [:paragraph "pdf test"]]]]]
+              [[:heading {:spacing-before 20} "Händelser"]
+               [:list
+                [[:phrase "2000-01-01 00:00" " " "Alice Applicant skapade ansökan 2000/1." nil nil nil]
+                 [:phrase "2001-01-01 00:00" " " "Alice Applicant lämnade in ansökan." nil nil nil]
+                 [:phrase "2003-01-01 00:00" " " "Developer begärde granskning av Carl Reviewer." nil "\nKommentar: please have a look" nil]
+                 [:phrase "2003-01-01 00:00" " " "Developer begärde beslut från användare David Decider." nil "\nKommentar: please decide" nil]
+                 [:phrase "2003-01-01 00:00" " " "David Decider behandlade ansökan." "\nDavid Decider godkände ansökan." "\nKommentar: I have decided" nil]]]]]
+             (with-language :sv
+               (fn []
+                 (with-fixed-time (time/date-time 2010)
+                   (fn []
+                     (#'pdf/render-application (applications/get-application-for-user "carl" application-id)))))))))))
 
 (deftest test-pdf-gold-standard
   (test-helpers/create-user! {:eppn "alice" :commonName "Alice Applicant" :mail "alice@example.com"})


### PR DESCRIPTION
implements #2161 

* feat: unify rendering of forms in application and pdf view
* feat: hide form if it contains only fields with `:field/private true`
* chore: add `vscode` specific files to gitignore (`.calva/` and `.lsp/`)

# Checklist for author

Remove items that aren't applicable, check items that are done.

## Reviewability
- [x] Link to issue
- [x] Consider adding screenshots for ease of review

## Documentation
- [x] Update changelog if necessary

## Testing
- [x] Valuable features are integration / browser / acceptance tested automatically

---
## screenshots (4 pictures, sorry for messy presentation)

### handler view (application)
![Screenshot 2021-08-26 at 17 31 21](https://user-images.githubusercontent.com/794087/130982222-ecd5ede6-2313-4aea-bfba-22a2511b2c10.png)
---
### handler view (pdf)
![Screenshot 2021-08-26 at 17 31 30](https://user-images.githubusercontent.com/794087/130982249-03df4254-d232-4775-a8bf-58ba720d4e5f.png)
---
### reviewer view (application)
![Screenshot 2021-08-26 at 17 32 06](https://user-images.githubusercontent.com/794087/130982313-9b111147-0c4c-4e31-a2d9-6546b20c68e7.png)
---
### reviewer view (pdf)
![Screenshot 2021-08-26 at 17 32 12](https://user-images.githubusercontent.com/794087/130982340-c2bdc4ca-807f-472c-a51c-57a6a57d3e81.png)