### PR TITLE
feat: update Dockerfile to use JDK17

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,16 @@
 # For documentation see docs/installing-upgrading.md
 
-FROM openjdk:11-jre-slim
+FROM eclipse-temurin:17-jre-alpine
+
+RUN apk add --no-cache bash
 
 RUN mkdir /rems
 WORKDIR /rems
 
-ENTRYPOINT ["./docker-entrypoint.sh"]
+ENTRYPOINT ["bash","./docker-entrypoint.sh"]
 
 COPY empty-config.edn /rems/config/config.edn
 COPY target/uberjar/rems.jar /rems/rems.jar
 COPY docker-entrypoint.sh /rems/docker-entrypoint.sh
 
-RUN chmod 664 /usr/local/openjdk-11/lib/security/cacerts
+RUN chmod 664 /opt/java/openjdk/lib/security/cacerts


### PR DESCRIPTION
relates #2762 

Update Dockerfile to use JDK17 image. `openjdk:17-jre-slim` was not available, but based on following SO discussion `eclipse-temurin` builds could work instead: https://stackoverflow.com/questions/69525199/openjdk-java-17-docker-image

# Checklist for author

Remove items that aren't applicable, check items that are done.

## Reviewability
- [x] Link to issue

## Documentation
- [ ] Update changelog if necessary
