### PR TITLE
Display order

### DIFF
--- a/resources/translations/en.edn
+++ b/resources/translations/en.edn
@@ -102,6 +102,7 @@
                    :disable "Disable"
                    :disabled-and-archived-explanation "Disabling hides an item from applicants. Archiving also hides it in the administration view."
                    :display-archived "Display archived"
+                   :display-order "Display order"
                    :duo {:codes "DUO codes"
                          :code "DUO code"
                          :description "Description"

--- a/resources/translations/fi.edn
+++ b/resources/translations/fi.edn
@@ -100,6 +100,7 @@
                    :disable "Poista käytöstä"
                    :disabled-and-archived-explanation "Käytöstä poistaminen piilottaa asian käyttäjiltä. Arkistoiminen piilottaa sen myös ylläpitonäkymästä."
                    :display-archived "Näytä arkistoidut"
+                   :display-order "Näyttöjärjestys"
                    :duo {:codes "DUO koodit"
                          :code "DUO koodi"
                          :description "Kuvaus"

--- a/resources/translations/sv.edn
+++ b/resources/translations/sv.edn
@@ -100,7 +100,7 @@
                    :disable "Avaktivera"
                    :disabled-and-archived-explanation "Att avaktivera ett föremål gör att det döljs för användarna. Att arkivera det gör att det även döljs från administrationsvyn."
                    :display-archived "Visa arkiverade"
-                   :display-order "Visa ordning"
+                   :display-order "Visningsordning"
                    :duo {:codes "DUO koder"
                          :code "DUO kod"
                          :description "Rubrik"

--- a/resources/translations/sv.edn
+++ b/resources/translations/sv.edn
@@ -100,6 +100,7 @@
                    :disable "Avaktivera"
                    :disabled-and-archived-explanation "Att avaktivera ett föremål gör att det döljs för användarna. Att arkivera det gör att det även döljs från administrationsvyn."
                    :display-archived "Visa arkiverade"
+                   :display-order "Visa ordning"
                    :duo {:codes "DUO koder"
                          :code "DUO kod"
                          :description "Rubrik"

--- a/src/clj/rems/api/schema.clj
+++ b/src/clj/rems/api/schema.clj
@@ -289,6 +289,7 @@
 (s/defschema CreateCategoryCommand
   {:category/title schema-base/LocalizedString
    (s/optional-key :category/description) schema-base/LocalizedString
+   (s/optional-key :category/display-order) s/Int
    (s/optional-key :category/children) [schema-base/CategoryId]})
 
 (s/defschema UpdateCategoryCommand

--- a/src/clj/rems/db/category.clj
+++ b/src/clj/rems/db/category.clj
@@ -62,10 +62,13 @@
   (vals @categories-cache))
 
 (defn- get-categorydata [category]
-  (-> {:category/title (:category/title category)}
-      (assoc-some :category/description (:category/description category))
-      (assoc-some :category/display-order (:category/display-order category))
-      (assoc-some :category/children (:category/children category))))
+  (let [display-order(some-> (:category/display-order category)
+                             (max 0)
+                             (min 1000000))]
+    (-> {:category/title (:category/title category)}
+        (assoc-some :category/description (:category/description category))
+        (assoc-some :category/display-order display-order)
+        (assoc-some :category/children (:category/children category)))))
 
 (defn- categorydata->json [category]
   (-> (get-categorydata category)

--- a/src/clj/rems/db/category.clj
+++ b/src/clj/rems/db/category.clj
@@ -62,9 +62,9 @@
   (vals @categories-cache))
 
 (defn- get-categorydata [category]
-  (let [display-order(some-> (:category/display-order category)
-                             (max 0)
-                             (min 1000000))]
+  (let [display-order (some-> (:category/display-order category)
+                              (max 0)
+                              (min 1000000))]
     (-> {:category/title (:category/title category)}
         (assoc-some :category/description (:category/description category))
         (assoc-some :category/display-order display-order)

--- a/src/clj/rems/db/category.clj
+++ b/src/clj/rems/db/category.clj
@@ -12,6 +12,7 @@
 (s/defschema CategoryData
   {:category/title schema-base/LocalizedString
    (s/optional-key :category/description) schema-base/LocalizedString
+   (s/optional-key :category/display-order) s/Int
    (s/optional-key :category/children) [schema-base/CategoryId]})
 
 (def ^:private validate-categorydata
@@ -62,6 +63,7 @@
 (defn- get-categorydata [category]
   (-> {:category/title (:category/title category)}
       (assoc-some :category/description (:category/description category))
+      (assoc-some :category/display-order (:category/display-order category))
       (assoc-some :category/children (:category/children category))))
 
 (defn- categorydata->json [category]

--- a/src/clj/rems/schema_base.clj
+++ b/src/clj/rems/schema_base.clj
@@ -106,6 +106,7 @@
   (merge CategoryId
          {:category/title LocalizedString
           (s/optional-key :category/description) LocalizedString
+          (s/optional-key :category/display-order) s/Int
           (s/optional-key :category/children) [CategoryId]}))
 
 (s/defschema CategoryFull

--- a/src/cljc/rems/common/util.cljc
+++ b/src/cljc/rems/common/util.cljc
@@ -478,6 +478,19 @@
   (is (= nil (parse-int "a")))
   (is (= 7 (parse-int "7"))))
 
+(defn clamp
+  "Clamps `x` to be between `low` and `high` inclusive."
+  [x low high]
+  (-> x
+      (min high)
+      (max low)))
+
+(deftest test-clamp
+  (is (= 0 (clamp -1 0 1)))
+  (is (= 0 (clamp 1 0 0)))
+  (is (= 1 (clamp 2 0 1)))
+  (is (= 0 (clamp 0 0 1))))
+
 (defn remove-empty-keys
   "Given a map, recursively remove keys with empty map or nil values.
 

--- a/src/cljs/rems/administration/categories.cljs
+++ b/src/cljs/rems/administration/categories.cljs
@@ -59,6 +59,9 @@
  (fn [[categories language] _]
    (map (fn [category]
           {:key (:category/id category)
+           :display-order {:value (:category/display-order category)
+                           :sort-value [(:category/display-order category 2147483647)  ; can't use Java Integer/MAX_VALUE here but anything that is not set is last
+                                        (get-in category [:category/title language])]} ; secondary sort-key is the same in the catalogue
            :title {:value (get-in category [:category/title language])}
            :description {:value (get-in category [:category/description language])}
            :commands {:td [:td.commands
@@ -69,7 +72,9 @@
 
 (defn- categories-list []
   (let [categories-table {:id ::categories
-                          :columns [{:key :title
+                          :columns [{:key :display-order
+                                     :title (text :t.administration/display-order)}
+                                    {:key :title
                                      :title (text :t.administration/category)}
                                     {:key :description
                                      :title (text :t.administration/description)}
@@ -77,7 +82,7 @@
                                      :sortable? false
                                      :filterable? false}]
                           :rows [::categories-table-rows]
-                          :default-sort-column :title}]
+                          :default-sort-column :display-order}]
     [:div.mt-3
      [table/search categories-table]
      [table/table categories-table]]))

--- a/src/cljs/rems/administration/category.cljs
+++ b/src/cljs/rems/administration/category.cljs
@@ -73,6 +73,7 @@
        :always [:div
                 [localized-info-field (:category/title @category) {:label (text :t.administration/title)}]
                 [localized-info-field (:category/description @category) {:label (text :t.administration/description)}]
+                [inline-info-field (text :t.administration/display-order) (:category/display-order @category)]
                 [inline-info-field (text :t.administration/category-children)
                  (when-let [categories (:category/children @category)]
                    (doall (interpose ", " (for [cat categories]

--- a/src/cljs/rems/administration/components.cljs
+++ b/src/cljs/rems/administration/components.cljs
@@ -20,6 +20,7 @@
             [rems.dropdown :as dropdown]
             [rems.fields :as fields]
             [rems.common.roles :as roles]
+            [rems.common.util :refer [clamp parse-int]]
             [rems.text :refer [text text-format]]))
 
 (defn- key-to-id [key]
@@ -78,6 +79,7 @@
   [context keys]
   (input-field (merge keys {:context context
                             :type "number"
+                            :normalizer #(some-> % parse-int (clamp (:min keys 0) (:max keys 1000000)))
                             :min 0
                             :max 1000000})))
 

--- a/src/cljs/rems/administration/components.cljs
+++ b/src/cljs/rems/administration/components.cljs
@@ -36,7 +36,7 @@
   [:div {:class "invalid-feedback"}
    (when error (text-format error label))])
 
-(defn input-field [{:keys [keys label placeholder context type normalizer readonly inline? input-style]}]
+(defn input-field [{:keys [keys label placeholder context type normalizer readonly inline? input-style] :as opts}]
   (let [form @(rf/subscribe [(:get-form context)])
         form-errors (when (:get-form-errors context)
                       @(rf/subscribe [(:get-form-errors context)]))
@@ -50,16 +50,17 @@
                        "administration-field-label")}
       label]
      [:div {:class (when inline? "col")}
-      [:input.form-control {:type type
-                            :id id
-                            :style input-style
-                            :disabled readonly
-                            :placeholder placeholder
-                            :class (when error "is-invalid")
-                            :value (get-in form keys)
-                            :on-change #(rf/dispatch [(:update-form context)
-                                                      keys
-                                                      (normalizer (.. % -target -value))])}]
+      [:input.form-control (merge {:type type
+                                   :id id
+                                   :style input-style
+                                   :disabled readonly
+                                   :placeholder placeholder
+                                   :class (when error "is-invalid")
+                                   :value (get-in form keys)
+                                   :on-change #(rf/dispatch [(:update-form context)
+                                                             keys
+                                                             (normalizer (.. % -target -value))])}
+                                  (select-keys opts [:min :max]))]
       [field-validation-message error label]]]))
 
 (defn text-field
@@ -75,7 +76,10 @@
 (defn number-field
   "A basic number field, full page width."
   [context keys]
-  (input-field (merge keys {:context context :type "number"})))
+  (input-field (merge keys {:context context
+                            :type "number"
+                            :min 0
+                            :max 1000000})))
 
 (defn textarea-autosize
   "A basic textarea, full page width."

--- a/src/cljs/rems/administration/components.cljs
+++ b/src/cljs/rems/administration/components.cljs
@@ -72,6 +72,11 @@
   [context keys]
   (input-field (merge keys {:context context :type "text" :inline? true})))
 
+(defn number-field
+  "A basic number field, full page width."
+  [context keys]
+  (input-field (merge keys {:context context :type "number"})))
+
 (defn textarea-autosize
   "A basic textarea, full page width."
   [context {:keys [keys label placeholder]}]

--- a/src/cljs/rems/administration/create_category.cljs
+++ b/src/cljs/rems/administration/create_category.cljs
@@ -2,7 +2,7 @@
   (:require [clojure.string :as str]
             [re-frame.core :as rf]
             [rems.administration.administration :as administration]
-            [rems.administration.components :refer [localized-text-field]]
+            [rems.administration.components :refer [localized-text-field number-field]]
             [rems.atoms :as atoms :refer [document-title]]
             [rems.collapsible :as collapsible]
             [rems.dropdown :as dropdown]
@@ -32,6 +32,7 @@
 (defn build-request [form]
   (let [request {:category/title (:title form)
                  :category/description (:description form)
+                 :category/display-order (:display-order form)
                  :category/children (map #(select-keys % [:category/id]) (:categories form))}]
     (when (valid-request? request)
       request)))
@@ -60,6 +61,10 @@
 (defn- category-description-field []
   [localized-text-field context {:keys [:description]
                                  :label (text :t.administration/description)}])
+
+(defn- category-display-order-field []
+  [number-field context {:keys [:display-order]
+                         :label (text :t.administration/display-order)}])
 
 (defn- category-children-field []
   (let [categories @(rf/subscribe [::categories])
@@ -108,6 +113,7 @@
                   [:div#category-editor.fields
                    [category-title-field]
                    [category-description-field]
+                   [category-display-order-field]
                    [category-children-field]
 
                    [:div.col.commands

--- a/src/cljs/rems/administration/edit_category.cljs
+++ b/src/cljs/rems/administration/edit_category.cljs
@@ -2,7 +2,7 @@
   (:require [clojure.string :as str]
             [re-frame.core :as rf]
             [rems.administration.administration :as administration]
-            [rems.administration.components :refer [localized-text-field]]
+            [rems.administration.components :refer [localized-text-field number-field]]
             [rems.atoms :as atoms :refer [document-title]]
             [rems.collapsible :as collapsible]
             [rems.common.util :refer [parse-int]]
@@ -29,6 +29,7 @@
     (when-let [category (get-in db [::category :data])]
       {::form {:title (:category/title category)
                :description (:category/description category)
+               :display-order (:category/display-order category)
                :categories (:category/children category)}}))))
 
 (fetcher/reg-fetcher ::categories "/api/categories")
@@ -47,6 +48,7 @@
 (defn build-request [form]
   (let [request {:category/title (:title form)
                  :category/description (:description form)
+                 :category/display-order (parse-int (:display-order form))
                  :category/children (map #(select-keys % [:category/id]) (:categories form))}]
     (when (valid-request? request)
       request)))
@@ -89,6 +91,10 @@
   [localized-text-field context {:keys [:description]
                                  :label (str (text :t.administration/description) " "
                                              (text :t.administration/optional))}])
+
+(defn- category-display-order-field []
+  [number-field context {:keys [:display-order]
+                         :label (text :t.administration/display-order)}])
 
 (defn- category-children-field []
   (let [category-id (:category/id @(rf/subscribe [::category]))
@@ -147,6 +153,7 @@
                   [:div#category-editor.fields
                    [category-title-field]
                    [category-description-field]
+                   [category-display-order-field]
                    [category-children-field]
 
                    [:div.col.commands

--- a/src/cljs/rems/catalogue.cljs
+++ b/src/cljs/rems/catalogue.cljs
@@ -126,7 +126,9 @@
                    :show-matching-parents? (:catalogue-tree-show-matching-parents config)
                    :columns [{:key :name
                               :value #(or (get (:category/title %) language) (get-localized-title % language))
-                              :sort-value #(str (get (:category/title %) language) "/" (get-localized-title % language))
+                              :sort-value #(vector (:category/display-order % 2147483647) ; can't use Java Integer/MAX_VALUE here but anything that is not set is last
+                                                   (get (:category/title %) language "_") ; "_" means not set i.e. item is last
+                                                   (get-localized-title % language))
                               :title (text :t.catalogue/header)
                               :content #(if (:category/id %)
                                           [:div.my-2
@@ -148,7 +150,7 @@
                               :filterable? false}]
                    :children #(concat (:category/items %) (:category/children %))
                    :rows [::catalogue-tree]
-                   :default-sort-column :no-default-sort}]
+                   :default-sort-column :name}]
     [:div
      [tree/search catalogue]
      [tree/tree catalogue]]))

--- a/src/cljs/rems/tree.cljs
+++ b/src/cljs/rems/tree.cljs
@@ -29,7 +29,9 @@
                                                 value (if-let [value-fn (:value column (:key column))]
                                                         (value-fn row)
                                                         (get row (:key column)))
-                                                display-value (str value)
+                                                display-value (if-let [display-value-fn (:display-value column)]
+                                                                (display-value-fn row)
+                                                                (str value))
                                                 filter-value (if-let [filter-value-fn (:filter-value column)]
                                                                (filter-value-fn row)
                                                                (str/lower-case display-value))

--- a/test/clj/rems/api/test_categories.clj
+++ b/test/clj/rems/api/test_categories.clj
@@ -15,6 +15,7 @@
         create-category-data {:category/title {:fi "integraatiotesti"
                                                :sv "integrationstest"
                                                :en "integration test"}
+                              :category/display-order 10000000 ; will be capped to max value
                               :category/description {:fi "integraatiotesti"
                                                      :sv "integrationstest"
                                                      :en "integration test"}
@@ -37,7 +38,8 @@
           (let [result (api-call :get (str "/api/categories/" (:category/id category)) nil
                                  +test-api-key+ owner)
                 expected (merge create-category-data
-                                {:category/id (:category/id category)})]
+                                {:category/id (:category/id category)
+                                 :category/display-order 1000000})]
             (is (= expected result))))))
 
     (testing "adding category as children"
@@ -59,7 +61,9 @@
                                  +test-api-key+ owner)
                 expected (merge create-category-data
                                 {:category/id (:category/id category)
-                                 :category/children [(merge {:category/id (:category/id dep-category)}
+                                 :category/display-order 1000000
+                                 :category/children [(merge {:category/id (:category/id dep-category)
+                                                             :category/display-order 1000000}
                                                             (select-keys create-category-data
                                                                          [:category/title :category/description :category/children]))]})]
             (is (= expected result))))))


### PR DESCRIPTION
Display order field that decides the ordering of the catalogue tree categories.

Tries to match it in the catalogue list too.

For #2800

![edit_world_order](https://user-images.githubusercontent.com/823661/146774843-02a6e0b7-65c5-4b2b-a9e4-badfafba3043.png)
![categories_sorted_out](https://user-images.githubusercontent.com/823661/146774852-f324a55b-2b0c-48db-8b17-10c29cb382bb.png)
![new_world_order](https://user-images.githubusercontent.com/823661/146774860-d698ed26-0876-4967-b0a0-b519d24660bd.png)


# Checklist for author

Remove items that aren't applicable, check items that are done.

## Reviewability
- [x] Link to issue
- [x] Consider adding screenshots for ease of review
