### PR TITLE
Improve fake login page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ NB: The login has changed to allow more configurable user identity and other att
 ### Additions
 - You can configure the OIDC attributes for name and email (see configuration.md)
 - User in the API can be an internal REMS id or any of the `:oidc-userid-attributes` (provided that the user has logged in once and we have stored the identity. (#2821 #2772)
+- Fake login page has been improved to include descriptions of the different users. (#2896)
 
 ### Fixes
 - API-key validity is not checked unless it is actually sent. (#2785)

--- a/src/clj/rems/auth/fake_login.clj
+++ b/src/clj/rems/auth/fake_login.clj
@@ -52,7 +52,8 @@
 (defn- user-selection [username]
   (let [url (url (login-url) {:username username})]
     [:div.user.m-3 {:onclick (str "window.location.href='" url "';")}
-     [:a.btn.btn-primary {:href url :style "width: 12rem;"} username]]))
+     [:a.btn.btn-primary {:href url :style "width: 12rem; overflow: hidden; text-overflow: ellipsis; white-space: nowrap"}
+      username]]))
 
 (defn- fake-login-screen [{session :session :as req}]
   (if-let [username (-> req :params :username)]

--- a/src/clj/rems/auth/fake_login.clj
+++ b/src/clj/rems/auth/fake_login.clj
@@ -71,6 +71,9 @@
                                       [:div
                                        [:h2.mx-3 group]
 
+                                       ;; XXX: this could be refactored so that
+                                       ;; this isn't a special case but an attribute of
+                                       ;; the group data
                                        (when (= "Special Users" group)
                                          [:div.ml-3
                                           [:p "Special users with special cases. Not for daily use!"]

--- a/src/clj/rems/auth/fake_login.clj
+++ b/src/clj/rems/auth/fake_login.clj
@@ -52,7 +52,7 @@
 (defn- user-selection [username]
   (let [url (url (login-url) {:username username})]
     [:div.user.m-3 {:onclick (str "window.location.href='" url "';")}
-     [:a.btn.btn-primary {:href url :style "width: 12rem; overflow: hidden; text-overflow: ellipsis; white-space: nowrap"}
+     [:a.btn.btn-primary.text-truncate {:href url :style "width: 12rem"}
       username]]))
 
 (defn- fake-login-screen [{session :session :as req}]

--- a/src/clj/rems/auth/fake_login.clj
+++ b/src/clj/rems/auth/fake_login.clj
@@ -3,9 +3,18 @@
             [hiccup.util :refer [url]]
             [rems.layout :as layout]
             [rems.auth.oidc :as oidc]
+            [rems.common.util :refer [escape-element-id]]
             [rems.config :refer [env]]
             [rems.db.test-data-users :as test-data-users]
             [ring.util.response :refer [redirect]]))
+
+(defn get-fake-user-descriptions []
+  (case (:fake-authentication-data env)
+    :test test-data-users/+user-descriptions+
+    :demo [{:group "Users" ; no fancy descriptions
+            :users (vec (for [[userid attrs] test-data-users/+demo-id-data+]
+                          {:userid userid
+                           :description (pr-str attrs)}))}]))
 
 (defn get-fake-users []
   (-> (case (:fake-authentication-data env)
@@ -42,25 +51,37 @@
 
 (defn- user-selection [username]
   (let [url (url (login-url) {:username username})]
-    [:div.user.mb-3.mr-3.flex-fill.d-flex {:onclick (str "window.location.href='" url "';")}
-     [:a.btn.btn-primary.flex-fill {:href url} username]]))
+    [:div.user.m-3 {:onclick (str "window.location.href='" url "';")}
+     [:a.btn.btn-primary {:href url :style "width: 12rem;"} username]]))
 
 (defn- fake-login-screen [{session :session :as req}]
   (if-let [username (-> req :params :username)]
     (fake-login session username)
     (layout/render nil
-                   {:app-content [:div.d-flex.justify-content-start.align-items-center
+                   {:app-content [:div.container
                                   [:div.row.w-100
                                    [:div.logo.w-100
                                     [:div.container.img]]]
-                                  [:div.login.row.d-flex.justify-content-center.align-items-center
-                                   [:div.col-md-8
-                                    [:h1.text-center "Development Login"]
-                                    [:div.users.d-flex.flex-wrap.justify-content-stretch.align-items-start
-                                     (->> (get-fake-users)
-                                          sort
-                                          distinct
-                                          (map user-selection))]]]]})))
+                                  [:div.login.row.d-flex.flex-column.justify-content-start.align-items-center.mb-5
+                                   [:h1.text-center "Development Login"]
+                                   [:div.users
+                                    (for [{:keys [group users]} (get-fake-user-descriptions)
+                                          :let [id (escape-element-id group)]]
+                                      [:div
+                                       [:h2.mx-3 group]
+
+                                       (when (= "Special Users" group)
+                                         [:div.ml-3
+                                          [:p "Special users with special cases. Not for daily use!"]
+                                          [:button#show-special-users.btn.btn-secondary {:data-toggle "collapse" :data-target (str "#" id)}
+                                           "Show"]])
+
+                                       [:div.collapse {:id id
+                                                       :class (if (= "Special Users" group) "hide" "show")}
+                                        (for [{:keys [userid description]} users]
+                                          [:div.d-flex.flex-row.align-start.justify-center
+                                           (user-selection userid)
+                                           [:div.m-3 description]])]])]]]})))
 
 
 (defn- fake-logout [{session :session}]

--- a/src/clj/rems/db/test_data_users.clj
+++ b/src/clj/rems/db/test_data_users.clj
@@ -68,6 +68,49 @@
   {"alice" {:researcher-status-by "so"}
    "elixir-alice" {:researcher-status-by "so"}})
 
+(def +user-descriptions+
+  [{:group "Applicants"
+    :users [{:userid "alice"
+             :description "Alice is a very active user, an applicant, with multiple applications already drafted and even submitted for processing."}
+            {:userid "elsa"
+             :description "Elsa is a normal user, an applicant, who didn't do anything yet."}
+            {:userid "frank"
+             :description "Frank is a normal user, an applicant, who didn't do anything yet."}]}
+
+   {:group "Experts"
+    :users [{:userid "handler"
+             :description "Handler is the user who is responsible for processing applications after they have been sent. They have the permissions given to them by the owner. The REMS model is such that handlers, in general, have a lot of power and flexibility in the handling process."}
+            {:userid "owner"
+             :description "Owner is the user who owns all the resources and manages them in the administration. They can create the catalogue of resources, workflows, forms etc. They can also delegate this power to other users and set who handles which applications, but aren't necessarily the person who does this work themselves."}
+            {:userid "carl"
+             :description "Carl is an expert, who is sometimes asked to review applications, thus taking a small part in the handling process."}
+            {:userid "reporter"
+             :description "Reporter is an administrative users, who is only interested in counting beans and applications, having no part in the actual handling."}]}
+
+   {:group "Special Users"
+    :users [{:userid "elixir-alice"
+             :description "Alternate identity of Alice, which they can also use to log in and see the same applications."}
+            {:userid "malice"
+             :description "A scammer who tries to fool everyone to think they are actually Alice."}
+            {:userid "developer"
+             :description "Another handler, that has a lot of permissions."}
+            {:userid "organization-owner1"
+             :description "An owner of many organizations, who can manage only their items."}
+            {:userid "organization-owner2"
+             :description "An owner of many organizations, who can manage only their items."}
+            {:userid "johnsmith"
+             :description "John and his wife Jill share an external identity (\"smith\"), so they will have difficulty using the API with it."}
+            {:userid "jillsmith"
+             :description "Jill and her wife John share an external identity (\"smith\"), so they will have difficulty using the API with it."}
+            {:userid "user-has-no-name"
+             :description "A user who unfortunately has no name defined in the Identity Provider data."}
+            {:userid "user-has-no-email"
+             :description "A user who unfortunately has no email defined in the Identity Provider data."}
+            {:userid "user-has-nothing"
+             :description "A user who unfortunately has no name or email defined in the Identity Provider data."}
+            {:userid "new-user"
+             :description "A user who isn't found in REMS yet. At login they will be created."}]}])
+
 (def +demo-users+
   {:applicant1 "RDapplicant1@funet.fi"
    :applicant2 "RDapplicant2@funet.fi"

--- a/src/cljc/rems/common/util.cljc
+++ b/src/cljc/rems/common/util.cljc
@@ -566,3 +566,19 @@
   (is (= {:a 1} (update-present {:a 1} :b (constantly true))))
   (is (= {:a 1 :b true} (update-present {:a 1 :b 2} :b (constantly true))))
   (is (= {:a 1 :b true} (update-present {:a 1 :b nil} :b (constantly true)))))
+
+;; https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/id
+(defn escape-element-id [id]
+  (when (string? id)
+    (-> id
+        (str/replace #"[^A-Za-z0-9\-\_]" "_") ; "only ASCII letters, digits, '_', and '-' should be used,"
+        (str/replace-first #"^[^A-Za-z]" #(str "id_" %))))) ; "and the value for an id attribute should start with a letter"
+
+(deftest test-escape-element-id
+  (testing "should replace element special characters with underscore"
+    (is (nil? (escape-element-id nil)))
+    (is (= "element_id-123_" (escape-element-id "element id-123 ")))
+    (is (= "element_id_123" (escape-element-id "element.id#123")))
+    (is (= "id_123-element" (escape-element-id "123-element")))
+    (is (= "id__123-element" (escape-element-id " 123-element")))))
+

--- a/src/cljs/rems/administration/duo.cljs
+++ b/src/cljs/rems/administration/duo.cljs
@@ -4,11 +4,12 @@
             [rems.administration.components :refer [date-field inline-info-field input-field textarea-autosize text-field]]
             [rems.atoms :as atoms]
             [rems.common.duo :refer [duo-restriction-label duo-validation-summary]]
+            [rems.common.util :refer [escape-element-id]]
             [rems.dropdown :as dropdown]
             [rems.fetcher :as fetcher]
             [rems.fields :as fields]
             [rems.text :refer [localized text text-format]]
-            [rems.util :refer [escape-element-id linkify]]))
+            [rems.util :refer [linkify]]))
 
 (defn duo-restriction-info-field [& [opts]]
   (let [restriction-type (:type opts)

--- a/src/cljs/rems/atoms.cljs
+++ b/src/cljs/rems/atoms.cljs
@@ -2,9 +2,10 @@
   (:require [clojure.string :as str]
             [komponentit.autosize :as autosize]
             [reagent.core :as reagent]
+            [rems.common.util :refer [escape-element-id]]
             [rems.guide-util :refer [component-info example]]
             [rems.text :refer [text localized]]
-            [rems.util :refer [escape-element-id focus-when-collapse-opened]]))
+            [rems.util :refer [focus-when-collapse-opened]]))
 
 (defn external-link []
   [:i {:class "fa fa-external-link-alt"

--- a/src/cljs/rems/util.cljs
+++ b/src/cljs/rems/util.cljs
@@ -5,7 +5,7 @@
             [goog.string :refer [format]]
             [promesa.core :as p]
             [re-frame.core :as rf]
-            [clojure.test :refer [deftest are is testing]]))
+            [clojure.test :refer [deftest are testing]]))
 
 ;; TODO move to cljc
 (defn getx
@@ -212,19 +212,3 @@
       nil nil
       nil {}
       nil [])))
-
-;; https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/id
-(defn escape-element-id [id]
-  (when (string? id)
-    (-> id
-        (str/replace #"[^A-Za-z0-9\-\_]" "_") ; "only ASCII letters, digits, '_', and '-' should be used,"
-        (str/replace-first #"^[^A-Za-z]" #(str "id_" %))))) ; "and the value for an id attribute should start with a letter"
-
-(deftest test-escape-element-id
-  (testing "should replace element special characters with underscore"
-    (is (nil? (escape-element-id nil)))
-    (is (= "element_id-123_" (escape-element-id "element id-123 ")))
-    (is (= "element_id_123" (escape-element-id "element.id#123")))
-    (is (= "id_123-element" (escape-element-id "123-element")))
-    (is (= "id__123-element" (escape-element-id " 123-element")))))
-

--- a/test/clj/rems/test_browser.clj
+++ b/test/clj/rems/test_browser.clj
@@ -53,6 +53,8 @@
   (btu/screenshot "landing-page.png")
   (btu/scroll-and-click {:css ".login-btn"})
   (btu/screenshot "login-page.png")
+  (when (btu/visible? :show-special-users) ; sometimes the user is in the hidden part
+    (btu/scroll-and-click :show-special-users))
   (btu/scroll-and-click [{:css ".users"} {:tag :a :fn/text username}])
   ;; NB. it's better to use wait-visible instead of
   ;; eventually-visible? in utils like this because we want the line

--- a/test/clj/rems/testing_util.clj
+++ b/test/clj/rems/testing_util.clj
@@ -63,6 +63,10 @@
   [users & body]
   `(with-redefs [rems.auth.fake-login/get-fake-users (constantly (keys ~users))
                  rems.auth.fake-login/get-fake-id-data (fn [username#] (get ~users username#))
-                 rems.auth.fake-login/get-fake-user-info (fn [username#] (get ~users username#))]
+                 rems.auth.fake-login/get-fake-user-info (fn [username#] (get ~users username#))
+                 rems.auth.fake-login/get-fake-user-descriptions (constantly [{:group "Test Users"
+                                                                               :users ~(vec (for [[k v] users]
+                                                                                              {:userid k
+                                                                                               :description (pr-str v)}))}])]
      ~@body))
 


### PR DESCRIPTION
Close #2896

This feature should make it more obvious what kind of users exist when trying out REMS. There is a further ticket that should be done to actually clean up the users more #2297, perhaps rename etc.

![users](https://user-images.githubusercontent.com/823661/162155002-9f4aa1d4-bd25-4236-a21b-7e03298dfe32.png)
![demo-users](https://user-images.githubusercontent.com/823661/162156527-a34a0a08-6f59-4888-9f81-4d0a197ee9a4.png)


# Checklist for author

Remove items that aren't applicable, check items that are done.

## Reviewability
- [x] Link to issue
- [x] Consider adding screenshots for ease of review

## Documentation
- [x] Update changelog if necessary

## Testing
- [x] Valuable features are integration / browser / acceptance tested automatically

## Follow-up
- [x] New tasks are created for pending or remaining tasks
