### PR TITLE
Error in OIDC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ NB: The login has changed to allow more configurable user identity and other att
 ### Additions
 - You can configure the OIDC attributes for name and email (see configuration.md)
 - User in the API can be an internal REMS id or any of the `:oidc-userid-attributes` (provided that the user has logged in once and we have stored the identity. (#2821 #2772)
+- Errors are now handled in `oidc-callback` by redirecting to an error page. (#2856)
 
 ### Fixes
 - API-key validity is not checked unless it is actually sent. (#2785)

--- a/resources/translations/en.edn
+++ b/resources/translations/en.edn
@@ -509,7 +509,8 @@
           :alternative-text ""
           :errors {:invalid-user "There was a problem logging you in because of missing information (%1). Please check your identity provider."
                    :email "Email"
-                   :name "Name"}
+                   :name "Name"
+                   :unknown "There was a problem logging you in. Please check your identity provider."}
           :fake-text ""
           :fake-title ""
           :intro [:div [:h1 "Welcome to REMS"] [:p "This is a demo environment for testing the REMS software. The demo environment has a couple of fictional datasets to which you can apply for access. More information is available on " [:a {:href "/extra-pages/about"} "About"] " page."]]

--- a/resources/translations/fi.edn
+++ b/resources/translations/fi.edn
@@ -466,7 +466,8 @@
           :alternative-text ""
           :errors {:invalid-user "Kirjautuminen epäonnistui puuttuvan tiedon takia (%1). Tarkista tietosi tunnistautumispalvelustasi."
                    :email "Sähköposti"
-                   :name "Nimi"}
+                   :name "Nimi"
+                   :unknown "Kirjautuminen epäonnistui. Tarkista tietosi tunnistautumispalvelustasi."}
           :fake-text ""
           :fake-title ""
           :intro [:div [:h1 "Tervetuloa REMSiin"] [:p "Tämä on demo-ympäristö, joka on tarkoitettu REMS-ohjelmiston kokeilemiseen. Demo-ympäristöön on luotu valmiiksi joitain kuvitteellisia tietoaineistoja, joihin voit hakea käyttöoikeutta. Lisätietoja " [:a {:href "/extra-pages/about"} "Info-sivulla"] "."]]

--- a/resources/translations/sv.edn
+++ b/resources/translations/sv.edn
@@ -466,7 +466,8 @@
           :alternative-text ""
           :errors {:invalid-user "Inloggningen misslyckades på grund av saknad information (%1). Kontrollera din identifieringstjänst."
                    :email "E-postaddress"
-                   :name "Namn"}
+                   :name "Namn"
+                   :unknown "Inloggningen misslyckades. Kontrollera din identifieringstjänst."}
           :fake-text ""
           :fake-title ""
           :intro [:div [:h1 "Välkommen till REMS"] [:p "Detta är en demo-version där du kan testa REMS. Här kan du ansöka om rättigheter till olika demo-resurser. Läs mer på " [:a {:href "/extra-pages/about"} "Info-sidan"] "."]]

--- a/src/clj/rems/auth/oidc.clj
+++ b/src/clj/rems/auth/oidc.clj
@@ -120,46 +120,57 @@
     user))
 
 (defn oidc-callback [request]
-  (let [response (-> (http/post (:token_endpoint oidc-configuration)
-                                ;; NOTE Some IdPs don't support client id and secret in form params,
-                                ;;      and require us to use HTTP basic auth
-                                {:basic-auth [(str (getx env :oidc-client-id))
-                                              (getx env :oidc-client-secret)]
-                                 :form-params {:grant_type "authorization_code"
-                                               :code (get-in request [:params :code])
-                                               :redirect_uri (str (getx env :public-url) "oidc-callback")}
-                                 ;; Setting these will cause the exceptions raised by http/post to contain
-                                 ;; the request body, useful for debugging failures.
-                                 :save-request? (getx env :log-authentication-details)
-                                 :debug-body (getx env :log-authentication-details)})
-                     ;; FIXME Complains about Invalid cookie header in logs
-                     ;; TODO Unhandled responses for token endpoint:
-                     ;;      403 {\"error\":\"invalid_grant\",\"error_description\":\"Invalid authorization code\"} when reusing codes
-                     (:body)
-                     (json/parse-string))
-        access-token (:access_token response)
-        id-token (:id_token response)
-        issuer (:issuer oidc-configuration)
-        audience (getx env :oidc-client-id)
-        now (Instant/now)
-        ;; id-data has keys:
-        ;; sub – unique ID
-        ;; name - non-unique name
-        ;; locale – could be used to set preferred lang on first login
-        ;; email – non-unique (!) email
-        id-data (jwt/validate id-token issuer audience now)
-        user-info (when-let [url (:userinfo_endpoint oidc-configuration)]
-                    (-> (http/get url {:headers {"Authorization" (str "Bearer " access-token)}})
-                        :body
-                        json/parse-string
-                        ga4gh/passport->researcher-status-by))
-        user (find-or-create-user! id-data user-info)]
-    (when (:log-authentication-details env)
-      (log/info "logged in" id-data user-info user))
-    (-> (redirect "/redirect")
-        (assoc :session (:session request))
-        (assoc-in [:session :access-token] access-token)
-        (assoc-in [:session :identity] user))))
+  (let [error (get-in request [:params :error])
+        code (get-in request [:params :code])]
+    (cond error
+          (do (log/warn "Login error in oidc-callback" (pr-str error))
+              (redirect "/error?key=t.login.errors/unknown"))
+
+          (str/blank? code)
+          (do (log/warn "Missing code in oidc-callback" (pr-str code))
+              (redirect "/error?key=t.login.errors/unknown"))
+
+          :else
+          (let [response (-> (http/post (:token_endpoint oidc-configuration)
+                                        ;; NOTE Some IdPs don't support client id and secret in form params,
+                                        ;;      and require us to use HTTP basic auth
+                                        {:basic-auth [(str (getx env :oidc-client-id))
+                                                      (getx env :oidc-client-secret)]
+                                         :form-params {:grant_type "authorization_code"
+                                                       :code code
+                                                       :redirect_uri (str (getx env :public-url) "oidc-callback")}
+                                         ;; Setting these will cause the exceptions raised by http/post to contain
+                                         ;; the request body, useful for debugging failures.
+                                         :save-request? (getx env :log-authentication-details)
+                                         :debug-body (getx env :log-authentication-details)})
+                             ;; FIXME Complains about Invalid cookie header in logs
+                             ;; TODO Unhandled responses for token endpoint:
+                             ;;      403 {\"error\":\"invalid_grant\",\"error_description\":\"Invalid authorization code\"} when reusing codes
+                             (:body)
+                             (json/parse-string))
+                access-token (:access_token response)
+                id-token (:id_token response)
+                issuer (:issuer oidc-configuration)
+                audience (getx env :oidc-client-id)
+                now (Instant/now)
+                ;; id-data has keys:
+                ;; sub – unique ID
+                ;; name - non-unique name
+                ;; locale – could be used to set preferred lang on first login
+                ;; email – non-unique (!) email
+                id-data (jwt/validate id-token issuer audience now)
+                user-info (when-let [url (:userinfo_endpoint oidc-configuration)]
+                            (-> (http/get url {:headers {"Authorization" (str "Bearer " access-token)}})
+                                :body
+                                json/parse-string
+                                ga4gh/passport->researcher-status-by))
+                user (find-or-create-user! id-data user-info)]
+            (when (:log-authentication-details env)
+              (log/info "logged in" id-data user-info user))
+            (-> (redirect "/redirect")
+                (assoc :session (:session request))
+                (assoc-in [:session :access-token] access-token)
+                (assoc-in [:session :identity] user))))))
 
 (defn- oidc-revoke [token]
   (when token

--- a/src/clj/rems/auth/oidc.clj
+++ b/src/clj/rems/auth/oidc.clj
@@ -124,11 +124,11 @@
         code (get-in request [:params :code])]
     (cond error
           (do (log/warn "Login error in oidc-callback" (pr-str error))
-              (redirect "/error?key=t.login.errors/unknown"))
+              (redirect "/error?key=:t.login.errors/unknown"))
 
           (str/blank? code)
           (do (log/warn "Missing code in oidc-callback" (pr-str code))
-              (redirect "/error?key=t.login.errors/unknown"))
+              (redirect "/error?key=:t.login.errors/unknown"))
 
           :else
           (let [response (-> (http/post (:token_endpoint oidc-configuration)

--- a/test/clj/rems/api/services/test_invitation.clj
+++ b/test/clj/rems/api/services/test_invitation.clj
@@ -37,11 +37,11 @@
 
         (testing "with invalid workflow"
           (is (= {:success false
-                  :errors [{:type :t.accept-invitation.errors/invalid-workflow :workflow-id 42}]}
+                  :errors [{:type :t.accept-invitation.errors/invalid-workflow :workflow-id 100042}]}
                  (invitation/create-invitation! {:userid "owner"
                                                  :name "Dorothy Vaughan"
                                                  :email "dorothy.vaughan@nasa.gov"
-                                                 :workflow-id 42}))))
+                                                 :workflow-id 100042}))))
 
         (testing "success"
           (let [sent-email (atom nil)]

--- a/test/clj/rems/auth/test_oidc.clj
+++ b/test/clj/rems/auth/test_oidc.clj
@@ -79,3 +79,33 @@
                          :commonName nil
                          :mail nil}}
                  (ex-data e))))))))
+
+(deftest test-no-code
+  (with-special-setup {:id-data {:sub "user" :name "User" :email "user@example.com"}}
+    (fn []
+      (let [request {}
+            response (oidc/oidc-callback request)]
+        (is (= {:status 302
+                :headers {"Location" "/error?key=t.login.errors/unknown"}
+                :body ""}
+               response)
+            "can't log in with missing code parameter in callback"))
+
+      (let [request {:params {:code ""}}
+            response (oidc/oidc-callback request)]
+        (is (= {:status 302
+                :headers {"Location" "/error?key=t.login.errors/unknown"}
+                :body ""}
+               response)
+            "can't log in with blank code parameter in callback")))))
+
+(deftest test-error
+  (with-special-setup {:id-data {:sub "user" :name "User" :email "user@example.com"}}
+    (fn []
+      (let [request {:params {:error "failed"}}
+            response (oidc/oidc-callback request)]
+        (is (= {:status 302
+                :headers {"Location" "/error?key=t.login.errors/unknown"}
+                :body ""}
+               response)
+            "can't log in when an error happens")))))

--- a/test/clj/rems/auth/test_oidc.clj
+++ b/test/clj/rems/auth/test_oidc.clj
@@ -86,7 +86,7 @@
       (let [request {}
             response (oidc/oidc-callback request)]
         (is (= {:status 302
-                :headers {"Location" "/error?key=t.login.errors/unknown"}
+                :headers {"Location" "/error?key=:t.login.errors/unknown"}
                 :body ""}
                response)
             "can't log in with missing code parameter in callback"))
@@ -94,7 +94,7 @@
       (let [request {:params {:code ""}}
             response (oidc/oidc-callback request)]
         (is (= {:status 302
-                :headers {"Location" "/error?key=t.login.errors/unknown"}
+                :headers {"Location" "/error?key=:t.login.errors/unknown"}
                 :body ""}
                response)
             "can't log in with blank code parameter in callback")))))
@@ -105,7 +105,7 @@
       (let [request {:params {:error "failed"}}
             response (oidc/oidc-callback request)]
         (is (= {:status 302
-                :headers {"Location" "/error?key=t.login.errors/unknown"}
+                :headers {"Location" "/error?key=:t.login.errors/unknown"}
                 :body ""}
                response)
             "can't log in when an error happens")))))


### PR DESCRIPTION
Close #2856

Using the error page, redirecting to it if the code is missing or error is given to the callback. Both will be logged, but not available for the user to not reveal details.

I guess these need to be tested further in real authentication setups.

Should review diff with whitespace changes off.

![login-error](https://user-images.githubusercontent.com/823661/162162965-ba0fa664-7904-41da-98ce-e6bed2bdca90.png)

# Checklist for author

Remove items that aren't applicable, check items that are done.

## Reviewability
- [x] Link to issue
- [x] Consider adding screenshots for ease of review

## Documentation
- [x] Update changelog if necessary

## Testing
- [x] Valuable features are integration / browser / acceptance tested automatically
