### PR TITLE
fix: previous applications going wide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ Changes since v2.25
 ### Additions
 - You can configure the OIDC attributes for name and email (see configuration.md)
 
+### Fixes
+- Hide applicant column and zoom to avoid previous applications to become too wide (#2855)
+
 ## v2.25 "Meripuistotie" 2022-02-15
 
 **NB: This release contains migrations!**

--- a/src/clj/rems/css/styles.clj
+++ b/src/clj/rems/css/styles.clj
@@ -6,8 +6,7 @@
   For development purposes with Figwheel the styles are rendered to
   `target/resources/public/css/:language/screen.css` whenever this ns is evaluated
   so that Figwheel can autoreload them."
-  (:require [clojure.string :as str]
-            [clojure.test :refer [deftest is testing]]
+  (:require [clojure.test :refer [deftest is testing]]
             [clojure.tools.logging :as log]
             [compojure.core :refer [GET defroutes]]
             [garden.color :as c]
@@ -79,6 +78,8 @@
    (stylesheet/at-media {:max-width (:xs bootstrap-media-breakpoints)}
                         [(s/descendant :.rems-table.cart :tr)
                          {:border-bottom "none"}])
+   (stylesheet/at-media {:max-width (:lg bootstrap-media-breakpoints)}
+                        [:.md-z80 {:zoom "80%"}])
    (stylesheet/at-media {:max-width (u/px 870)}
                         [:.user-widget [:.icon-description {:display "none"}]])
    (stylesheet/at-media {:min-width (:xs bootstrap-media-breakpoints)}

--- a/src/cljs/rems/application.cljs
+++ b/src/cljs/rems/application.cljs
@@ -840,10 +840,11 @@
   [collapsible/component
    {:id "previous-applications"
     :title (text :t.form/previous-applications)
-    :collapse [application-list/component {:applications ::previous-applications-except-current
-                                           :hidden-columns #{:created :handlers :todo :last-activity}
-                                           :default-sort-column :submitted
-                                           :default-sort-order :desc}]}])
+    :collapse [:div.md-z80
+               [application-list/component {:applications ::previous-applications-except-current
+                                            :hidden-columns #{:created :handlers :todo :last-activity :applicant}
+                                            :default-sort-column :submitted
+                                            :default-sort-order :desc}]]}])
 
 (defn- render-application [{:keys [application edit-application config userid highlight-request-id language]}]
   [:<>


### PR DESCRIPTION
Fix #2855.

Hide the applicant column and zoom to avoid going too large.

The effect of the zooming is a little bit difficult to see in this preview but the font size (and everything really) changes. For large screens we use the full size again.

![narrow](https://user-images.githubusercontent.com/823661/158799326-1806d73d-fb8c-44bc-864e-62e49075b4ab.png)
![wider](https://user-images.githubusercontent.com/823661/158799339-d44866e0-a07e-42df-ad35-cc372bb5af31.png)


# Checklist for author

Remove items that aren't applicable, check items that are done.

## Reviewability
- [x] Link to issue
- [x] Consider adding screenshots for ease of review

## Documentation
- [x] Update changelog if necessary
