### PR TITLE
fix: close (and flush) temp file stream on attachment upload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ have notable changes.
 
 Changes since v2.21
 
+### Fixes
+- Attachment uploading resulted in broken or empty files due to inproper stream handling, this behaviour is now fixed. (#2786)
+
 ## v2.21 "Veneentekijän(tie|kuja|kaari)" 2021-10-04
 
 **NB: This release contains migrations!**

--- a/src/clj/rems/multipart.clj
+++ b/src/clj/rems/multipart.clj
@@ -58,7 +58,8 @@
      (fn [item]
        (force clean-up)
        (let [temp-file (#'ring.middleware.multipart-params.temp-file/make-temp-file file-set)
-             maybe-error (size-checking-copy (:stream item) (io/output-stream temp-file) options)]
+             maybe-error (with-open [os (io/output-stream temp-file)]
+                           (size-checking-copy (:stream item) os options))]
          (when maybe-error
            (log/error "Upload is too large, filename" (:filename item) "max size" max-size))
          (-> (select-keys item [:filename :content-type])


### PR DESCRIPTION
fixes issue with attachment uploading where uploaded files were only partly uploaded or not at all. this is probably due to stream not having time to flush parts of bytes before handling is over

# Checklist for author

Remove items that aren't applicable, check items that are done.

## Reviewability
- [ ] Link to issue
- [ ] Note if PR is on top of other PR
- [ ] Note if related change in rems-deploy repo
- [ ] Consider adding screenshots for ease of review

## Backwards compatibility
- [ ] API is backwards compatible or completely new
- [ ] Events are backwards compatible _or_ have migrations
- [ ] Config is backwards compatible

## Documentation
- [x] Update changelog if necessary
- [ ] API is documented and shows up in Swagger UI
- [ ] Components are added to guide page
- [ ] Update docs/ (if applicable)
- [ ] Update manual/ (if applicable)
- [ ] ADR for major architectural decisions or experiments
- [ ] New config options in config-defaults.edn

## Testing
- [ ] Complex logic is unit tested
- [ ] Valuable features are integration / browser / acceptance tested automatically

## Follow-up
- [ ] New tasks are created for pending or remaining tasks
