### PR TITLE
feat: email configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ NB: The login has changed to allow more configurable user identity and other att
 - User in the API can be an internal REMS id or any of the `:oidc-userid-attributes` (provided that the user has logged in once and we have stored the identity. (#2821 #2772)
 - Fake login page has been improved to include descriptions of the different users. (#2896)
 - Errors are now handled in `oidc-callback` by redirecting to an error page. (#2856)
+- Mail settings can be configured with the `:smtp` config including authentication. (#2895)
 
 ### Fixes
 - API-key validity is not checked unless it is actually sent. (#2785)

--- a/resources/config-defaults.edn
+++ b/resources/config-defaults.edn
@@ -83,8 +83,20 @@
  :oidc-extra-attributes []
 
  ;; Sending email.
+ ;;
+ ;; Either you specify `:smtp-host` and `:smtp-port` like here:
  :smtp-host nil
  :smtp-port 25
+ ;;
+ ;; Or you can specify a map under `:smtp` with host, port, authentication details etc.
+ ;;
+ ;; Example:
+ ;; :smtp {:host "https://..." :pass "..." :port 587 :ssl true}
+ ;;
+ ;; For the full set of available keys see https://github.com/drewr/postal#smtp
+ :smtp nil
+
+ ;; Other email parameters (in addition to the above):
  :smtp-connectiontimeout 5000 ; milliseconds waiting for connection
  :smtp-timeout 10000 ; milliseconds waiting for processing
  :smtp-writetimeout 10000 ; milliseconds waiting for writes


### PR DESCRIPTION
Close #2895 

There is more possibilities for configuring the email using the
`:smtp` key in config. The map will be passed to library (postal).
See https://github.com/drewr/postal#smtp

# Checklist for author

Remove items that aren't applicable, check items that are done.

## Reviewability
- [x] Link to issue

## Backwards compatibility
- [x] Config is backwards compatible

## Documentation
- [x] Update changelog if necessary
- [x] New config options in config-defaults.edn

## Testing
- [x] Valuable features are integration / browser / acceptance tested automatically
