### PR TITLE
fix: add run to standalone CLI parameters for uberjar

### DIFF
--- a/src/clj/rems/standalone.clj
+++ b/src/clj/rems/standalone.clj
@@ -121,6 +121,9 @@
       (apply start-app args)
       (do
         (case (first args)
+          "run"
+          (apply start-app args)
+          
           "help"
           (usage)
 

--- a/src/clj/rems/standalone.clj
+++ b/src/clj/rems/standalone.clj
@@ -123,7 +123,7 @@
         (case (first args)
           "run"
           (apply start-app args)
-          
+
           "help"
           (usage)
 


### PR DESCRIPTION
relates #2518 

* add `run` to supported arguments in standalone CLI to fix issue that occurred in previous PR where running uberjar with parameter `run` caused following error:
```
Unrecognized argument: run
```

# Checklist for author

Remove items that aren't applicable, check items that are done.

## Reviewability
- [x] Link to issue
