### PR TITLE
User rename mapping

### DIFF
--- a/resources/sql/queries.sql
+++ b/resources/sql/queries.sql
@@ -788,6 +788,9 @@ WHERE id = :id;
 SELECT extIdAttribute, extIdValue, userId
 FROM user_mappings
 WHERE 1 = 1
+/*~ (when (:userid params) */
+AND userId = :userid
+/*~ ) ~*/
 /*~ (when (:ext-id-attribute params) */
 AND extIdAttribute = :ext-id-attribute
 /*~ ) ~*/

--- a/resources/sql/queries.sql
+++ b/resources/sql/queries.sql
@@ -801,3 +801,7 @@ INSERT INTO user_mappings (userId, extIdAttribute, extIdValue)
 VALUES (:userid, :ext-id-attribute, :ext-id-value)
 ON CONFLICT (userId, extIdAttribute, extIdValue)
 DO NOTHING;
+
+-- :name delete-user-mapping! :!
+DELETE FROM user_mappings
+WHERE userId = :userid;

--- a/src/clj/rems/auth/oidc.clj
+++ b/src/clj/rems/auth/oidc.clj
@@ -79,7 +79,7 @@
 (defn- find-user [id-data]
   (let [userid-attrs (get-userid-attributes id-data)
         user-mapping-match (fn [[attribute value]]
-                             (let [mappings (user-mappings/get-user-mappings attribute value)]
+                             (let [mappings (user-mappings/get-user-mappings {:ext-id-attribute attribute :ext-id-value value})]
                                (:userid (first mappings))))] ; should be at most one by kv search
     (or (some user-mapping-match userid-attrs)
         (find-first users/user-exists? (map second userid-attrs)))))

--- a/src/clj/rems/db/user_mappings.clj
+++ b/src/clj/rems/db/user_mappings.clj
@@ -1,5 +1,6 @@
 (ns rems.db.user-mappings
   (:require [clojure.string :as str]
+            [medley.core :refer [map-vals]]
             [rems.db.core :as db]
             [schema.core :as s]))
 
@@ -11,16 +12,22 @@
 (def ^:private validate-user-mapping
   (s/validator UserMappings))
 
-(defn get-user-mappings [attribute value]
-  (->> (db/get-user-mappings {:ext-id-attribute (name attribute)
-                              :ext-id-value value})
+(defn- format-user-mapping [mapping]
+  {:userid (:userid mapping)
+   :ext-id-attribute (:extidattribute mapping)
+   :ext-id-value (:extidvalue mapping)})
+
+(defn get-user-mappings
+  [params]
+  (->> (db/get-user-mappings (map-vals name params))
+       (mapv format-user-mapping)
+       (mapv validate-user-mapping)
        not-empty))
 
 (defn create-user-mapping! [user-mapping]
   (-> user-mapping
       validate-user-mapping
       db/create-user-mapping!))
-
 
 (defn delete-user-mapping! [userid]
   (db/delete-user-mapping! {:userid userid}))

--- a/src/clj/rems/db/user_mappings.clj
+++ b/src/clj/rems/db/user_mappings.clj
@@ -21,6 +21,10 @@
       validate-user-mapping
       db/create-user-mapping!))
 
+
+(defn delete-user-mapping! [userid]
+  (db/delete-user-mapping! {:userid userid}))
+
 (defn find-userid
   "Figures out the `userid` of a user reference.
 
@@ -32,3 +36,4 @@
       (assert (< (count mappings) 2) (str "Multiple users found with identity " (pr-str mappings)))
       (or (some :userid mappings)
           userid-or-ext-id))))
+

--- a/test/clj/rems/api/test_users.clj
+++ b/test/clj/rems/api/test_users.clj
@@ -143,7 +143,7 @@
                  (users/format-user (:identity (middleware/get-session cookie)))))))
 
       (testing "log in elixir-alice and create user mapping"
-        (is (nil? (user-mappings/get-user-mappings "elixirId" "elixir-alice")) "user mapping should not exist")
+        (is (nil? (user-mappings/get-user-mappings {:ext-id-attribute "elixirId" :ext-id-value "elixir-alice"})) "user mapping should not exist")
         (let [cookie (login-with-cookies "elixir-alice")]
           (assert-can-make-a-request! cookie)
           (is (= #{{:userid "alice" :name "Alice Applicant" :email "alice@example.com" :nickname "In Wonderland"}
@@ -151,9 +151,9 @@
                  (set (api-call :get "/api/users/active" nil
                                 +test-api-key+ "owner"))))
           (is (= [{:userid "alice"
-                   :extidvalue "elixir-alice"
-                   :extidattribute "elixirId"}]
-                 (user-mappings/get-user-mappings "elixirId" "elixir-alice")))
+                   :ext-id-value "elixir-alice"
+                   :ext-id-attribute "elixirId"}]
+                 (user-mappings/get-user-mappings {:ext-id-attribute "elixirId" :ext-id-avlue "elixir-alice"})))
           (is (= {:userid "alice" :name "Elixir Alice" :email "alice@elixir-europe.org"}
                  (users/get-user "alice")
                  (users/format-user (:identity (middleware/get-session cookie))))
@@ -162,8 +162,9 @@
     (with-fake-login-users {"elixir-alice" {:sub "elixir-alice" :name "Elixir Alice" :email "alice@elixir-europe.org"}}
       (testing "log in elixir-alice with user mapping"
         (is (= [{:userid "alice"
-                 :extidvalue "elixir-alice"
-                 :extidattribute "elixirId"}] (user-mappings/get-user-mappings "elixirId" "elixir-alice")))
+                 :ext-id-value "elixir-alice"
+                 :ext-id-attribute "elixirId"}]
+               (user-mappings/get-user-mappings {:ext-id-attribute "elixirId" :ext-id-value "elixir-alice"})))
         (let [cookie (login-with-cookies "elixir-alice")]
           (assert-can-make-a-request! cookie)
           (is (= #{{:userid "alice" :name "Alice Applicant" :email "alice@example.com" :nickname "In Wonderland"}


### PR DESCRIPTION
The user rename now works with mappings. This was a missing feature. After #2858.

If a user already exists (i.e., there is a user with two identities), the user mapping code will not use the old identity. Then you can use the `rename "new id" "old id"` trick to get rid of the new user, fix the data and effectively remove the wrong mapping. This happened in dev with "elixir-alice" since it existed already. And would have fixed the case (tested manually).

# Checklist for author

Remove items that aren't applicable, check items that are done.

## Reviewability
- [ ] Link to issue
- [x] Note if PR is on top of other PR

## Documentation
- [ ] Update changelog if necessary (I guess nothing is needed as this is kind of expected to be supported)

## Testing
- [x] Complex logic is unit tested
- [ ] Valuable features are integration / browser / acceptance tested automatically (user rename is not tested as it is difficult)

## Follow-up
- [ ] New tasks are created for pending or remaining tasks
