### PR TITLE
feat: don't show empty categories

### DIFF
--- a/src/clj/rems/api/catalogue.clj
+++ b/src/clj/rems/api/catalogue.clj
@@ -41,7 +41,9 @@
       (cond
         (or (:catalogue-is-public env)
             (roles/has-roles? :logged-in))
-        (ok (catalogue/get-catalogue-tree (merge {:archived false :expand-catalogue-data? true}
+        (ok (catalogue/get-catalogue-tree (merge {:archived false
+                                                  :expand-catalogue-data? true
+                                                  :empty false}
                                                  (when-not (apply roles/has-roles? roles/+admin-read-roles+)  ; only admins get enabled and disabled items
                                                    {:enabled true}))))
 

--- a/src/clj/rems/api/services/catalogue.clj
+++ b/src/clj/rems/api/services/catalogue.clj
@@ -54,6 +54,14 @@
         categories-with-items (for [category (category/get-categories)
                                     :let [matching-items (filterv #(has-category? % category) catalogue-items)]]
                                 (assoc category :category/items matching-items))
+        categories-with-items (filter (fn [category]
+                                        (case (:empty query-params)
+                                          nil true ; not set, include all
+                                          false (or (seq (:category/children category))
+                                                    (seq (:category/items category)))
+                                          true (and (empty? (:category/children category))
+                                                    (empty? (:category/items category)))))
+                                      categories-with-items)
         items-without-category (for [item catalogue-items
                                      :when (empty? (:categories item))]
                                  item)


### PR DESCRIPTION
If a category does not have child categories or catalogue items then it's not shown.

See #2800.

# Checklist for author

Remove items that aren't applicable, check items that are done.

## Reviewability
- [x] Link to issue

## Testing
- [ ] Complex logic is unit tested
- [ ] Valuable features are integration / browser / acceptance tested automatically