### PR TITLE
feat: update circle ci to use java 17

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,10 +14,10 @@ defaults: &defaults
 executors:
   clojure:
     docker:
-      - image: circleci/clojure:openjdk-16-lein-2.9.5-buster-node-browsers
+      - image: circleci/clojure:openjdk-17-lein-2.9.7-buster-node-browsers
   db:
     docker:
-      - image: circleci/clojure:openjdk-16-lein-2.9.5-buster-node-browsers
+      - image: circleci/clojure:openjdk-17-lein-2.9.7-buster-node-browsers
       - image: postgres:13
         environment:
           POSTGRES_HOST_AUTH_METHOD: trust

--- a/docs/development.md
+++ b/docs/development.md
@@ -5,8 +5,8 @@
 In order to get started with REMS, you need to have the following software installed:
 
    - Docker
-   - Java. Currently REMS should be working with Java versions 11 to 16
-   - leiningen. As of 2021-04-14, the project should work with lein version Leiningen 2.9.5 on Java 16 OpenJDK 64-Bit Server VM.
+   - Java. Currently REMS should be working with Java versions 11 to 17
+   - leiningen. As of 2021-11-01, the project should work with lein version Leiningen 2.9.7 on Java 17 OpenJDK 64-Bit Server VM.
 ### Mac OS installation for Apple M1 Chip (Apple Silicon M1)
 
 1. Java Installation: install Java via Azul, make sure you download the version of [Java for MacOS for ARM architecture](https://www.azul.com/downloads/zulu-community/?os=macos&architecture=arm-64-bit&package=jdk).


### PR DESCRIPTION
relates #2726 

* tested rems locally with [OpenJDK 17.0.1+12](https://github.com/adoptium/temurin17-binaries/releases/tag/jdk-17.0.1%2B12)
* updated `.circleci/config.yml` to use JDK17 for building

NB! leiningen versions <2.9.7 will throw following complain on running which does not affect anything:
```
OpenJDK 64-Bit Server VM warning: Options -Xverify:none and -noverify were deprecated in JDK 13 and will likely be removed in a future release.
```

# Checklist for author

Remove items that aren't applicable, check items that are done.

## Reviewability
- [x] Link to issue

## Documentation
- [x] Update docs/ (if applicable)