### PR TITLE
fix: #2814 hide invalid edit button

### DIFF
--- a/src/cljc/rems/common/roles.cljc
+++ b/src/cljc/rems/common/roles.cljc
@@ -38,8 +38,8 @@
   [organization-id]
   #?(:cljs (let [owned-organizations @(rf/subscribe [:owned-organizations])]
              (->> owned-organizations
-                 (map #(get-in % [:organization/id]))
-                 (in? organization-id)))))
+                  (map #(get-in % [:organization/id]))
+                  (in? organization-id)))))
 
 (defn has-permission?
   "Does the current user have the proper permissions?
@@ -52,10 +52,10 @@
    (defn show-when
      ([roles & body]
       (clojure.core/when (apply has-roles? roles)
-                         (into [:<>] body)))))
+        (into [:<>] body)))))
 
 #?(:cljs
    (defn show-when-correct-access
      [roles organization-id & body]
      (clojure.core/when (has-permission? roles organization-id)
-                        (into [:<>] body))))
+       (into [:<>] body))))

--- a/src/cljc/rems/common/util.cljc
+++ b/src/cljc/rems/common/util.cljc
@@ -554,3 +554,8 @@
   (is (= [] (replace-key [] :a :b)))
   (is (= {:b 1} (replace-key {:a 1} :a :b)))
   (is (= {:a 1} (replace-key {:a 1} :b :c))))
+
+(defn in?
+  "Returns a true boolean value when the collection contains a element value else nil."
+  [element collection]
+  (some #(= element %) collection))

--- a/src/cljs/rems/administration/catalogue_items.cljs
+++ b/src/cljs/rems/administration/catalogue_items.cljs
@@ -138,7 +138,7 @@
                       :sort-value (if checked? 1 2)})
            :commands {:td [:td.commands
                            [view-button (:id item)]
-                           [roles/show-when roles/+admin-write-roles+
+                           [roles/show-when-correct-access roles/+admin-write-roles+ (get-in item [:organization :organization/id])
                             [catalogue-item/edit-button (:id item)]
                             [status-flags/enabled-toggle item #(rf/dispatch [::set-catalogue-item-enabled %1 %2 [::fetch-catalogue]])]
                             [status-flags/archived-toggle item #(rf/dispatch [::set-catalogue-item-archived %1 %2 [::fetch-catalogue]])]]]}})

--- a/test/cljc/rems/common/test_util.cljc
+++ b/test/cljc/rems/common/test_util.cljc
@@ -1,6 +1,6 @@
 (ns rems.common.test-util
   (:require [clojure.test :refer [deftest is testing]]
-            [rems.common.util :refer [select-vals distinct-by]]))
+            [rems.common.util :refer [select-vals distinct-by in?]]))
 
 (deftest select-vals-test
   (is (= [] (select-vals nil nil)))
@@ -14,3 +14,7 @@
 (deftest test-distinct-by
   (is (= [1 2]
          (sort (distinct-by even? [1 2 3 4])))))
+
+(deftest test-in?
+  (is (= true (in? 1 '(1 2 3))))
+  (is (= nil (in? 4 '(1 2 3)))))


### PR DESCRIPTION
## Reviewability
- [x] Link to issue
- [x] Consider adding screenshots for ease of review

## Testing
- [x] Complex logic is unit tested

## Follow-up
- [ ] New tasks are created for pending or remaining tasks

Hello everyone! This PR enhances the Catalogue Items page so Edit, Archive, and Disable buttons only show when the user has the appropriate role *and* is an owner of the organization. Below is a screenshot of how the UI looks with this change. 

<img width="1224" alt="Screen Shot 2022-01-15 at 3 18 16 PM" src="https://user-images.githubusercontent.com/3600122/149638194-7d8b24fc-a5e3-47ce-901a-1cad106c1240.png">

I do have a follow up question (left new task checkbox open above in case). Should this same logic be enforced on the `administration/resources` page? I _believe_ the rules should be the same but I am new to this project and the role system in general so any guidance is appreciated :) 

I am also fairly new to Clojure but want to become an expert in it. Please feel free to give me an constructive criticism as I want to improve and learn from others! 


I would also like to note on the creation of method `roles.cljc#show-when-correct-access`. I attempted to make this a part of `roles.cljc#show-when` however due to the variadic arg I ran into issues with creating it into a multi-arity function. The new function was my workaround. If anyone has insights on how to make this cleaner, I would really appreciate it! I was hoping the multi-arity function would have worked :(  