### PR TITLE
Category admin UI browser tests

### DIFF
--- a/src/cljs/rems/administration/administration.cljs
+++ b/src/cljs/rems/administration/administration.cljs
@@ -14,7 +14,7 @@
 
 (defn back-button [href]
   (let [previous-page @(rf/subscribe [::previous-page])]
-    [atoms/link {:class "btn btn-secondary"}
+    [atoms/link {:class "btn btn-secondary" :id :back}
      (or previous-page href)
      (text :t.administration/back)]))
 

--- a/src/cljs/rems/administration/category.cljs
+++ b/src/cljs/rems/administration/category.cljs
@@ -52,7 +52,7 @@
    (localized (:category/title category))])
 
 (defn- to-edit-category [category-id]
-  [atoms/link {:class "btn btn-primary"}
+  [atoms/link {:class "btn btn-primary" :id :edit}
    (str "/administration/categories/edit/" category-id)
    (text :t.administration/edit)])
 

--- a/src/cljs/rems/administration/edit_category.cljs
+++ b/src/cljs/rems/administration/edit_category.cljs
@@ -152,7 +152,7 @@
 
 (defn- cancel-button []
   (let [category (rf/subscribe [::category])]
-    [atoms/link {:class "btn btn-secondary"}
+    [atoms/link {:class "btn btn-secondary" :id :cancel}
      (str "/administration/categories/" (:category/id @category))
      (text :t.administration/cancel)]))
 

--- a/test/clj/rems/test_browser.clj
+++ b/test/clj/rems/test_browser.clj
@@ -2081,3 +2081,33 @@
     (is (btu/eventually-visible? {:tag :h1 :fn/text "Hakemukset"}))
     (user-settings/delete-user-settings! "alice") ; clear language settings
     (is true)))  ; avoid no assertions warning
+
+(deftest test-categories
+  (btu/with-postmortem
+    (login-as "owner")
+    (btu/scroll-and-click {:fn/text "Manage categories"})
+
+    (testing "create new category"
+      (btu/scroll-and-click :create-category)
+      (is (btu/eventually-visible? {:tag :h1 :fn/text "Create category"}))
+
+      (btu/fill-human :title-en "Test category")
+      (btu/fill-human :title-fi "Testikategoria")
+      (btu/fill-human :title-sv "Test kategori")
+      (btu/fill-human :description-en "Description")
+      (btu/fill-human :description-fi "Kuvaus")
+      (btu/fill-human :description-sv "Rubrik")
+      (select-option "Subcategories" "Ordinary")
+      (select-option "Subcategories" "Technical")
+      (btu/scroll-and-click :save)
+
+      (testing "after create"
+        (is (btu/eventually-visible? :category))
+        (is (= {"Title (EN)" "Test category"
+                "Title (FI)" "Testikategoria"
+                "Title (SV)" "Test kategori"
+                "Description (EN)" "Description"
+                "Description (FI)" "Kuvaus"
+                "Description (SV)" "Rubrik"
+                "Subcategories" "Ordinary, Technical"}
+               (slurp-fields :category)))))))

--- a/test/clj/rems/test_browser.clj
+++ b/test/clj/rems/test_browser.clj
@@ -2096,7 +2096,8 @@
     (login-as "owner")
     (go-to-admin "Catalogue items")
     (btu/scroll-and-click {:fn/text "Manage categories"})
-    (is (btu/eventually-visible? {:tag :h1 :fn/text "Categories"}))
+    (is (btu/eventually-visible? :categories))
+
 
     (testing "create new category"
       (btu/scroll-and-click :create-category)
@@ -2143,4 +2144,16 @@
                 "Description (FI)" "Description (FI)"
                 "Description (SV)" "Description (SV)"
                 "Subcategories" ""}
-               (slurp-fields :category)))))))
+               (slurp-fields :category)))))
+
+    (testing "delete category"
+      (btu/scroll-and-click :delete)
+      (btu/wait-has-alert) ;; are you sure you want to delete?
+      (btu/accept-alert)
+
+      (is (btu/eventually-visible? :categories))
+      (is (= #{"E2E category 1 (EN)" "E2E category 2 (EN)" "Ordinary" "Special" "Technical"}
+             (->> (slurp-rows :categories)
+                  (map #(get % "title"))
+                  (filter some?)
+                  set))))))

--- a/test/clj/rems/test_browser.clj
+++ b/test/clj/rems/test_browser.clj
@@ -2100,7 +2100,7 @@
 
     (testing "create new category"
       (btu/scroll-and-click :create-category)
-      (is (btu/eventually-visible? {:tag :h1 :fn/text "Create category"}))
+      (is (btu/eventually-visible? :create-category))
 
       (btu/fill-human :title-en "E2E Test category (EN)")
       (btu/fill-human :title-fi "E2E Test category (FI)")
@@ -2125,7 +2125,7 @@
 
     (testing "edit category"
       (btu/scroll-and-click {:tag :a :fn/text "Edit"})
-      (is (btu/eventually-visible? {:tag :h1 :fn/text "Edit category"}))
+      (is (btu/eventually-visible? :edit-category))
 
       (btu/clear :title-en)
       (btu/fill-human :title-en "Edited title (EN)")

--- a/test/clj/rems/test_browser.clj
+++ b/test/clj/rems/test_browser.clj
@@ -2095,7 +2095,7 @@
     (btu/fill-human :display-order (str display-order)))
   (when (seq categories)
     (doseq [cat categories]
-     (select-option "Subcategories" cat))))
+      (select-option "Subcategories" cat))))
 
 (defn navigate-to-categories []
   (go-to-admin "Catalogue items")


### PR DESCRIPTION
relates #2769 #2800 #2189

- add browser tests for category admin UI (create/update/delete):
  * create new category
  * edit category
  * create ancestor category (adding previously created category as sub-category)
  * update ancestor category as subcategory, resulting in loop error
  * delete category, resulting in dependency error (as it is sub-category of the ancestor category)
  * delete ancestor category

# Checklist for author

Remove items that aren't applicable, check items that are done.

## Reviewability
- [x] Link to issue

## Testing
- [x] Valuable features are integration / browser / acceptance tested automatically

## Follow-up
- [ ] New tasks are created for pending or remaining tasks
