### PR TITLE
fix: deduplicate forms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ Changes since v2.25
 ### Additions
 - You can configure the OIDC attributes for name and email (see configuration.md)
 
+### Fixes
+- Duplicated forms have been removed. Previously, if a workflow form was the same as a catalogue item form, that form would be duplicated. (#2853)
+
 ## v2.25 "Meripuistotie" 2022-02-15
 
 **NB: This release contains migrations!**

--- a/src/clj/rems/application/commands.clj
+++ b/src/clj/rems/application/commands.clj
@@ -1,10 +1,8 @@
 (ns rems.application.commands
   (:require [clojure.test :refer [deftest is testing]]
-            [com.rpl.specter :refer [ALL transform]]
-            [medley.core :refer [assoc-some]]
+            [medley.core :refer [assoc-some distinct-by]]
             [rems.common.application-util :as application-util]
             [rems.common.form :as form]
-            [rems.common.util :refer [build-index]]
             [rems.form-validation :as form-validation]
             [rems.permissions :as permissions]
             [rems.schema-base :as schema-base]
@@ -299,13 +297,14 @@
                       :event/attachments (when-let [att (:attachments cmd)]
                                            (vec att))))))
 
-(defn- build-forms-list [catalogue-item-ids {:keys [get-catalogue-item]}]
+(defn- build-forms-list [workflow catalogue-item-ids {:keys [get-catalogue-item]}]
   (->> catalogue-item-ids
        (mapv get-catalogue-item)
        (mapv :formid)
        (remove nil?)
-       (distinct)
-       (mapv (fn [form-id] {:form/id form-id}))))
+       (mapv (fn [form-id] {:form/id form-id}))
+       (concat (get-in workflow [:workflow :forms])) ; NB: workflow forms end up first
+       (distinct-by :form/id)))
 
 (defn- build-resources-list [catalogue-item-ids {:keys [get-catalogue-item]}]
   (->> catalogue-item-ids
@@ -348,8 +347,7 @@
                  :application/external-id (:application/external-id ids)
                  :application/resources (build-resources-list catalogue-item-ids injections)
                  :application/licenses (build-licenses-list catalogue-item-ids injections)
-                 :application/forms (concat (get-in workflow [:workflow :forms])
-                                            (build-forms-list catalogue-item-ids injections))
+                 :application/forms (build-forms-list workflow catalogue-item-ids injections)
                  :workflow/id workflow-id
                  :workflow/type workflow-type}})))
 
@@ -494,8 +492,7 @@
         (changes-original-workflow application cat-ids (:actor cmd) injections)
         (add-comment-and-attachments cmd injections
                                      {:event/type :application.event/resources-changed
-                                      :application/forms (concat (get-in workflow [:workflow :forms])
-                                                                 (build-forms-list cat-ids injections))
+                                      :application/forms (build-forms-list workflow cat-ids injections)
                                       :application/resources (build-resources-list cat-ids injections)
                                       :application/licenses (build-licenses-list cat-ids injections)}))))
 

--- a/test/clj/rems/api/test_end_to_end.clj
+++ b/test/clj/rems/api/test_end_to_end.clj
@@ -153,7 +153,7 @@
                    (api-call :post "/api/workflows/create" {:organization {:organization/id "e2e"}
                                                             :title "e2e workflow"
                                                             :type :workflow/default
-                                                            :forms [{:form/id wf-form-id}]
+                                                            :forms [{:form/id wf-form-id} {:form/id form-id}]
                                                             :handlers [handler-id]}
                              api-key owner-id)))
 

--- a/test/clj/rems/application/test_commands.clj
+++ b/test/clj/rems/application/test_commands.clj
@@ -59,7 +59,7 @@
                        :handlers [{:userid handler-user-id
                                    :name "user"
                                    :email "user@example.com"}]
-                       :forms [{:form/id 3} {:form/id 4}]}}}
+                       :forms [{:form/id 1} {:form/id 3} {:form/id 4}]}}}
         id))
 (defn- dummy-get-form-template [id]
   (getx {1 {:form/id 1
@@ -304,7 +304,7 @@
                             :catalogue-item-ids [1 3]}
                        injections))))
 
-  (testing "workflow form, multiple catalogue items with different forms"
+  (testing "workflow form, multiple catalogue items with different forms, workflow has duplicated catalogue item form"
     (is (= {:event/type :application.event/created
             :event/actor applicant-user-id
             :event/time (DateTime. 1000)
@@ -313,7 +313,8 @@
             :application/resources [{:catalogue-item/id 4 :resource/ext-id "res4"}
                                     {:catalogue-item/id 5 :resource/ext-id "res5"}]
             :application/licenses []
-            :application/forms [{:form/id 3} {:form/id 4} {:form/id 1} {:form/id 2}]
+            ;; NB: form/id 1 is also a workflow form
+            :application/forms [{:form/id 1} {:form/id 3} {:form/id 4} {:form/id 2}] ; wf forms first, then catalogue item forms
             :workflow/id 2
             :workflow/type :workflow/default}
            (ok-command nil {:type :application.command/create


### PR DESCRIPTION
Fixes #2853.

Workflow forms were concatenated to catalogue item forms so
duplicates could happen. Now they are deduplicated after
concatenation. Also added some tests of this feature.

# Checklist for author

Remove items that aren't applicable, check items that are done.

## Reviewability
- [x] Link to issue

## Backwards compatibility
- [x] API is backwards compatible or completely new
- [x] Events are backwards compatible _or_ have migrations

## Documentation
- [x] Update changelog if necessary

## Testing
- [x] Complex logic is unit tested
- [x] Valuable features are integration / browser / acceptance tested automatically
