### PR TITLE
fix: use passive event listener for client keepalive

### DIFF
--- a/src/cljs/rems/keepalive.cljs
+++ b/src/cljs/rems/keepalive.cljs
@@ -8,4 +8,4 @@
 (defn register-keepalive-listeners! []
   (let [throttled-keepalive-listener (throttle keepalive! 60000)]
     (doseq [event ["mousedown", "mousemove", "keydown", "scroll", "touchstart"]]
-      (.addEventListener js/document event throttled-keepalive-listener true))))
+      (.addEventListener js/document event throttled-keepalive-listener (js-obj "passive" true)))))


### PR DESCRIPTION
https://www.chromestatus.com/feature/5745543795965952

keepalive event listener does not require to prevent default event behaviour, so we can hint the browser to optimize it's scrolling behaviour