### PR TITLE
fix: owner as organization owner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ Changes since v2.25
 - You can configure the OIDC attributes for name and email (see configuration.md)
 - API-Keys are cached for a minute for a slight performance improvement. (#2785)
 
+### Fixes
+- An owner that is also an organization owner can now properly edit organization ownerships. (#2850)
+
 ## v2.25 "Meripuistotie" 2022-02-15
 
 **NB: This release contains migrations!**

--- a/src/clj/rems/api/services/organizations.clj
+++ b/src/clj/rems/api/services/organizations.clj
@@ -2,6 +2,7 @@
   (:require [clojure.set :as set]
             [medley.core :refer [assoc-some find-first remove-keys]]
             [rems.api.services.dependencies :as dependencies]
+            [rems.context :as context]
             [rems.db.applications :as applications]
             [rems.db.core :as db]
             [rems.db.organizations :as organizations]
@@ -60,9 +61,10 @@
   (organizations/update-organization! (:organization/id org)
                                       (fn [db-organization]
                                         (let [organization-owners (set (map :userid (:organization/owners db-organization)))
-                                              organization-owner? (contains? organization-owners userid)]
+                                              organization-owner? (contains? organization-owners userid)
+                                              owner? (contains? context/*roles* :owner)]
                                           (merge db-organization
-                                                 (remove-keys (if organization-owner?
+                                                 (remove-keys (if (and organization-owner? (not owner?))
                                                                 #{:organization/id :organization/owners} ; org owner can't update owners
                                                                 #{:organization/id})
                                                               org)))))

--- a/src/cljs/rems/administration/create_organization.cljs
+++ b/src/cljs/rems/administration/create_organization.cljs
@@ -179,7 +179,8 @@
 (defn- organization-owners-field []
   (let [form @(rf/subscribe [::form])
         all-owners @(rf/subscribe [::available-owners])
-        selected-owners (set (map :userid (get-in form [:organization/owners])))]
+        selected-owners (set (map :userid (get-in form [:organization/owners])))
+        roles @(rf/subscribe [:roles])]
     [:div.form-group
      [:label.administration-field-label
       {:for owners-dropdown-id}
@@ -191,7 +192,8 @@
        :item-label :display
        :item-selected? #(contains? selected-owners (% :userid))
        :multi? true
-       :disabled? (some #{:organization-owner} @(rf/subscribe [:roles]))
+       :disabled? (and (some #{:organization-owner} roles)
+                       (not (some #{:owner} roles)))
        :on-change #(rf/dispatch [::set-owners %])}]]))
 
 (defn- remove-review-email-button [field-index]

--- a/test/clj/rems/api/test_organizations.clj
+++ b/test/clj/rems/api/test_organizations.clj
@@ -89,12 +89,37 @@
                               :organization/name {:fi "Organisaatiot API Test ORG 2"
                                                   :en "Organizations API Test ORG 2"}
                               :organization/short-name {:fi "ORG2" :en "ORG2"}
-                              :organization/owners [{:userid org-owner1} {:userid org-owner2}]
+                              :organization/owners [{:userid org-owner1} {:userid org-owner2} {:userid owner}]
                               :organization/review-emails [{:email "test@organization2.test.org"
                                                             :name {:fi "Organisaatiot 2 API Test ORG Katselmoijat"
                                                                    :en "Organizations 2 API Test ORG Reviewers"}}]}
                              api-key owner)]
           (is (= "organizations-api-test-org" (:organization/id data)))
+          (is (= {:organization/id "organizations-api-test-org"
+                  :organization/name {:fi "Organisaatiot API Test ORG 2"
+                                      :en "Organizations API Test ORG 2"}
+                  :organization/short-name {:fi "ORG2" :en "ORG2"}
+                  :organization/owners [{:userid org-owner1 :email "organization-owner1@example.com" :name "Organization Owner 1"}
+                                        {:userid org-owner2 :email "organization-owner2@example.com" :name "Organization Owner 2"}
+                                        {:userid owner :email "owner@example.com" :name "Owner"}]
+                  :organization/review-emails [{:email "test@organization2.test.org"
+                                                :name {:fi "Organisaatiot 2 API Test ORG Katselmoijat"
+                                                       :en "Organizations 2 API Test ORG Reviewers"}}]
+                  :enabled true
+                  :archived false}
+                 (find-first (comp #{"organizations-api-test-org"} :organization/id) (get-orgs owner))
+                 (get-org owner "organizations-api-test-org"))))
+        (testing "that is also an organization owner can edit"
+          (api-call :put "/api/organizations/edit"
+                    {:organization/id "organizations-api-test-org"
+                     :organization/name {:fi "Organisaatiot API Test ORG 2"
+                                         :en "Organizations API Test ORG 2"}
+                     :organization/short-name {:fi "ORG2" :en "ORG2"}
+                     :organization/owners [{:userid org-owner1} {:userid org-owner2}]
+                     :organization/review-emails [{:email "test@organization2.test.org"
+                                                   :name {:fi "Organisaatiot 2 API Test ORG Katselmoijat"
+                                                          :en "Organizations 2 API Test ORG Reviewers"}}]}
+                    api-key owner)
           (is (= {:organization/id "organizations-api-test-org"
                   :organization/name {:fi "Organisaatiot API Test ORG 2"
                                       :en "Organizations API Test ORG 2"}


### PR DESCRIPTION
Fixes #2850.

Owner wasn't able to edit organization ownership when they were also
an organization owner themselves.

![owner1](https://user-images.githubusercontent.com/823661/159128595-90b34186-aff2-4fe4-88c5-d7a0b04357a5.png)
![owner2](https://user-images.githubusercontent.com/823661/159128593-0c7936cd-b0e7-4854-9623-a5ea6f659b75.png)

# Checklist for author

Remove items that aren't applicable, check items that are done.

## Reviewability
- [x] Link to issue
- [x] Consider adding screenshots for ease of review

## Backwards compatibility
- [x] API is backwards compatible or completely new

## Documentation
- [x] Update changelog if necessary

## Testing
- [x] Valuable features are integration / browser / acceptance tested automatically
