### PR TITLE
fix: check that expired-application-poller exists before stopping it

### DIFF
--- a/src/clj/rems/application/eraser.clj
+++ b/src/clj/rems/application/eraser.clj
@@ -52,7 +52,8 @@
 (mount/defstate expired-application-poller
   :start (when (:application-expiration env)
            (scheduler/start! remove-expired-applications! (.toStandardDuration (time/days 1))))
-  :stop (scheduler/stop! expired-application-poller))
+  :stop (when expired-application-poller
+          (scheduler/stop! expired-application-poller)))
 
 (comment
   (mount/defstate expired-application-poller-test


### PR DESCRIPTION
relates #2665 

* check that `expired-application-poller` defstate exists before calling `:stop`. this fixes issue where application eraser scheduler is stopped but the scheduler did not exist before (due to configuration)

# Checklist for author

Remove items that aren't applicable, check items that are done.

## Reviewability
- [x] Link to issue
