### PR TITLE
Cache user mappings

### DIFF
--- a/resources/migrations/20220120121117-user-mappings.down.sql
+++ b/resources/migrations/20220120121117-user-mappings.down.sql
@@ -1,2 +1,1 @@
-DROP TABLE IF EXISTS user_mappings CASCADE;
-
+DROP TABLE IF EXISTS user_mappings;

--- a/resources/migrations/20220120121117-user-mappings.up.sql
+++ b/resources/migrations/20220120121117-user-mappings.up.sql
@@ -5,6 +5,3 @@ CREATE TABLE user_mappings (
   PRIMARY KEY (userId, extIdAttribute, extIdValue),
   FOREIGN KEY (userId) REFERENCES users
 );
---;;
-CREATE INDEX index_user_mappings ON user_mappings(extIdAttribute, extIdValue);
-

--- a/src/clj/rems/auth/oidc.clj
+++ b/src/clj/rems/auth/oidc.clj
@@ -30,14 +30,14 @@
   (for [{:keys [attribute rename]} (getx env :oidc-userid-attributes)
         :let [value (get id-data (keyword attribute))]
         :when value]
-    [(keyword (or rename attribute)) value]))
+    [(or rename attribute) value]))
 
 (deftest test-get-userid-attributes
   (with-redefs [env {:oidc-userid-attributes [{:attribute "sub" :rename "elixirId"}
                                               {:attribute "old_sub"}]}]
     (is (= [] (get-userid-attributes nil)))
-    (is (= [[:elixirId "elixir-alice"]
-            [:old_sub "alice"]]
+    (is (= [["elixirId" "elixir-alice"]
+            ["old_sub" "alice"]]
            (get-userid-attributes {:old_sub "alice"
                                    :sub "elixir-alice"
                                    :name "Alice Applicant"})))))

--- a/src/clj/rems/db/core.clj
+++ b/src/clj/rems/db/core.clj
@@ -9,10 +9,10 @@
             [clj-time.jdbc] ;; convert db timestamps to joda-time objects
             [clojure.java.jdbc]
             [clojure.set :refer [superset?]]
+            [clojure.string :as str]
             [conman.core :as conman]
             [mount.core :refer [defstate] :as mount]
-            [rems.config :refer [env]]
-            [clojure.string :as str]))
+            [rems.config :refer [env]]))
 
 ;; See docs/architecture/010-transactions.md
 (defn- hikaricp-settings []

--- a/src/clj/rems/db/user_mappings.clj
+++ b/src/clj/rems/db/user_mappings.clj
@@ -58,7 +58,7 @@
   (swap! user-mappings-by-value
          (fn [mappings]
            (->> mappings
-                vals
+                (mapcat val)
                 (remove #(= userid (:userid %)))
                 (group-by :ext-id-value)))))
 

--- a/test/clj/rems/api/test_users.clj
+++ b/test/clj/rems/api/test_users.clj
@@ -178,7 +178,66 @@
                    {:userid "alice" :name "Elixir Alice" :email "alice@elixir-europe.org"}}
                  (set (api-call :get "/api/users/active" nil
                                 +test-api-key+ "owner")))
-              "both alices show as active"))))))
+              "both alices show as active"))))
+
+    (testing "mappings create, get, delete"
+      (user-mappings/create-user-mapping! {:userid "alice"
+                                           :ext-id-value "alice-alt-id"
+                                           :ext-id-attribute "alt-id"})
+      (user-mappings/create-user-mapping! {:userid "alice"
+                                           :ext-id-value "alice-alt-id"
+                                           :ext-id-attribute "alt-id2"})
+      (is (= [{:userid "alice"
+               :ext-id-value "elixir-alice"
+               :ext-id-attribute "elixirId"}
+              {:userid "alice"
+               :ext-id-value "alice-alt-id"
+               :ext-id-attribute "alt-id"}
+              {:userid "alice"
+               :ext-id-value "alice-alt-id"
+               :ext-id-attribute "alt-id2"}]
+             (user-mappings/get-user-mappings {:userid "alice"})))
+      (is (= [{:userid "alice"
+               :ext-id-value "elixir-alice"
+               :ext-id-attribute "elixirId"}]
+             (user-mappings/get-user-mappings {:ext-id-value "elixir-alice"})))
+      (is (= [{:userid "alice"
+               :ext-id-value "alice-alt-id"
+               :ext-id-attribute "alt-id"}
+              {:userid "alice"
+               :ext-id-value "alice-alt-id"
+               :ext-id-attribute "alt-id2"}]
+             (user-mappings/get-user-mappings {:ext-id-value "alice-alt-id"})))
+
+      (user-mappings/delete-user-mapping! "unrelated") ; should not affect tested data
+
+      (is (= [{:userid "alice"
+               :ext-id-value "elixir-alice"
+               :ext-id-attribute "elixirId"}
+              {:userid "alice"
+               :ext-id-value "alice-alt-id"
+               :ext-id-attribute "alt-id"}
+              {:userid "alice"
+               :ext-id-value "alice-alt-id"
+               :ext-id-attribute "alt-id2"}]
+             (user-mappings/get-user-mappings {:userid "alice"})))
+      (is (= [{:userid "alice"
+               :ext-id-value "elixir-alice"
+               :ext-id-attribute "elixirId"}]
+             (user-mappings/get-user-mappings {:ext-id-value "elixir-alice"})))
+      (is (= [{:userid "alice"
+               :ext-id-value "alice-alt-id"
+               :ext-id-attribute "alt-id"}
+              {:userid "alice"
+               :ext-id-value "alice-alt-id"
+               :ext-id-attribute "alt-id2"}]
+             (user-mappings/get-user-mappings {:ext-id-value "alice-alt-id"})))
+
+      (user-mappings/delete-user-mapping! "alice")
+
+      (is (= nil (user-mappings/get-user-mappings {:userid "alice"})))
+      (is (= nil (user-mappings/get-user-mappings {:ext-id-value "elixir-alice"})))
+      (is (= nil (user-mappings/get-user-mappings {:ext-id-value "alice-alt-id"}))))))
 
 
 (deftest user-name-test

--- a/test/clj/rems/api/test_users.clj
+++ b/test/clj/rems/api/test_users.clj
@@ -132,6 +132,8 @@
                                                                                 {:attribute "old_sub"}])]
     (with-fake-login-users {"alice" {:sub "alice" :name "Alice Applicant" :email "alice@example.com" :nickname "In Wonderland"}
                             "elixir-alice" {:sub "elixir-alice" :old_sub "alice" :name "Elixir Alice" :email "alice@elixir-europe.org"}}
+      (is (nil? (user-mappings/get-user-mappings {:ext-id-attribute "elixirId" :ext-id-value "elixir-alice"})) "user mapping should not exist")
+
       (testing "log in alice"
         (let [cookie (login-with-cookies "alice")]
           (assert-can-make-a-request! cookie)
@@ -140,27 +142,32 @@
                            +test-api-key+ "owner")))
           (is (= {:userid "alice" :name "Alice Applicant" :email "alice@example.com" :nickname "In Wonderland"}
                  (users/get-user "alice")
-                 (users/format-user (:identity (middleware/get-session cookie)))))))
+                 (users/format-user (:identity (middleware/get-session cookie)))))
+          (is (= #{{:userid "alice" :name "Alice Applicant" :email "alice@example.com" :nickname "In Wonderland"}}
+                 (set (api-call :get "/api/users/active" nil
+                                +test-api-key+ "owner")))
+              "alice shows as active")))
 
       (testing "log in elixir-alice and create user mapping"
         (is (nil? (user-mappings/get-user-mappings {:ext-id-attribute "elixirId" :ext-id-value "elixir-alice"})) "user mapping should not exist")
         (let [cookie (login-with-cookies "elixir-alice")]
           (assert-can-make-a-request! cookie)
-          (is (= #{{:userid "alice" :name "Alice Applicant" :email "alice@example.com" :nickname "In Wonderland"}
-                   {:userid "alice" :name "Elixir Alice" :email "alice@elixir-europe.org"}}
-                 (set (api-call :get "/api/users/active" nil
-                                +test-api-key+ "owner"))))
           (is (= [{:userid "alice"
                    :ext-id-value "elixir-alice"
                    :ext-id-attribute "elixirId"}]
-                 (user-mappings/get-user-mappings {:ext-id-attribute "elixirId" :ext-id-avlue "elixir-alice"})))
+                 (user-mappings/get-user-mappings {:ext-id-attribute "elixirId" :ext-id-value "elixir-alice"})))
           (is (= {:userid "alice" :name "Elixir Alice" :email "alice@elixir-europe.org"}
                  (users/get-user "alice")
                  (users/format-user (:identity (middleware/get-session cookie))))
-              "Attributes should be updated when logging in"))))
+              "Attributes should be updated when logging in")
+          (is (= #{{:userid "alice" :name "Alice Applicant" :email "alice@example.com" :nickname "In Wonderland"}
+                   {:userid "alice" :name "Elixir Alice" :email "alice@elixir-europe.org"}}
+                 (set (api-call :get "/api/users/active" nil
+                                +test-api-key+ "owner")))
+              "both alices show as active"))))
 
     (with-fake-login-users {"elixir-alice" {:sub "elixir-alice" :name "Elixir Alice" :email "alice@elixir-europe.org"}}
-      (testing "log in elixir-alice with user mapping"
+      (testing "log in elixir-alice with user mapping, no old_sub"
         (is (= [{:userid "alice"
                  :ext-id-value "elixir-alice"
                  :ext-id-attribute "elixirId"}]
@@ -170,7 +177,8 @@
           (is (= #{{:userid "alice" :name "Alice Applicant" :email "alice@example.com" :nickname "In Wonderland"}
                    {:userid "alice" :name "Elixir Alice" :email "alice@elixir-europe.org"}}
                  (set (api-call :get "/api/users/active" nil
-                                +test-api-key+ "owner")))))))))
+                                +test-api-key+ "owner")))
+              "both alices show as active"))))))
 
 
 (deftest user-name-test

--- a/test/clj/rems/db/testing.clj
+++ b/test/clj/rems/db/testing.clj
@@ -1,19 +1,16 @@
 (ns rems.db.testing
-  (:require [clj-time.core :as time]
-            [clojure.java.jdbc :as jdbc]
+  (:require [clojure.java.jdbc :as jdbc]
             [clojure.test :refer :all]
-            [clojure.tools.logging :as log]
             [conman.core :as conman]
             [luminus-migrations.core :as migrations]
             [mount.core :as mount]
             [rems.application.search]
             [rems.config :refer [env]]
-            [rems.db.api-key :as api-key]
             [rems.db.applications]
             [rems.db.category :as category]
             [rems.db.core :as db]
             [rems.db.test-data :as test-data]
-            [rems.db.test-data-helpers :as test-helpers]
+            [rems.db.user-mappings :as user-mappings]
             [rems.locales])
   (:import [org.joda.time Duration ReadableInstant]))
 
@@ -45,7 +42,8 @@
     (mount/start #'rems.db.applications/all-applications-cache)
     (f)
     (finally
-      (category/reset-cache!))))
+      (category/reset-cache!)
+      (user-mappings/reset-cache!))))
 
 (def +test-api-key+ test-data/+test-api-key+) ;; re-exported for convenience
 


### PR DESCRIPTION
Closes #2774.

Users are fetched as before, but mappings are always cached in memory for performance.

# Checklist for author

Remove items that aren't applicable, check items that are done.

## Reviewability
- [x] Link to issue
- [x] Note if PR is on top of other PR

## Backwards compatibility
- [x] API is backwards compatible or completely new

## Documentation
- [ ] Update changelog if necessary (will be part of the new feature set, no need to advertise)

## Testing
- [x] Valuable features are integration / browser / acceptance tested automatically

## Follow-up
- [ ] New tasks are created for pending or remaining tasks (in the cache ticket we can improve more #2777)
