### PR TITLE
feat: don't bother with the cache reload in rename-user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Changes since v2.24
 - Validate GA4GH claims by the public key from trusted issuer jku (instead of OIDC configuration). Configure `:ga4gh-visa-trusted-issuers` if needed. (#2798)
 - Pollers have been made more robust, including timeouts for email sending (#2841)
 - SSL certificate can now be configured and SSL enabled. HTTP port can be disabled. (#2844)
+- `rename-user` will not bother reloading the application cache anymore (since it is usually run in a separate process from the server).
 
 ## v2.24 "Heikkiläntie" 2022-01-17
 

--- a/src/clj/rems/db/fix_userid.clj
+++ b/src/clj/rems/db/fix_userid.clj
@@ -289,7 +289,7 @@
                   [(:name (meta f))
                    (f old-userid new-userid simulate?)]))]
     (remove-old-user old-userid simulate?)
-    (rems.db.applications/reload-cache!)
+    ;; (rems.db.applications/reload-cache!) ; can be useful if running from REPL
     result))
 
 (comment


### PR DESCRIPTION
There is no need to reload the cache as the server process is usually separate. When running from REPL we can reset cache when we wish in other ways.