### PR TITLE
fix: zoom

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ NB: The login has changed to allow more configurable user identity and other att
 - API-key validity is not checked unless it is actually sent. (#2785)
 - API-Keys are cached for a minute for a slight performance improvement. (#2785)
 - Resources can be filtered in the API by `resid` (#2852)
-- Hide applicant column and zoom to avoid previous applications to become too wide (#2855)
+- Hide applicant column and reduce font size to avoid previous applications to become too wide (#2855)
 - Duplicated forms have been removed. Previously, if a workflow form was the same as a catalogue item form, that form would be duplicated. (#2853)
 - An owner that is also an organization owner can now properly edit organization ownerships. (#2850)
 - The column names in the tables and the field names in create/edit pages of the administration now match.

--- a/src/clj/rems/css/styles.clj
+++ b/src/clj/rems/css/styles.clj
@@ -80,7 +80,7 @@
                         [(s/descendant :.rems-table.cart :tr)
                          {:border-bottom "none"}])
    (stylesheet/at-media {:max-width (:xl bootstrap-media-breakpoints)}
-                        [:.lg-z75 {:zoom "75%"}])
+                        [:.lg-fs70pct {:font-size (u/percent 70)}])
    (stylesheet/at-media {:max-width (u/px 870)}
                         [:.user-widget [:.icon-description {:display "none"}]])
    (stylesheet/at-media {:min-width (:xs bootstrap-media-breakpoints)}

--- a/src/cljs/rems/application.cljs
+++ b/src/cljs/rems/application.cljs
@@ -892,7 +892,7 @@
   [collapsible/component
    {:id "previous-applications"
     :title (text :t.form/previous-applications)
-    :collapse [:div.lg-z75
+    :collapse [:div.lg-fs70pct
                [application-list/component {:applications ::previous-applications-except-current
                                             :hidden-columns #{:created :handlers :todo :last-activity :applicant}
                                             :default-sort-column :submitted


### PR DESCRIPTION
Fixes https://github.com/CSCfi/rems/issues/2855

The zoom attribute isn't supported in Firefox. We can use font-size for a
similar effect. Trying to use transform scale runs into trouble with
not being so responsive as it does not fill available space.

![zoom-to-size](https://user-images.githubusercontent.com/823661/161536261-7eefd0e5-3c9e-46bf-b9d5-1cfa7b2de515.png)

# Checklist for author

Remove items that aren't applicable, check items that are done.

## Reviewability
- [x] Link to issue
- [x] Consider adding screenshots for ease of review

## Documentation
- [x] Update changelog if necessary
