### PR TITLE
2764/category db

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -165,4 +165,28 @@ components in various configurations and is useful for example to develop and do
 
 See a running guide as example [https://rems-dev.rahtiapp.fi/guide](https://rems-dev.rahtiapp.fi/guide).
 
+## Developing database migrations
 
+We use [Migratus](https://github.com/yogthos/migratus) for database migrations. It supports both SQL and Clojure code-based migrations. See `src/clj/rems/migrations/example.clj` for example on code-based migration.
+
+To create new migration:
+
+```sh
+lein migratus create feature-name
+```
+
+This will create two new files:
+```
+resources/migrations/20211105110533-feature-name.down.sql
+resources/migrations/20211105110533-feature-name.up.sql
+```
+
+To run specific migration down (use only timestamp as identifier):
+```sh
+lein migratus down 20211105110533
+```
+
+To run specific migration up:
+```sh
+lein migratus up 20211105110533
+```

--- a/resources/migrations/20211104084242-categories.down.sql
+++ b/resources/migrations/20211104084242-categories.down.sql
@@ -1,0 +1,4 @@
+DROP TABLE IF EXISTS category CASCADE;
+--;;
+ALTER TABLE catalogue_item
+DROP COLUMN catalogueitemdata;

--- a/resources/migrations/20211104084242-categories.up.sql
+++ b/resources/migrations/20211104084242-categories.up.sql
@@ -1,0 +1,8 @@
+CREATE TABLE category (
+  id serial NOT NULL PRIMARY KEY,
+  categorydata jsonb,
+  organization varchar(255)
+);
+--;;
+ALTER TABLE catalogue_item
+ ADD COLUMN catalogueitemdata jsonb;

--- a/resources/sql/queries.sql
+++ b/resources/sql/queries.sql
@@ -684,3 +684,25 @@ WHERE id = :id;
 -- :name delete-invitation! :!
 DELETE FROM invitation
 WHERE id = :id;
+
+-- :name get-category-by-id :? :1
+SELECT id, categorydata::TEXT, organization
+FROM category
+WHERE id = :id;
+
+-- :name get-categories :*
+SELECT id, categorydata::TEXT, organization
+FROM category;
+
+-- :name create-category! :insert
+INSERT INTO category (categorydata, organization)
+VALUES (:categorydata::jsonb, :organization);
+
+-- :name update-category! :!
+UPDATE category
+SET (categorydata, organization) = (:categorydata::jsonb, :organization)
+WHERE id = :id;
+
+-- :name delete-category! :!
+DELETE FROM category
+WHERE id = :id;

--- a/src/clj/rems/db/category.clj
+++ b/src/clj/rems/db/category.clj
@@ -9,7 +9,8 @@
             [medley.core :refer [assoc-some]]))
 
 (s/defschema CategoryData
-  {(s/optional-key :description) schema-base/LocalizedString
+  {:title schema-base/LocalizedString
+   (s/optional-key :description) schema-base/LocalizedString
    (s/optional-key :children) [{:id s/Int}]})
 
 (def ^:private validate-categorydata
@@ -54,10 +55,10 @@
     (reload-cache!))
   (vals @categories-cache))
 
-(defn- get-categorydata [{:keys [children description]}]
-  (-> {}
-      (assoc-some :children children)
-      (assoc-some :description description)))
+(defn- get-categorydata [{:keys [title description children]}]
+  (-> {:title title}
+      (assoc-some :description description)
+      (assoc-some :children children)))
 
 (defn- categorydata->json [category]
   (-> (get-categorydata category)

--- a/src/clj/rems/db/category.clj
+++ b/src/clj/rems/db/category.clj
@@ -1,0 +1,82 @@
+(ns rems.db.category
+  (:require [clojure.tools.logging :as log]
+            [rems.db.core :as db]
+            [rems.json :as json]
+            [rems.schema-base :as schema-base]
+            [rems.common.util :refer [build-index]]
+            [schema.coerce :as coerce]
+            [schema.core :as s]
+            [medley.core :refer [assoc-some]]))
+
+(s/defschema CategoryData
+  {(s/optional-key :description) schema-base/LocalizedString
+   (s/optional-key :children) [{:id s/Int}]})
+
+(def ^:private validate-categorydata
+  (s/validator CategoryData))
+
+(s/defschema CategoryDb
+  (-> {:id s/Int
+       :organization schema-base/OrganizationId}
+      (merge CategoryData)))
+
+(def ^:private coerce-CategoryDb
+  (coerce/coercer! CategoryDb coerce/string-coercion-matcher))
+
+(defn- format-category [category]
+  (let [categorydata (json/parse-string (:categorydata category))]
+    (-> category
+        (update :organization (fn [organization-id] {:organization/id organization-id}))
+        (dissoc :categorydata)
+        (merge categorydata))))
+
+(def ^:private categories-cache (atom nil))
+
+(defn reload-cache! []
+  (log/info :start #'reload-cache!)
+  (reset! categories-cache
+          (build-index {:keys [:id] :value-fn identity}
+                       (map (comp coerce-CategoryDb format-category)
+                            (db/get-categories))))
+  (log/info :end #'reload-cache!))
+
+(defn get-category
+  "Get a single category by id"
+  [id]
+  (when (nil? @categories-cache)
+    (reload-cache!))
+  (get @categories-cache id))
+
+(defn get-categories
+  "Get all categories"
+  []
+  (when (nil? @categories-cache)
+    (reload-cache!))
+  (vals @categories-cache))
+
+(defn- get-categorydata [{:keys [children description]}]
+  (-> {}
+      (assoc-some :children children)
+      (assoc-some :description description)))
+
+(defn- categorydata->json [category]
+  (-> (get-categorydata category)
+      validate-categorydata
+      json/generate-string))
+
+(defn create-category! [category]
+  (let [id (:id (db/create-category! {:organization (get-in category [:organization :organization/id])
+                                      :categorydata (categorydata->json category)}))]
+    (reload-cache!)
+    id))
+
+(defn update-category! [id category]
+  (let [id (:id (db/update-category! {:id id
+                                      :organization (get-in category [:organization :organization/id])
+                                      :categorydata (categorydata->json category)}))]
+    (reload-cache!)
+    id))
+
+(defn delete-category! [id]
+  (:id (db/delete-category! {:id id}))
+  (reload-cache!))


### PR DESCRIPTION
implements #2764

* create new table `category` with columns:
  * `id`, `categorydata` (jsonb), `organization`
* add `catalogueitemdata` (jsonb) column to `catalogue_item` table
* add `rems.db.category` namespace with related functions to CRUD categories
  * categories are cached to app memory
* add documentation to `development.md` regarding using migratus through CLI

`categorydata` has schema validation following keys:
* (required) `title` localized string
* (optional) `description` localized string
* (optional) `children` [{:id s/Str}]

# Checklist for author

Remove items that aren't applicable, check items that are done.

## Reviewability
- [x] Link to issue

## Documentation
- [x] Update docs/ (if applicable)

## Follow-up
- [x] New tasks are created for pending or remaining tasks #2777 
