### PR TITLE
Refactor categories API

### DIFF
--- a/src/clj/rems/api/categories.clj
+++ b/src/clj/rems/api/categories.clj
@@ -45,11 +45,15 @@
       :roles #{:owner}
       :body [command schema/UpdateCategoryCommand]
       :return schema/SuccessResponse
-      (ok (category/update-category! command)))
+      (if (category/get-category (:category/id command))
+        (ok (category/update-category! command))
+        (not-found-json-response)))
 
     (POST "/remove" []
       :summary "Delete category"
       :roles #{:owner}
       :body [command schema/DeleteCategoryCommand]
       :return schema/SuccessResponse
-      (ok (category/delete-category! command)))))
+      (if (category/get-category (:category/id command))
+        (ok (category/delete-category! command))
+        (not-found-json-response)))))

--- a/src/clj/rems/db/category.clj
+++ b/src/clj/rems/db/category.clj
@@ -82,15 +82,5 @@
   (db/delete-category! {:id id})
   (reload-cache!))
 
-(defn- enrich-category [category]
-  (let [id (:category/id category)
-        unknown-category {:category/id id
-                          :category/title {:fi "Tuntematon kategoria"
-                                           :sv "Okänd kategori"
-                                           :en "Unknown category"}}]
-    (if-let [category (get-category id)]
-      category
-      unknown-category)))
-
 (defn enrich-categories [categories]
-  (mapv enrich-category categories))
+  (mapv #(get-category (:category/id %)) categories))

--- a/src/cljs/rems/administration/create_catalogue_item.cljs
+++ b/src/cljs/rems/administration/create_catalogue_item.cljs
@@ -1,6 +1,5 @@
 (ns rems.administration.create-catalogue-item
-  (:require [clojure.set :refer [intersection]]
-            [clojure.string :as str]
+  (:require [clojure.string :as str]
             [medley.core :refer [find-first map-vals]]
             [re-frame.core :as rf]
             [rems.administration.administration :as administration]
@@ -13,8 +12,7 @@
             [rems.flash-message :as flash-message]
             [rems.spinner :as spinner]
             [rems.text :refer [text localized]]
-            [rems.util :refer [navigate! post! put! trim-when-string]]
-            [rems.common.util :refer [build-index]]))
+            [rems.util :refer [navigate! post! put! trim-when-string]]))
 
 (defn- item-by-id [items id-key id]
   (find-first #(= (id-key %) id) items))


### PR DESCRIPTION
relates #2765 

* return 404 from categories API update and delete endpoints if category does not exist. category is fetched from cache unless cache has been cleared, so this should be a constant time check
* remove "unknown category" mapping

# Checklist for author

Remove items that aren't applicable, check items that are done.

## Reviewability
- [x] Link to issue

## Testing
- [x] Valuable features are integration / browser / acceptance tested automatically
