### PR TITLE
fix: relax schema to allow empty EGA map

### DIFF
--- a/src/clj/rems/db/user_settings.clj
+++ b/src/clj/rems/db/user_settings.clj
@@ -21,7 +21,7 @@
 (s/defschema DbUserSettings
   {:language s/Keyword
    (s/optional-key :notification-email) (s/maybe s/Str)
-   (s/optional-key :ega) {:api-key-expiration-date DateTime}})
+   (s/optional-key :ega) {(s/optional-key :api-key-expiration-date) DateTime}})
 
 (def ^:private validate-user-settings
   (s/validator UserSettings))


### PR DESCRIPTION
Tests seem to be failing randomly with some seeds because some tests generate users that don't have the required attributes. I think it makes sense to relax the DB schema for the EGA user settings. Existing users won't have them either without a migration. Tests should now pass with more certainty.

Original feature in #2637