### PR TITLE
feat: allow org owners to edit categories

### DIFF
--- a/src/clj/rems/api/categories.clj
+++ b/src/clj/rems/api/categories.clj
@@ -4,7 +4,7 @@
             [rems.schema-base :as schema-base]
             [rems.api.services.category :as category]
             [rems.api.util :refer [not-found-json-response]]
-            [rems.common.roles :refer [+admin-read-roles+]]
+            [rems.common.roles :refer [+admin-read-roles+ +admin-write-roles+]]
             [ring.util.http-response :refer :all]
             [schema.core :as s]))
 
@@ -35,14 +35,14 @@
 
     (POST "/" []
       :summary "Create category"
-      :roles #{:owner}
+      :roles +admin-write-roles+
       :body [command schema/CreateCategoryCommand]
       :return CreateCategoryResponse
       (ok (category/create-category! command)))
 
     (PUT "/" []
       :summary "Update category"
-      :roles #{:owner}
+      :roles +admin-write-roles+
       :body [command schema/UpdateCategoryCommand]
       :return schema/SuccessResponse
       (if (category/get-category (:category/id command))
@@ -51,7 +51,7 @@
 
     (POST "/delete" []
       :summary "Delete category"
-      :roles #{:owner}
+      :roles +admin-write-roles+
       :body [command schema/DeleteCategoryCommand]
       :return schema/SuccessResponse
       (if (category/get-category (:category/id command))

--- a/test/clj/rems/api/test_categories.clj
+++ b/test/clj/rems/api/test_categories.clj
@@ -12,6 +12,7 @@
 
 (deftest categories-api-create-test
   (let [owner "owner"
+        org-owner "organization-owner1"
         create-category-data {:category/title {:fi "integraatiotesti"
                                                :sv "integrationstest"
                                                :en "integration test"}
@@ -21,66 +22,66 @@
                                                      :en "integration test"}
                               :category/children []}]
 
-    (testing "fetch nonexistent"
-      (let [response (api-response :get "/api/categories/9999999" nil
-                                   +test-api-key+ owner)]
-        (is (response-is-not-found? response))
-        (is (= {:error "not found"} (read-body response)))))
+    (doseq [user-id [owner org-owner]]
+      (testing "fetch nonexistent"
+        (let [response (api-response :get "/api/categories/9999999" nil
+                                     +test-api-key+ user-id)]
+          (is (response-is-not-found? response))
+          (is (= {:error "not found"} (read-body response)))))
 
-    (testing "create"
-      (let [category (api-call :post "/api/categories"
-                               create-category-data
-                               +test-api-key+ owner)]
-        (is (:success category))
-        (is (int? (:category/id category)))
-
-        (testing "and fetch"
-          (let [result (api-call :get (str "/api/categories/" (:category/id category)) nil
-                                 +test-api-key+ owner)
-                expected (merge create-category-data
-                                {:category/id (:category/id category)
-                                 :category/display-order 1000000})]
-            (is (= expected result))))))
-
-    (testing "adding category as children"
-      (let [owner "owner"
-            dep-category (api-call :post "/api/categories"
-                                   create-category-data
-                                   +test-api-key+ owner)]
-        (is (:success dep-category))
-        (is (int? (:category/id dep-category)))
-
+      (testing "create"
         (let [category (api-call :post "/api/categories"
-                                 (merge create-category-data
-                                        {:category/children [{:category/id (:category/id dep-category)}]})
-                                 +test-api-key+ owner)]
+                                 create-category-data
+                                 +test-api-key+ user-id)]
           (is (:success category))
           (is (int? (:category/id category)))
 
-          (let [result (api-call :get (str "/api/categories/" (:category/id category)) nil
-                                 +test-api-key+ owner)
-                expected (merge create-category-data
-                                {:category/id (:category/id category)
-                                 :category/display-order 1000000
-                                 :category/children [(merge {:category/id (:category/id dep-category)
-                                                             :category/display-order 1000000}
-                                                            (select-keys create-category-data
-                                                                         [:category/title :category/description :category/children]))]})]
-            (is (= expected result))))))
+          (testing "and fetch"
+            (let [result (api-call :get (str "/api/categories/" (:category/id category)) nil
+                                   +test-api-key+ user-id)
+                  expected (merge create-category-data
+                                  {:category/id (:category/id category)
+                                   :category/display-order 1000000})]
+              (is (= expected result))))))
 
-    (testing "creating category with non-existing children should fail"
-      (let [owner "owner"
-            result (api-call :post "/api/categories"
-                             (merge create-category-data
-                                    {:category/children [{:category/id 9999999}]})
-                             +test-api-key+ owner)]
-        (is (not (:success result)))
-        (is (= [{:type "t.administration.errors/dependencies-not-found"
-                 :categories [{:category/id 9999999}]}]
-               (:errors result)))))))
+      (testing "adding category as children"
+        (let [dep-category (api-call :post "/api/categories"
+                                     create-category-data
+                                     +test-api-key+ user-id)]
+          (is (:success dep-category))
+          (is (int? (:category/id dep-category)))
+
+          (let [category (api-call :post "/api/categories"
+                                   (merge create-category-data
+                                          {:category/children [{:category/id (:category/id dep-category)}]})
+                                   +test-api-key+ user-id)]
+            (is (:success category))
+            (is (int? (:category/id category)))
+
+            (let [result (api-call :get (str "/api/categories/" (:category/id category)) nil
+                                   +test-api-key+ user-id)
+                  expected (merge create-category-data
+                                  {:category/id (:category/id category)
+                                   :category/display-order 1000000
+                                   :category/children [(merge {:category/id (:category/id dep-category)
+                                                               :category/display-order 1000000}
+                                                              (select-keys create-category-data
+                                                                           [:category/title :category/description :category/children]))]})]
+              (is (= expected result))))))
+
+      (testing "creating category with non-existing children should fail"
+        (let [result (api-call :post "/api/categories"
+                               (merge create-category-data
+                                      {:category/children [{:category/id 9999999}]})
+                               +test-api-key+ user-id)]
+          (is (not (:success result)))
+          (is (= [{:type "t.administration.errors/dependencies-not-found"
+                   :categories [{:category/id 9999999}]}]
+                 (:errors result))))))))
 
 (deftest categories-api-update-test
   (let [owner "owner"
+        org-owner "organization-owner1"
         create-category-data {:category/title {:fi "integraatiotesti"
                                                :sv "integrationstest"
                                                :en "integration test"}
@@ -91,80 +92,81 @@
         update-category-data {:category/title {:fi "integraatiotesti 2"
                                                :sv "integrationstest 2"
                                                :en "integration test 2"}}]
+    (doseq [user-id [owner org-owner]]
+      (testing "create"
+        (let [category (api-call :post "/api/categories"
+                                 create-category-data
+                                 +test-api-key+ user-id)]
+          (is (:success category))
+          (is (int? (:category/id category)))
 
-    (testing "create"
-      (let [category (api-call :post "/api/categories"
-                               create-category-data
-                               +test-api-key+ owner)]
-        (is (:success category))
-        (is (int? (:category/id category)))
+          (testing "and update"
+            (let [update-result (api-call :put "/api/categories"
+                                          (merge create-category-data
+                                                 update-category-data
+                                                 {:category/id (:category/id category)})
+                                          +test-api-key+ user-id)]
+              (is (:success update-result))
 
-        (testing "and update"
-          (let [update-result (api-call :put "/api/categories"
-                                        (merge create-category-data
-                                               update-category-data
-                                               {:category/id (:category/id category)})
-                                        +test-api-key+ owner)]
-            (is (:success update-result))
+              (let [result (api-call :get (str "/api/categories/" (:category/id category)) nil
+                                     +test-api-key+ user-id)
+                    expected (merge create-category-data
+                                    update-category-data
+                                    {:category/id (:category/id category)})]
+                (is (= expected result)))))
 
-            (let [result (api-call :get (str "/api/categories/" (:category/id category)) nil
-                                   +test-api-key+ owner)
-                  expected (merge create-category-data
-                                  update-category-data
-                                  {:category/id (:category/id category)})]
-              (is (= expected result)))))
-
-        (testing "updating category with self as child should fail"
-          (let [result (api-call :put "/api/categories"
-                                 (merge create-category-data
-                                        update-category-data
-                                        {:category/id (:category/id category)
-                                         :category/children [{:category/id (:category/id category)}]})
-                                 +test-api-key+ owner)]
-            (is (not (:success result)))
-            (is (= [{:type "t.administration.errors/self-as-subcategory-disallowed"
-                     :category/id (:category/id category)}]
-                   (:errors result)))))
-
-        (testing "should error when setting ancestor categories as category children"
-          (let [ancestor-category (api-call :post "/api/categories"
-                                            (merge create-category-data
-                                                   {:category/children [{:category/id (:category/id category)}]})
-                                            +test-api-key+ owner)
-                subcategory (api-call :post "/api/categories"
-                                      create-category-data
-                                      +test-api-key+ owner)
-                update-parent-result (api-call :put "/api/categories"
-                                               (merge create-category-data
-                                                      {:category/id (:category/id category)
-                                                       :category/children [{:category/id (:category/id subcategory)}]})
-                                               +test-api-key+ owner)
-                loop-update-result (api-call :put "/api/categories"
-                                             (merge create-category-data
-                                                    {:category/id (:category/id subcategory)
-                                                     :category/children [{:category/id (:category/id ancestor-category)}
-                                                                         {:category/id (:category/id category)}]})
-                                             +test-api-key+ owner)]
-            (is (:success update-parent-result))
-            (is (not (:success loop-update-result)))
-            (is (= [{:type "t.administration.errors/ancestor-as-subcategory-disallowed"
-                     :categories [{:category/id (:category/id ancestor-category)
-                                   :category/title (:category/title create-category-data)}
-                                  {:category/id (:category/id category)
-                                   :category/title (:category/title create-category-data)}]}]
-                   (:errors loop-update-result)))))))
-
-    (testing "updating non-existing category returns 404"
-      (let [response (api-response :put "/api/categories"
+          (testing "updating category with self as child should fail"
+            (let [result (api-call :put "/api/categories"
                                    (merge create-category-data
                                           update-category-data
-                                          {:category/id 9999999})
-                                   +test-api-key+ owner)]
-        (is (not (:success response)))
-        (is (= {:error "not found"} (read-body response)))))))
+                                          {:category/id (:category/id category)
+                                           :category/children [{:category/id (:category/id category)}]})
+                                   +test-api-key+ user-id)]
+              (is (not (:success result)))
+              (is (= [{:type "t.administration.errors/self-as-subcategory-disallowed"
+                       :category/id (:category/id category)}]
+                     (:errors result)))))
+
+          (testing "should error when setting ancestor categories as category children"
+            (let [ancestor-category (api-call :post "/api/categories"
+                                              (merge create-category-data
+                                                     {:category/children [{:category/id (:category/id category)}]})
+                                              +test-api-key+ user-id)
+                  subcategory (api-call :post "/api/categories"
+                                        create-category-data
+                                        +test-api-key+ user-id)
+                  update-parent-result (api-call :put "/api/categories"
+                                                 (merge create-category-data
+                                                        {:category/id (:category/id category)
+                                                         :category/children [{:category/id (:category/id subcategory)}]})
+                                                 +test-api-key+ user-id)
+                  loop-update-result (api-call :put "/api/categories"
+                                               (merge create-category-data
+                                                      {:category/id (:category/id subcategory)
+                                                       :category/children [{:category/id (:category/id ancestor-category)}
+                                                                           {:category/id (:category/id category)}]})
+                                               +test-api-key+ user-id)]
+              (is (:success update-parent-result))
+              (is (not (:success loop-update-result)))
+              (is (= [{:type "t.administration.errors/ancestor-as-subcategory-disallowed"
+                       :categories [{:category/id (:category/id ancestor-category)
+                                     :category/title (:category/title create-category-data)}
+                                    {:category/id (:category/id category)
+                                     :category/title (:category/title create-category-data)}]}]
+                     (:errors loop-update-result)))))))
+
+      (testing "updating non-existing category returns 404"
+        (let [response (api-response :put "/api/categories"
+                                     (merge create-category-data
+                                            update-category-data
+                                            {:category/id 9999999})
+                                     +test-api-key+ user-id)]
+          (is (not (:success response)))
+          (is (= {:error "not found"} (read-body response))))))))
 
 (deftest categories-api-delete-test
   (let [owner "owner"
+        org-owner "organization-owner1"
         create-category-data {:category/title {:fi "integraatiotesti"
                                                :sv "integrationstest"
                                                :en "integration test"}
@@ -173,77 +175,78 @@
                                                      :en "integration test"}
                               :category/children []}]
 
-    (testing "create"
-      (let [dep-category (api-call :post "/api/categories"
-                                   create-category-data
-                                   +test-api-key+ owner)
-            category (api-call :post "/api/categories"
-                               (merge create-category-data
-                                      {:category/children [{:category/id (:category/id dep-category)}]})
-                               +test-api-key+ owner)]
-        (is (:success dep-category))
-        (is (:success category))
-        (is (int? (:category/id dep-category)))
-        (is (int? (:category/id category)))
-
-        (testing "and delete"
-          (let [result (api-call :post "/api/categories/delete"
-                                 {:category/id (:category/id category)}
-                                 +test-api-key+ owner)]
-            (is (:success result))
-
-            (let [response (api-response :get (str "/api/categories/" (:category/id category)) nil
-                                         +test-api-key+ owner)]
-              (is (response-is-not-found? response))
-              (is (= {:error "not found"} (read-body response))))))))
-
-    (testing "cannot delete category that is depended on by another category"
-      (let [dep-category (api-call :post "/api/categories"
-                                   create-category-data
-                                   +test-api-key+ owner)]
-        (is (:success dep-category))
-        (is (int? (:category/id dep-category)))
-
-        (let [category (api-call :post "/api/categories"
+    (doseq [user-id [owner org-owner]]
+      (testing "create"
+        (let [dep-category (api-call :post "/api/categories"
+                                     create-category-data
+                                     +test-api-key+ user-id)
+              category (api-call :post "/api/categories"
                                  (merge create-category-data
                                         {:category/children [{:category/id (:category/id dep-category)}]})
-                                 +test-api-key+ owner)]
+                                 +test-api-key+ user-id)]
+          (is (:success dep-category))
           (is (:success category))
+          (is (int? (:category/id dep-category)))
           (is (int? (:category/id category)))
 
-          (let [result (api-call :post "/api/categories/delete"
-                                 {:category/id (:category/id dep-category)}
-                                 +test-api-key+ owner)]
-            (is (not (:success result)))
-            (is (= [{:type "t.administration.errors/in-use-by"
-                     :categories [{:category/id (:category/id category)
-                                   :category/title (:category/title create-category-data)}]}]
-                   (:errors result)))))))
+          (testing "and delete"
+            (let [result (api-call :post "/api/categories/delete"
+                                   {:category/id (:category/id category)}
+                                   +test-api-key+ user-id)]
+              (is (:success result))
 
-    (testing "cannot delete category that is depended on by a catalogue item"
-      (let [dep-category (api-call :post "/api/categories"
-                                   create-category-data
-                                   +test-api-key+ owner)]
-        (is (:success dep-category))
-        (is (int? (:category/id dep-category)))
+              (let [response (api-response :get (str "/api/categories/" (:category/id category)) nil
+                                           +test-api-key+ user-id)]
+                (is (response-is-not-found? response))
+                (is (= {:error "not found"} (read-body response))))))))
 
-        (let [resource (test-helpers/create-resource! {:resource-ext-id "urn:1234"})
-              catalogue-item (test-helpers/create-catalogue-item! {:actor "owner"
-                                                                   :resource-id resource
-                                                                   :categories [(select-keys dep-category [:category/id])]})]
-          (is (int? catalogue-item))
+      (testing "cannot delete category that is depended on by another category"
+        (let [dep-category (api-call :post "/api/categories"
+                                     create-category-data
+                                     +test-api-key+ user-id)]
+          (is (:success dep-category))
+          (is (int? (:category/id dep-category)))
 
-          (let [result (api-call :post "/api/categories/delete"
-                                 {:category/id (:category/id dep-category)}
-                                 +test-api-key+ owner)]
-            (is (not (:success result)))
-            (is (= [{:type "t.administration.errors/in-use-by"
-                     :catalogue-items [{:id catalogue-item :localizations {}}]}]
-                   (:errors result)))))))
+          (let [category (api-call :post "/api/categories"
+                                   (merge create-category-data
+                                          {:category/children [{:category/id (:category/id dep-category)}]})
+                                   +test-api-key+ user-id)]
+            (is (:success category))
+            (is (int? (:category/id category)))
 
-    (testing "deleting non-existing category returns 404"
-      (let [response (api-response :post "/api/categories/delete"
-                                   {:category/id 9999999}
-                                   +test-api-key+ owner)]
-        (is (not (:success response)))
-        (is (= {:error "not found"} (read-body response)))))))
+            (let [result (api-call :post "/api/categories/delete"
+                                   {:category/id (:category/id dep-category)}
+                                   +test-api-key+ user-id)]
+              (is (not (:success result)))
+              (is (= [{:type "t.administration.errors/in-use-by"
+                       :categories [{:category/id (:category/id category)
+                                     :category/title (:category/title create-category-data)}]}]
+                     (:errors result)))))))
+
+      (testing "cannot delete category that is depended on by a catalogue item"
+        (let [dep-category (api-call :post "/api/categories"
+                                     create-category-data
+                                     +test-api-key+ user-id)]
+          (is (:success dep-category))
+          (is (int? (:category/id dep-category)))
+
+          (let [resource (test-helpers/create-resource! {:resource-ext-id "urn:1234"})
+                catalogue-item (test-helpers/create-catalogue-item! {:actor user-id
+                                                                     :resource-id resource
+                                                                     :categories [(select-keys dep-category [:category/id])]})]
+            (is (int? catalogue-item))
+
+            (let [result (api-call :post "/api/categories/delete"
+                                   {:category/id (:category/id dep-category)}
+                                   +test-api-key+ user-id)]
+              (is (not (:success result)))
+              (is (= [{:type "t.administration.errors/in-use-by"
+                       :catalogue-items [{:id catalogue-item :localizations {}}]}]
+                     (:errors result)))))))
+
+      (testing "deleting non-existing category returns 404"
+        (let [response (api-response :post "/api/categories/delete"
+                                     {:category/id 9999999}
+                                     +test-api-key+ user-id)]
+          (is (not (:success response)))
+          (is (= {:error "not found"} (read-body response))))))))

--- a/test/clj/rems/test_browser.clj
+++ b/test/clj/rems/test_browser.clj
@@ -1145,6 +1145,10 @@
 (defn create-catalogue-item []
   (testing "create catalogue item"
     (btu/with-postmortem
+      (test-helpers/create-category! {:actor "owner"
+                                      :category/title {:en "E2E create-catalogue-item category (EN)"
+                                                       :fi "E2E create-catalogue-item category (FI)"
+                                                       :sv "E2E create-catalogue-item category (SV)"}})
       (go-to-admin "Catalogue items")
       (btu/scroll-and-click :create-catalogue-item)
       (is (btu/eventually-visible? {:tag :h1 :fn/text "Create catalogue item"}))
@@ -1157,6 +1161,7 @@
       (select-option "Resource" (btu/context-get :resid))
       (when-let [form-name (btu/context-get :form-name)]
         (select-option "Form" form-name))
+      (select-option "Categories" "E2E create-catalogue-item category (EN)")
       (btu/screenshot "about-to-create-catalogue-item.png")
       (btu/scroll-and-click :save)
       (is (btu/eventually-visible? {:tag :h1 :fn/text "Catalogue item"}))
@@ -1174,7 +1179,7 @@
               "Resource" (btu/context-get :resid)
               "Form" (or (btu/context-get :form-name)
                          "")
-              "Categories" ""
+              "Categories" "E2E create-catalogue-item category (EN)"
               "Active" false
               "End" ""}
              (dissoc (slurp-fields :catalogue-item)


### PR DESCRIPTION
relates #2800 

UI uses `+admin-write-roles+´ to determine which role can see edit button (and consequently enter edit page), this change allows organization owners to edit categories the same as owners

* use `+admin-write-roles+` instead of `#{:owner}` for checking categories edit roles in API
* refactor create catalogue item browser test to include categories

# Checklist for author

Remove items that aren't applicable, check items that are done.

## Reviewability
- [x] Link to issue

## Testing
- [x] Valuable features are integration / browser / acceptance tested automatically
