### PR TITLE
feat: show CLI help on unrecognized command, otherwise start app

### DIFF
--- a/src/clj/rems/standalone.clj
+++ b/src/clj/rems/standalone.clj
@@ -217,9 +217,9 @@
             (when-not (validate/validate)
               (System/exit 2)))
 
-          ;; show usage if command is unrecognized
+          ;; show usage if argument is unrecognized
           (do
-            (println "Unrecognized command:" (first args))
+            (println "Unrecognized argument:" (first args))
             (usage)
             (System/exit 1)))
         ;; exit CLI after succesful command execution

--- a/src/clj/rems/standalone.clj
+++ b/src/clj/rems/standalone.clj
@@ -217,7 +217,6 @@
             (when-not (validate/validate)
               (System/exit 2)))
 
-          ;; show usage if argument is unrecognized
           (do
             (println "Unrecognized argument:" (first args))
             (usage)

--- a/src/clj/rems/standalone.clj
+++ b/src/clj/rems/standalone.clj
@@ -116,7 +116,7 @@
   (let [usage #(do
                  (println "Usage:")
                  (println (:doc (meta #'-main))))]
-    (if-not (seq args)
+    (if (empty? args)
       ;; start app by default if no CLI command was supplied
       (apply start-app args)
       (do
@@ -219,6 +219,7 @@
 
           ;; show usage if command is unrecognized
           (do
+            (println "Unrecognized command:" (first args))
             (usage)
             (System/exit 1)))
         ;; exit CLI after succesful command execution

--- a/src/clj/rems/standalone.clj
+++ b/src/clj/rems/standalone.clj
@@ -218,6 +218,8 @@
               (System/exit 2)))
 
           ;; show usage if command is unrecognized
-          (usage))
+          (do
+            (usage)
+            (System/exit 1)))
         ;; exit CLI after succesful command execution
         (System/exit 0)))))


### PR DESCRIPTION
implements #2518 

* if no args are provided, start server app from CLI (`$ lein run`)
* if provided arg is unrecognized, show usage help (same as running `$ lein run help`)
* exit CLI with code `0` after succesful command execution

# Checklist for author

Remove items that aren't applicable, check items that are done.

## Reviewability
- [x] Link to issue
- [x] Consider adding screenshots for ease of review

---
![Screenshot 2021-09-22 at 10 11 11](https://user-images.githubusercontent.com/794087/134298854-5d520591-7193-47ca-b27f-52a03911151b.png)
