### PR TITLE
fix: reset categories cache after all tests have run

### DIFF
--- a/src/clj/rems/db/category.clj
+++ b/src/clj/rems/db/category.clj
@@ -31,6 +31,9 @@
 
 (def ^:private categories-cache (atom nil))
 
+(defn reset-cache! []
+  (reset! categories-cache nil))
+
 (defn reload-cache! []
   (log/info :start #'reload-cache!)
   (reset! categories-cache

--- a/test/clj/rems/api/test_categories.clj
+++ b/test/clj/rems/api/test_categories.clj
@@ -2,21 +2,12 @@
   (:require [clojure.test :refer :all]
             [rems.db.testing :refer [owners-fixture +test-api-key+]]
             [rems.api.testing :refer :all]
-            [ring.mock.request :refer :all]
-            [rems.db.category :as category]))
+            [ring.mock.request :refer :all]))
 
 (use-fixtures
   :each
   api-fixture
   owners-fixture)
-
-(use-fixtures
-  :once
-  (fn [f]
-    (try
-      (f)
-      (finally
-        (category/reset-cache!)))))
 
 (deftest categories-api-create-test
   (let [owner "owner"

--- a/test/clj/rems/api/test_categories.clj
+++ b/test/clj/rems/api/test_categories.clj
@@ -2,12 +2,21 @@
   (:require [clojure.test :refer :all]
             [rems.db.testing :refer [owners-fixture +test-api-key+]]
             [rems.api.testing :refer :all]
-            [ring.mock.request :refer :all]))
+            [ring.mock.request :refer :all]
+            [rems.db.category :as category]))
 
 (use-fixtures
   :each
   api-fixture
   owners-fixture)
+
+(use-fixtures
+  :once
+  (fn [f]
+    (try
+      (f)
+      (finally
+        (category/reset-cache!)))))
 
 (deftest categories-api-create-test
   (let [owner "owner"

--- a/test/clj/rems/db/testing.clj
+++ b/test/clj/rems/db/testing.clj
@@ -10,6 +10,7 @@
             [rems.config :refer [env]]
             [rems.db.api-key :as api-key]
             [rems.db.applications]
+            [rems.db.category :as category]
             [rems.db.core :as db]
             [rems.db.test-data :as test-data]
             [rems.db.test-data-helpers :as test-helpers]
@@ -40,9 +41,11 @@
   (f))
 
 (defn caches-fixture [f]
-  ;; no specific teardown. relies on the teardown of test-db-fixture.
-  (mount/start #'rems.db.applications/all-applications-cache)
-  (f))
+  (try
+    (mount/start #'rems.db.applications/all-applications-cache)
+    (f)
+    (finally
+      (category/reset-cache!))))
 
 (def +test-api-key+ test-data/+test-api-key+) ;; re-exported for convenience
 


### PR DESCRIPTION
no issue, fixes flaky categories test

* after running all `rems.api.test-categories` tests, reset `rems.db.category/categories-cache` so that categories cache does not leak into other tests. this caused dependencies service tests to fail in flaky manner because categories were fetched from cache instead of DB, unrelated to dependencies tests
* add teardown to `rems.db.testing/caches-fixture` which can be used to rollback/reset caches after test function

# Checklist for author

Remove items that aren't applicable, check items that are done.

## Testing
- [x] Valuable features are integration / browser / acceptance tested automatically
