### PR TITLE
Rename old attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ have notable changes.
 
 Changes since v2.25
 
+**NB: This release contains migrations!**
+
 NB: The login has changed to allow more configurable user identity and other attributes. Consider this a big change worth some manual testing to see that everything works.
 
 ### Breaking changes
@@ -15,6 +17,7 @@ NB: The login has changed to allow more configurable user identity and other att
 - User attributes are not saved on every request, only when logging in. (#2829)
 - The `:oidc-userid-attribute` config has been renamed to `:oidc-userid-attributes` and has new options to allow internally renaming an attribute from IdP to REMS db. (#2771, #2821)
 - Users are required a name and email from the IdP to be allowed in. (#2889)
+- User attributes have been renamed internally. If you directly accessed the database, please note that `eppn -> userid`, `commonName -> name` and `mail -> email`. (#2377)
 
 ### Additions
 - You can configure the OIDC attributes for name and email (see configuration.md)

--- a/resources/migrations/20220421155417-un-haka.edn
+++ b/resources/migrations/20220421155417-un-haka.edn
@@ -1,0 +1,3 @@
+{:ns rems.migrations.un-haka
+ :up-fn migrate-up
+ :down-fn migrate-down}

--- a/resources/sql/queries.sql
+++ b/resources/sql/queries.sql
@@ -276,7 +276,7 @@ WHERE catAppId = :application
 --   :user -- user id to limit select to
 --   :resource -- resid to limit select to
 --   :active-at -- only return entitlements with start<=active-at<end (or end undefined)
-SELECT entitlement.id AS entitlementId, res.id AS resourceId, res.resId, catAppId, entitlement.userId, entitlement.start, entitlement.endt AS "end", users.userAttrs->>'mail' AS mail,
+SELECT entitlement.id AS entitlementId, res.id AS resourceId, res.resId, catAppId, entitlement.userId, entitlement.start, entitlement.endt AS "end", users.userAttrs->>'email' AS mail,
 entitlement.approvedby FROM entitlement
 LEFT OUTER JOIN resource res ON entitlement.resId = res.id
 LEFT OUTER JOIN users on entitlement.userId = users.userId

--- a/src/clj/rems/api/services/util.clj
+++ b/src/clj/rems/api/services/util.clj
@@ -25,7 +25,7 @@
         org-carl {:organization/id "organization owned by bob" :organization/owners [{:userid "carl"}]}
         org-bob-carl {:organization/id "organization owned by bob and carl" :organization/owners [{:userid "bob"} {:userid "carl"}]}]
     (testing "for owner, all organizations are permitted"
-      (binding [context/*user* {:eppn "owner"}
+      (binding [context/*user* {:userid "owner"}
                 context/*roles* #{:owner}]
         (is (may-edit-organization? org-empty))
         (is (may-edit-organization? org-nobody))
@@ -34,7 +34,7 @@
         (is (may-edit-organization? org-bob-carl))))
 
     (testing "for owner who is also an organization owner, all organizations are permitted"
-      (binding [context/*user* {:eppn "bob"}
+      (binding [context/*user* {:userid "bob"}
                 context/*roles* #{:owner}]
         (is (may-edit-organization? org-empty))
         (is (may-edit-organization? org-nobody))
@@ -43,7 +43,7 @@
         (is (may-edit-organization? org-bob-carl))))
 
     (testing "for organization owner, only own organizations are permitted"
-      (binding [context/*user* {:eppn "bob"}
+      (binding [context/*user* {:userid "bob"}
                 context/*roles* #{}]
         (is (not (may-edit-organization? org-empty)))
         (is (not (may-edit-organization? org-nobody)))
@@ -52,7 +52,7 @@
         (is (may-edit-organization? org-bob-carl)))
 
       (testing ", even if they are a handler"
-        (binding [context/*user* {:eppn "bob"}
+        (binding [context/*user* {:userid "bob"}
                   context/*roles* #{:handler}]
           (is (not (may-edit-organization? org-empty)))
           (is (not (may-edit-organization? org-nobody)))
@@ -61,7 +61,7 @@
           (is (may-edit-organization? org-bob-carl)))))
 
     (testing "for other user, no organizations are permitted"
-      (binding [context/*user* {:eppn "alice"}
+      (binding [context/*user* {:userid "alice"}
                 context/*roles* #{}]
         (is (not (may-edit-organization? org-empty)))
         (is (not (may-edit-organization? org-nobody)))

--- a/src/clj/rems/auth/auth.clj
+++ b/src/clj/rems/auth/auth.clj
@@ -27,7 +27,7 @@
     (-authenticate [_ request _]
       (when (:uses-valid-api-key? request)
         (when-let [uid (get-api-user request)]
-          (merge {:eppn uid}
+          (merge {:userid uid}
                  ;; we need the raw user attrs here to emulate other login methods
                  (users/get-raw-user-attributes uid)))))))
 

--- a/src/clj/rems/auth/oidc.clj
+++ b/src/clj/rems/auth/oidc.clj
@@ -86,7 +86,7 @@
         (find-first users/user-exists? (map second userid-attrs)))))
 
 (defn- upsert-user! [user]
-  (let [userid (:eppn user)]
+  (let [userid (:userid user)]
     (users/add-user-raw! userid user)
     user))
 
@@ -94,9 +94,9 @@
   ;; TODO all attributes could support :rename
   (let [userid (or (find-user id-data) (get-new-userid id-data))
         _ (assert userid (when (:log-authentication-details env) {:id-data id-data :user-info user-info}))
-        identity-base {:eppn userid
-                       :commonName (some (comp id-data keyword) (:oidc-name-attributes env))
-                       :mail (some (comp id-data keyword) (:oidc-email-attributes env))}
+        identity-base {:userid userid
+                       :name (some (comp id-data keyword) (:oidc-name-attributes env))
+                       :email (some (comp id-data keyword) (:oidc-email-attributes env))}
         extra-attributes (select-keys id-data (map (comp keyword :attribute) (:oidc-extra-attributes env)))
         user-info-attributes (select-keys user-info [:researcher-status-by])]
     (merge identity-base extra-attributes user-info-attributes)))
@@ -105,8 +105,8 @@
 (defn- validate-user! [user]
   ;; userid already checked
   (when-let [errors (seq (remove nil?
-                                 [(when (str/blank? (:commonName user)) :t.login.errors/name)
-                                  (when (str/blank? (:mail user)) :t.login.errors/email)]))]
+                                 [(when (str/blank? (:name user)) :t.login.errors/name)
+                                  (when (str/blank? (:email user)) :t.login.errors/email)]))]
     (throw (ex-info "Invalid user"
                     {:key :t.login.errors/invalid-user
                      :args errors
@@ -116,7 +116,7 @@
   (let [user (get-user-attributes id-data user-info)
         _ (validate-user! user)
         user (upsert-user! user)]
-    (save-user-mappings! id-data (:eppn user))
+    (save-user-mappings! id-data (:userid user))
     user))
 
 (defn oidc-callback [request]

--- a/src/clj/rems/db/test_data.clj
+++ b/src/clj/rems/db/test_data.clj
@@ -577,9 +577,9 @@
                        (for [n (range-1 user-count)]
                          (fn []
                            (let [user-id (str "perftester" n)]
-                             (users/add-user-raw! user-id {:eppn user-id
-                                                           :mail (str user-id "@example.com")
-                                                           :commonName (str "Performance Tester " n)})
+                             (users/add-user-raw! user-id {:userid user-id
+                                                           :email (str user-id "@example.com")
+                                                           :name (str "Performance Tester " n)})
                              user-id)))))]
     (in-parallel
      (for [n (range-1 application-count)]

--- a/src/clj/rems/db/test_data_helpers.clj
+++ b/src/clj/rems/db/test_data_helpers.clj
@@ -51,7 +51,7 @@
 (defn create-user! [user-attributes-and-mappings & roles]
   (let [mappings (:mappings user-attributes-and-mappings)
         user-attributes (dissoc user-attributes-and-mappings :mappings)
-        user (:eppn user-attributes)]
+        user (:userid user-attributes)]
     (users/add-user-raw! user user-attributes)
     (doseq [[k v] mappings]
       (user-mappings/create-user-mapping! {:userid user :ext-id-attribute k :ext-id-value v}))

--- a/src/clj/rems/db/test_data_users.clj
+++ b/src/clj/rems/db/test_data_users.clj
@@ -10,9 +10,9 @@
    :rejecter-bot rejecter-bot/bot-userid})
 
 (def +bot-user-data+
-  {approver-bot/bot-userid {:eppn approver-bot/bot-userid :commonName "Approver Bot"}
-   bona-fide-bot/bot-userid {:eppn bona-fide-bot/bot-userid :commonName "Bona Fide Bot"}
-   rejecter-bot/bot-userid {:eppn rejecter-bot/bot-userid :commonName "Rejecter Bot"}})
+  {approver-bot/bot-userid {:userid approver-bot/bot-userid :name "Approver Bot"}
+   bona-fide-bot/bot-userid {:userid bona-fide-bot/bot-userid :name "Bona Fide Bot"}
+   rejecter-bot/bot-userid {:userid rejecter-bot/bot-userid :name "Rejecter Bot"}})
 
 (def +fake-users+
   {:applicant1 "alice"
@@ -30,19 +30,19 @@
    :jillsmith "jillsmith"})
 
 (def +fake-user-data+
-  {"developer" {:eppn "developer" :mail "developer@example.com" :commonName "Developer" :nickname "The Dev"}
-   "alice" {:eppn "alice" :mail "alice@example.com" :commonName "Alice Applicant" :organizations [{:organization/id "default"}] :nickname "In Wonderland" :researcher-status-by "so"}
-   "malice" {:eppn "malice" :mail "malice@example.com" :commonName "Malice Applicant" :twinOf "alice" :other "Attribute Value" :mappings {"alt-id" "malice-alt-id"}}
-   "handler" {:eppn "handler" :mail "handler@example.com" :commonName "Hannah Handler" :mappings {"alt-id" "handler-alt-id"}}
-   "carl" {:eppn "carl" :mail "carl@example.com" :commonName "Carl Reviewer" :mappings {"alt-id" "carl-alt-id"}}
-   "elsa" {:eppn "elsa" :mail "elsa@example.com" :commonName "Elsa Roleless" :mappings {"alt-id" "elsa-alt-id"}}
-   "frank" {:eppn "frank" :mail "frank@example.com" :commonName "Frank Roleless" :organizations [{:organization/id "frank"}]}
-   "organization-owner1" {:eppn "organization-owner1" :mail "organization-owner1@example.com" :commonName "Organization Owner 1"}
-   "organization-owner2" {:eppn "organization-owner2" :mail "organization-owner2@example.com" :commonName "Organization Owner 2" :organizations [{:organization/id "organization2"}]}
-   "owner" {:eppn "owner" :mail "owner@example.com" :commonName "Owner"}
-   "reporter" {:eppn "reporter" :mail "reporter@example.com" :commonName "Reporter"}
-   "johnsmith" {:eppn "johnsmith" :commonName "John Smith" :mail "john.smith@example.com" :mappings {"identity1" "johnsmith" "identity2" "smith"}}
-   "jillsmith" {:eppn "jillsmith" :commonName "Jill Smith" :mail "jill.smith@example.com" :mappings {"identity1" "jillsmith" "identity2" "smith"}}})
+  {"developer" {:userid "developer" :email "developer@example.com" :name "Developer" :nickname "The Dev"}
+   "alice" {:userid "alice" :email "alice@example.com" :name "Alice Applicant" :organizations [{:organization/id "default"}] :nickname "In Wonderland" :researcher-status-by "so"}
+   "malice" {:userid "malice" :email "malice@example.com" :name "Malice Applicant" :twinOf "alice" :other "Attribute Value" :mappings {"alt-id" "malice-alt-id"}}
+   "handler" {:userid "handler" :email "handler@example.com" :name "Hannah Handler" :mappings {"alt-id" "handler-alt-id"}}
+   "carl" {:userid "carl" :email "carl@example.com" :name "Carl Reviewer" :mappings {"alt-id" "carl-alt-id"}}
+   "elsa" {:userid "elsa" :email "elsa@example.com" :name "Elsa Roleless" :mappings {"alt-id" "elsa-alt-id"}}
+   "frank" {:userid "frank" :email "frank@example.com" :name "Frank Roleless" :organizations [{:organization/id "frank"}]}
+   "organization-owner1" {:userid "organization-owner1" :email "organization-owner1@example.com" :name "Organization Owner 1"}
+   "organization-owner2" {:userid "organization-owner2" :email "organization-owner2@example.com" :name "Organization Owner 2" :organizations [{:organization/id "organization2"}]}
+   "owner" {:userid "owner" :email "owner@example.com" :name "Owner"}
+   "reporter" {:userid "reporter" :email "reporter@example.com" :name "Reporter"}
+   "johnsmith" {:userid "johnsmith" :name "John Smith" :email "john.smith@example.com" :mappings {"identity1" "johnsmith" "identity2" "smith"}}
+   "jillsmith" {:userid "jillsmith" :name "Jill Smith" :email "jill.smith@example.com" :mappings {"identity1" "jillsmith" "identity2" "smith"}}})
 
 (def +fake-id-data+
   {"developer" {:sub "developer" :email "developer@example.com" :name "Developer" :nickname "The Dev"}
@@ -123,15 +123,15 @@
    :reporter "RDdomainreporter@funet.fi"})
 
 (def +demo-user-data+
-  {"RDapplicant1@funet.fi" {:eppn "RDapplicant1@funet.fi" :mail "RDapplicant1.test@test_example.org" :commonName "RDapplicant1 REMSDEMO1" :organizations [{:organization/id "default"}]}
-   "RDapplicant2@funet.fi" {:eppn "RDapplicant2@funet.fi" :mail "RDapplicant2.test@test_example.org" :commonName "RDapplicant2 REMSDEMO"}
-   "RDapprover1@funet.fi" {:eppn "RDapprover1@funet.fi" :mail "RDapprover1.test@rems_example.org" :commonName "RDapprover1 REMSDEMO"}
-   "RDapprover2@funet.fi" {:eppn "RDapprover2@funet.fi" :mail "RDapprover2.test@rems_example.org" :commonName "RDapprover2 REMSDEMO"}
-   "RDreview@funet.fi" {:eppn "RDreview@funet.fi" :mail "RDreview.test@rems_example.org" :commonName "RDreview REMSDEMO"}
-   "RDowner@funet.fi" {:eppn "RDowner@funet.fi" :mail "RDowner.test@test_example.org" :commonName "RDowner REMSDEMO"}
-   "RDorganizationowner1@funet.fi" {:eppn "RDorganizationowner1@funet.fi" :mail "RDorganizationowner1.test@test_example.org" :commonName "RDorganizationowner1 REMSDEMO" :organizations [{:organization/id "organization1"}]}
-   "RDorganizationowner2@funet.fi" {:eppn "RDorganizationowner2@funet.fi" :mail "RDorganizationowner2.test@test_example.org" :commonName "RDorganizationowner2 REMSDEMO" :organizations [{:organization/id "organization2"}]}
-   "RDdomainreporter@funet.fi" {:eppn "RDdomainreporter@funet.fi" :mail "RDdomainreporter.test@test_example.org" :commonName "RDdomainreporter REMSDEMO"}})
+  {"RDapplicant1@funet.fi" {:userid "RDapplicant1@funet.fi" :email "RDapplicant1.test@test_example.org" :name "RDapplicant1 REMSDEMO1" :organizations [{:organization/id "default"}]}
+   "RDapplicant2@funet.fi" {:userid "RDapplicant2@funet.fi" :email "RDapplicant2.test@test_example.org" :name "RDapplicant2 REMSDEMO"}
+   "RDapprover1@funet.fi" {:userid "RDapprover1@funet.fi" :email "RDapprover1.test@rems_example.org" :name "RDapprover1 REMSDEMO"}
+   "RDapprover2@funet.fi" {:userid "RDapprover2@funet.fi" :email "RDapprover2.test@rems_example.org" :name "RDapprover2 REMSDEMO"}
+   "RDreview@funet.fi" {:userid "RDreview@funet.fi" :email "RDreview.test@rems_example.org" :name "RDreview REMSDEMO"}
+   "RDowner@funet.fi" {:userid "RDowner@funet.fi" :email "RDowner.test@test_example.org" :name "RDowner REMSDEMO"}
+   "RDorganizationowner1@funet.fi" {:userid "RDorganizationowner1@funet.fi" :email "RDorganizationowner1.test@test_example.org" :name "RDorganizationowner1 REMSDEMO" :organizations [{:organization/id "organization1"}]}
+   "RDorganizationowner2@funet.fi" {:userid "RDorganizationowner2@funet.fi" :email "RDorganizationowner2.test@test_example.org" :name "RDorganizationowner2 REMSDEMO" :organizations [{:organization/id "organization2"}]}
+   "RDdomainreporter@funet.fi" {:userid "RDdomainreporter@funet.fi" :email "RDdomainreporter.test@test_example.org" :name "RDdomainreporter REMSDEMO"}})
 
 (def +demo-id-data+
   {"RDapplicant1@funet.fi" {:sub "RDapplicant1@funet.fi" :email "RDapplicant1.test@test_example.org" :name "RDapplicant1 REMSDEMO1" :organizations [{:organization/id "default"}]}
@@ -159,12 +159,12 @@
    :owner "BACZQAPVWBDJ2OXLKT2WWW5LT5LV6YR4"})
 
 (def +oidc-user-data+
-  {"WHFS36UEZD6TNURJ76WYLSVDCUUENOOF" {:eppn "WHFS36UEZD6TNURJ76WYLSVDCUUENOOF" :mail "RDapplicant1@mailinator.com" :commonName "RDapplicant1 REMSDEMO1" :organizations [{:organization/id "default"}]}
-   "C567LI5QAACWKC7YYA74BJ2X7DH7EEYI" {:eppn "C567LI5QAACWKC7YYA74BJ2X7DH7EEYI" :mail "RDapplicant2@mailinator.com" :commonName "RDapplicant2 REMSDEMO"}
-   "EKGFNAAGCHIQ5ERUUFS2RCZ44IHYZPEA" {:eppn "EKGFNAAGCHIQ5ERUUFS2RCZ44IHYZPEA" :mail "RDapprover1@mailinator.com" :commonName "RDapprover1 REMSDEMO"}
-   "7R3JYB32PL3EPVD34RWIAWDZSEOXW4OQ" {:eppn "7R3JYB32PL3EPVD34RWIAWDZSEOXW4OQ" :mail "RDapprover2@mailinator.com" :commonName "RDapprover2 REMSDEMO"}
-   "F3OJL757ACT4QXVXZZ4F7VG6HQGBEC4M" {:eppn "F3OJL757ACT4QXVXZZ4F7VG6HQGBEC4M" :mail "RDreview@mailinator.com" :commonName "RDreview REMSDEMO"}
-   "JOBDHBMX4EFXQC5IPQVXPP4FFWJ6XQYL" {:eppn "JOBDHBMX4EFXQC5IPQVXPP4FFWJ6XQYL" :mail "RDdomainreporter@mailinator.com" :commonName "RDdomainreporter REMSDEMO"}
-   "W6OKPQGANG6QK54GRF7AOOGMZL7M6IVH" {:eppn "W6OKPQGANG6QK54GRF7AOOGMZL7M6IVH" :mail "RDorganizationowner1@mailinator.com" :commonName "RDorganizationowner1 REMSDEMO" :organizations [{:organization/id "organization1"}]}
-   "D4ZJM7XNXKGFQABRQILDI6EYHLJRLYSF" {:eppn "D4ZJM7XNXKGFQABRQILDI6EYHLJRLYSF" :mail "RDorganizationowner2@mailinator.com" :commonName "RDorganizationowner2 REMSDEMO" :organizations [{:organization/id "organization2"}]}
-   "BACZQAPVWBDJ2OXLKT2WWW5LT5LV6YR4" {:eppn "BACZQAPVWBDJ2OXLKT2WWW5LT5LV6YR4" :mail "RDowner@mailinator.com" :commonName "RDowner REMSDEMO"}})
+  {"WHFS36UEZD6TNURJ76WYLSVDCUUENOOF" {:userid "WHFS36UEZD6TNURJ76WYLSVDCUUENOOF" :email "RDapplicant1@mailinator.com" :name "RDapplicant1 REMSDEMO1" :organizations [{:organization/id "default"}]}
+   "C567LI5QAACWKC7YYA74BJ2X7DH7EEYI" {:userid "C567LI5QAACWKC7YYA74BJ2X7DH7EEYI" :email "RDapplicant2@mailinator.com" :name "RDapplicant2 REMSDEMO"}
+   "EKGFNAAGCHIQ5ERUUFS2RCZ44IHYZPEA" {:userid "EKGFNAAGCHIQ5ERUUFS2RCZ44IHYZPEA" :email "RDapprover1@mailinator.com" :name "RDapprover1 REMSDEMO"}
+   "7R3JYB32PL3EPVD34RWIAWDZSEOXW4OQ" {:userid "7R3JYB32PL3EPVD34RWIAWDZSEOXW4OQ" :email "RDapprover2@mailinator.com" :name "RDapprover2 REMSDEMO"}
+   "F3OJL757ACT4QXVXZZ4F7VG6HQGBEC4M" {:userid "F3OJL757ACT4QXVXZZ4F7VG6HQGBEC4M" :email "RDreview@mailinator.com" :name "RDreview REMSDEMO"}
+   "JOBDHBMX4EFXQC5IPQVXPP4FFWJ6XQYL" {:userid "JOBDHBMX4EFXQC5IPQVXPP4FFWJ6XQYL" :email "RDdomainreporter@mailinator.com" :name "RDdomainreporter REMSDEMO"}
+   "W6OKPQGANG6QK54GRF7AOOGMZL7M6IVH" {:userid "W6OKPQGANG6QK54GRF7AOOGMZL7M6IVH" :email "RDorganizationowner1@mailinator.com" :name "RDorganizationowner1 REMSDEMO" :organizations [{:organization/id "organization1"}]}
+   "D4ZJM7XNXKGFQABRQILDI6EYHLJRLYSF" {:userid "D4ZJM7XNXKGFQABRQILDI6EYHLJRLYSF" :email "RDorganizationowner2@mailinator.com" :name "RDorganizationowner2 REMSDEMO" :organizations [{:organization/id "organization2"}]}
+   "BACZQAPVWBDJ2OXLKT2WWW5LT5LV6YR4" {:userid "BACZQAPVWBDJ2OXLKT2WWW5LT5LV6YR4" :email "RDowner@mailinator.com" :name "RDowner REMSDEMO"}})

--- a/src/clj/rems/layout.clj
+++ b/src/clj/rems/layout.clj
@@ -89,8 +89,7 @@ window.rems = {
     (include-js (cache-bust "/js/app.js"))
     [:script {:type "text/javascript"}
      (format "rems.app.setIdentity(%s);"
-             (json/generate-string {:user (when context/*user*
-                                            (users/format-user context/*user*))
+             (json/generate-string {:user context/*user*
                                     :roles context/*roles*}))])))
 
 (defn- error-content

--- a/src/clj/rems/middleware.clj
+++ b/src/clj/rems/middleware.clj
@@ -61,7 +61,7 @@
   [handler]
   (fn [request]
     (binding [context/*user* (keywordize-keys (:identity request))]
-      (with-mdc {:user (:eppn context/*user*)}
+      (with-mdc {:user (:userid context/*user*)}
         (handler request)))))
 
 (defn wrap-context [handler]
@@ -219,7 +219,7 @@
    (for [session (vals (.em_map session-store))
          :let [identity (:identity session)]
          :when identity]
-     (users/format-user identity))))
+     identity)))
 
 (defn get-session
   "Returns the session associated with a cookie. Useful for testing."

--- a/src/clj/rems/migrations/multiple_organizations.clj
+++ b/src/clj/rems/migrations/multiple_organizations.clj
@@ -54,7 +54,7 @@ UPDATE users SET userAttrs = :userattrs::jsonb WHERE userid = :userid;
   (migrate-up {:conn rems.db.core/*db*})
   (db/add-user! rems.db.core/*db*
                 {:user "alice"
-                 :userattrs (json/generate-string {:eppn "alice"
-                                                   :mail "alice@example.com"
-                                                   :commonName "Alice Applicant"
+                 :userattrs (json/generate-string {:userid "alice"
+                                                   :email "alice@example.com"
+                                                   :name "Alice Applicant"
                                                    :organization "default"})}))

--- a/src/clj/rems/migrations/un_haka.clj
+++ b/src/clj/rems/migrations/un_haka.clj
@@ -21,13 +21,12 @@ UPDATE users SET userAttrs = :userattrs::jsonb WHERE userid = :userid;
   {:userid userid
    :userattrs (map-keys #(swaps % %) userattrs)})
 
-(deftest test-migrate-user-organizations
+(deftest test-migrate-user
   (is (= {:userid "alice"
           :userattrs {:newthing 42}}
          (migrate-user {:userid "alice"
                         :userattrs {:something 42}}
-                       {:something :newthing}))
-      "adds organizations even if empty")
+                       {:something :newthing})))
   (is (= {:userid "alice"
           :userattrs {:something 42
                       :newthing ["foo"]}}

--- a/src/clj/rems/migrations/un_haka.clj
+++ b/src/clj/rems/migrations/un_haka.clj
@@ -1,0 +1,76 @@
+(ns rems.migrations.un-haka
+  (:require [clojure.test :refer [deftest is]]
+            [hugsql.core :as hugsql]
+            [medley.core :refer [map-keys]]
+            [rems.json :as json]
+            [rems.db.core :as db]))
+
+(hugsql/def-db-fns-from-string
+  "
+-- :name get-users :? :*
+SELECT
+  userId,
+  userAttrs::TEXT
+FROM users
+
+-- :name set-user-attributes! :!
+UPDATE users SET userAttrs = :userattrs::jsonb WHERE userid = :userid;
+")
+
+(defn- migrate-user [{:keys [userid userattrs]} swaps]
+  {:userid userid
+   :userattrs (map-keys #(swaps % %) userattrs)})
+
+(deftest test-migrate-user-organizations
+  (is (= {:userid "alice"
+          :userattrs {:newthing 42}}
+         (migrate-user {:userid "alice"
+                        :userattrs {:something 42}}
+                       {:something :newthing}))
+      "adds organizations even if empty")
+  (is (= {:userid "alice"
+          :userattrs {:something 42
+                      :newthing ["foo"]}}
+         (migrate-user {:userid "alice"
+                        :userattrs {:something 42
+                                    :else ["foo"]}}
+                       {:else :newthing}))))
+
+(defn migrate-users! [conn swaps]
+  (doseq [{:keys [userattrs] :as user} (get-users conn)
+          :let [userattrs (json/parse-string userattrs)
+                user (assoc user :userattrs userattrs)
+                new-user (update (migrate-user user swaps)
+                                 :userattrs
+                                 json/generate-string)]]
+    (set-user-attributes! conn new-user)))
+
+(def attribute-swaps
+  {:eppn :userid
+   :mail :email
+   :commonName :name
+   :displayName :name})
+
+(def reverse-attribute-swaps
+  ;; NB: let's call just having displayName or commonName enough
+  (into {} (map (comp vec reverse) attribute-swaps)))
+
+(defn migrate-up [{:keys [conn]}]
+  (migrate-users! conn attribute-swaps))
+
+(defn migrate-down [{:keys [conn]}]
+  (migrate-users! conn reverse-attribute-swaps))
+
+(comment
+  (migrate-user {:userid "malice",
+                 :userattrs (json/parse-string "{\"name\": \"Malice Applicant\", \"email\": \"malice@example.com\", \"other\": \"Attribute Value\", \"twinOf\": \"alice\", \"userid\": \"malice\"}")}
+                reverse-attribute-swaps)
+  (filter (comp #{"oldish"} :userid) (get-users rems.db.core/*db*))
+  (migrate-up {:conn rems.db.core/*db*})
+  (db/add-user! rems.db.core/*db*
+                {:user "oldish"
+                 :userattrs (json/generate-string {:userid "oldish"
+                                                   :mail "oldish@example.com"
+                                                   :displayName "Oldish Applicant"
+                                                   :commonName "Oldish Applicant"
+                                                   :other "attribute"})}))

--- a/src/clj/rems/util.clj
+++ b/src/clj/rems/util.clj
@@ -32,13 +32,13 @@
   ([]
    (get-user-id context/*user*))
   ([user]
-   (:eppn user)))
+   (:userid user)))
 
 (defn getx-user-id
   ([]
    (getx-user-id context/*user*))
   ([user]
-   (getx user :eppn)))
+   (getx user :userid)))
 
 (defn secure-token
   []

--- a/src/cljs/rems/application.cljs
+++ b/src/cljs/rems/application.cljs
@@ -1259,7 +1259,7 @@
             [render-application
              {:application {:application/id 17
                             :application/state :application.state/approved
-                            :application/applicant {:userid "eppn"
+                            :application/applicant {:userid "userid"
                                                     :email "email@example.com"
                                                     :additional "additional field"}
                             :application/resources [{:catalogue-item/title {:en "An applied item"}}]

--- a/test/clj/rems/api/services/test_invitation.clj
+++ b/test/clj/rems/api/services/test_invitation.clj
@@ -19,8 +19,8 @@
 (use-fixtures :each rollback-db-fixture)
 
 (deftest test-crud-invitation
-  (test-helpers/create-user! {:eppn "owner" :commonName "owner" :mail "owner@example.com"} :owner)
-  (test-helpers/create-user! {:eppn "new-handler" :commonName "New Handler" :mail "new-handler@example.com"})
+  (test-helpers/create-user! {:userid "owner" :name "owner" :email "owner@example.com"} :owner)
+  (test-helpers/create-user! {:userid "new-handler" :name "New Handler" :email "new-handler@example.com"})
   (let [workflow-id (test-helpers/create-workflow! {})]
     (with-user "owner"
       (testing "before creating invitations"

--- a/test/clj/rems/api/services/test_organizations.clj
+++ b/test/clj/rems/api/services/test_organizations.clj
@@ -14,7 +14,7 @@
         (select-keys [:enabled :archived]))))
 
 (deftest organization-enabled-archived-test
-  (test-helpers/create-user! {:eppn "owner"} :owner)
+  (test-helpers/create-user! {:userid "owner"} :owner)
   (with-user "owner"
     (let [org-id1 (test-helpers/create-organization! {:organization/id "test-org-1"})
           org-id2 (test-helpers/create-organization! {:organization/id "test-org-2"})]

--- a/test/clj/rems/api/services/test_resources.clj
+++ b/test/clj/rems/api/services/test_resources.clj
@@ -15,7 +15,7 @@
         (select-keys [:enabled :archived]))))
 
 (deftest resource-enabled-archived-test
-  (test-helpers/create-user! {:eppn "owner"} :owner)
+  (test-helpers/create-user! {:userid "owner"} :owner)
   (with-user "owner"
     (let [_org (test-helpers/create-organization! {})
           lic-id (test-helpers/create-license! {})

--- a/test/clj/rems/api/services/test_workflow.clj
+++ b/test/clj/rems/api/services/test_workflow.clj
@@ -13,10 +13,10 @@
 (use-fixtures :each rollback-db-fixture)
 
 (defn- create-users []
-  (test-helpers/create-user! {:eppn "user1" :commonName "User 1" :mail "user1@example.com"})
-  (test-helpers/create-user! {:eppn "user2" :commonName "User 2" :mail "user2@example.com"})
-  (test-helpers/create-user! {:eppn "user3" :commonName "User 3" :mail "user3@example.com"})
-  (test-helpers/create-user! {:eppn "owner" :commonName "owner" :mail "owner@example.com"} :owner))
+  (test-helpers/create-user! {:userid "user1" :name "User 1" :email "user1@example.com"})
+  (test-helpers/create-user! {:userid "user2" :name "User 2" :email "user2@example.com"})
+  (test-helpers/create-user! {:userid "user3" :name "User 3" :email "user3@example.com"})
+  (test-helpers/create-user! {:userid "owner" :name "owner" :email "owner@example.com"} :owner))
 
 (deftest test-create-workflow
   (create-users)

--- a/test/clj/rems/api/test_api.clj
+++ b/test/clj/rems/api/test_api.clj
@@ -31,8 +31,8 @@
 
 (deftest test-api-key-security
   (api-key/add-api-key! "42" {})
-  (test-helpers/create-user! {:eppn "alice"})
-  (test-helpers/create-user! {:eppn "owner"} :owner)
+  (test-helpers/create-user! {:userid "alice"})
+  (test-helpers/create-user! {:userid "owner"} :owner)
   (testing ":api-key role"
     (testing "available for valid api key"
       (is (response-is-ok? (-> (request :post "/api/email/send-reminders")
@@ -106,7 +106,7 @@
 
 (deftest test-health-api
   ;; create at least one event
-  (test-helpers/create-user! {:eppn "alice"})
+  (test-helpers/create-user! {:userid "alice"})
   (test-helpers/create-application! {:actor "alice"})
   (let [body (-> (request :get "/api/health")
                  handler
@@ -122,7 +122,7 @@
 
 (deftest data-exception-test
   (api-key/add-api-key! "42" {})
-  (test-helpers/create-user! {:eppn "owner"} :owner)
+  (test-helpers/create-user! {:userid "owner"} :owner)
   (testing "a broken license without an organization"
     (let [license-id (:id (db/create-license! {:organization "does-not-exist"
                                                :type "text"}))

--- a/test/clj/rems/api/test_applications.clj
+++ b/test/clj/rems/api/test_applications.clj
@@ -740,9 +740,9 @@
         applicant "alice"
         handler "developer"
         app-id (test-helpers/create-application! {:actor applicant})]
-    (test-helpers/create-user! {:eppn "member1"})
-    (test-helpers/create-user! {:eppn "reviewer1"})
-    (test-helpers/create-user! {:eppn "decider1"})
+    (test-helpers/create-user! {:userid "member1"})
+    (test-helpers/create-user! {:userid "reviewer1"})
+    (test-helpers/create-user! {:userid "decider1"})
     (testing "invite member for draft as applicant"
       (is (= {:success true}
              (send-command applicant {:type :application.command/invite-member
@@ -1932,9 +1932,9 @@
                                            handler)))))))
 
 (deftest test-applications-api-duplicate-user
-  (let [_ (test-helpers/create-user! {:eppn "duplicated" :name "Dupli Cated" :email "duplicated@example.com" :mappings {"identity1" "dupe" "identity2" "dupe"}})
-        _ (test-helpers/create-user! {:eppn "johnsmith" :name "John Smith" :email "john.smith@example.com" :mappings {"identity1" "johnsmith" "identity2" "smith"}})
-        _ (test-helpers/create-user! {:eppn "jillsmith" :name "Jill Smith" :email "jill.smith@example.com" :mappings {"identity1" "jillsmith" "identity2" "smith"}})]
+  (let [_ (test-helpers/create-user! {:userid "duplicated" :name "Dupli Cated" :email "duplicated@example.com" :mappings {"identity1" "dupe" "identity2" "dupe"}})
+        _ (test-helpers/create-user! {:userid "johnsmith" :name "John Smith" :email "john.smith@example.com" :mappings {"identity1" "johnsmith" "identity2" "smith"}})
+        _ (test-helpers/create-user! {:userid "jillsmith" :name "Jill Smith" :email "jill.smith@example.com" :mappings {"identity1" "jillsmith" "identity2" "smith"}})]
 
     (testing "duplicate mappings but only for one userid"
       (is (api-call :get "/api/my-applications" nil "42" "dupe")))
@@ -1972,8 +1972,8 @@
         reviewer "reviewer"
         decider "decider"
         app-id (test-helpers/create-application! {:actor applicant})]
-    (test-helpers/create-user! {:eppn reviewer})
-    (test-helpers/create-user! {:eppn decider})
+    (test-helpers/create-user! {:userid reviewer})
+    (test-helpers/create-user! {:userid decider})
 
     (testing "does not list drafts"
       (is (not (contains? (get-ids (get-todos handler))

--- a/test/clj/rems/api/test_audit_log.clj
+++ b/test/clj/rems/api/test_audit_log.clj
@@ -11,16 +11,16 @@
 
 (deftest test-audit-log
   (api-key/add-api-key! "42" {})
-  (test-helpers/create-user! {:eppn "alice"})
-  (test-helpers/create-user! {:eppn "malice"})
-  (test-helpers/create-user! {:eppn "owner"} :owner)
-  (test-helpers/create-user! {:eppn "reporter"} :reporter)
+  (test-helpers/create-user! {:userid "alice"})
+  (test-helpers/create-user! {:userid "malice"})
+  (test-helpers/create-user! {:userid "owner"} :owner)
+  (test-helpers/create-user! {:userid "reporter"} :reporter)
   (let [time-a (atom nil)
         app-id (test-helpers/create-application! {:actor "alice"})]
 
-    (test-helpers/command! {:type           :application.command/submit
+    (test-helpers/command! {:type :application.command/submit
                             :application-id app-id
-                            :actor          "alice"})
+                            :actor "alice"})
 
     (testing "populate log"
       (testing "> unknown endpoint"

--- a/test/clj/rems/api/test_blacklist.clj
+++ b/test/clj/rems/api/test_blacklist.clj
@@ -50,11 +50,11 @@
 
 (deftest test-blacklist
   (api-key/add-api-key! "42")
-  (test-helpers/create-user! {:eppn +command-user+ :commonName "Owner" :mail "owner@example.com"} :owner)
-  (test-helpers/create-user! {:eppn +fetch-user+} :reporter)
-  (test-helpers/create-user! {:eppn "user1" :email "" :mappings {"alt-id" "user1-alt-id"}})
-  (test-helpers/create-user! {:eppn "user2" :email ""})
-  (test-helpers/create-user! {:eppn "user3" :email ""})
+  (test-helpers/create-user! {:userid +command-user+ :name "Owner" :email "owner@example.com"} :owner)
+  (test-helpers/create-user! {:userid +fetch-user+} :reporter)
+  (test-helpers/create-user! {:userid "user1" :mappings {"alt-id" "user1-alt-id"}})
+  (test-helpers/create-user! {:userid "user2"})
+  (test-helpers/create-user! {:userid "user3"})
   (let [_ (test-helpers/create-resource! {:resource-ext-id "A"})
         res-id-2 (test-helpers/create-resource! {:resource-ext-id "B"})
         _ (test-helpers/create-resource! {:resource-ext-id "C"})

--- a/test/clj/rems/api/test_catalogue_items.clj
+++ b/test/clj/rems/api/test_catalogue_items.clj
@@ -97,7 +97,7 @@
 (deftest catalogue-items-edit-test
   (let [owner "owner"
         user "alice"
-        _ (test-helpers/create-user! {:eppn "alice"})
+        _ (test-helpers/create-user! {:userid "alice"})
         changed-organization1 (test-helpers/create-organization! {:organization/id "changed-organization1" :organization/owners [{:userid "organization-owner1"}]})
         changed-organization2 (test-helpers/create-organization! {:organization/id "changed-organization2" :organization/owners [{:userid "organization-owner1"}]})
         form-id (test-helpers/create-form! {:organization {:organization/id "organization1"}})

--- a/test/clj/rems/api/test_end_to_end.clj
+++ b/test/clj/rems/api/test_end_to_end.clj
@@ -59,7 +59,7 @@
                                     :ssn "012345-0123"}]
 
           (testing "create owner & api key"
-            (test-helpers/create-user! {:eppn owner-id} :owner)
+            (test-helpers/create-user! {:userid owner-id} :owner)
             (api-key/add-api-key! api-key))
 
           (testing "create organization"
@@ -394,7 +394,7 @@
                              :name "rejecter"}]
 
     (testing "create owner & api key"
-      (test-helpers/create-user! {:eppn owner-id} :owner)
+      (test-helpers/create-user! {:userid owner-id} :owner)
       (api-key/add-api-key! api-key))
 
     (testing "create users"
@@ -517,7 +517,7 @@
                              :name "rejecter"}]
 
     (testing "create owner & api key"
-      (test-helpers/create-user! {:eppn owner-id} :owner)
+      (test-helpers/create-user! {:userid owner-id} :owner)
       (api-key/add-api-key! api-key))
 
     (testing "create users"
@@ -659,7 +659,7 @@
                         :name "bona fide bot"}]
 
     (testing "create owner & api key"
-      (test-helpers/create-user! {:eppn owner-id} :owner)
+      (test-helpers/create-user! {:userid owner-id} :owner)
       (api-key/add-api-key! api-key))
 
     (testing "create users"

--- a/test/clj/rems/api/test_entitlements.clj
+++ b/test/clj/rems/api/test_entitlements.clj
@@ -3,7 +3,6 @@
             [clojure.test :refer :all]
             [rems.api.testing :refer :all]
             [rems.db.api-key :as api-key]
-            [rems.db.core :as db]
             [rems.db.roles :as roles]
             [rems.db.test-data-helpers :as test-helpers]
             [rems.db.users :as users]

--- a/test/clj/rems/api/test_forms.clj
+++ b/test/clj/rems/api/test_forms.clj
@@ -751,7 +751,7 @@
                          handler)]
         (is (response-is-unauthorized? response))
         (is (= "Invalid anti-forgery token" (read-body response))))))
-  (test-helpers/create-user! {:eppn "alice"})
+  (test-helpers/create-user! {:userid "alice"})
   (testing "without owner role"
     (testing "list"
       (let [response (-> (request :get (str "/api/forms"))

--- a/test/clj/rems/api/test_invitations.clj
+++ b/test/clj/rems/api/test_invitations.clj
@@ -59,7 +59,7 @@
             (is (= {:success true
                     :invitation/workflow {:workflow/id workflow-id}}
                    (api-call :post "/api/invitations/accept-invitation" {:token token} test-data/+test-api-key+ "katherine"))))
-          (test-helpers/create-user! {:eppn "katherine" :mail "katherine.johnson@nasa.gov" :commonName "Katherine Johnson"})
+          (test-helpers/create-user! {:userid "katherine" :email "katherine.johnson@nasa.gov" :name "Katherine Johnson"})
 
           (let [accepted-invitation (first (api-call :get "/api/invitations" nil test-data/+test-api-key+ "owner"))]
             (is (= {:invitation/name "Katherine Johnson"
@@ -83,7 +83,7 @@
              :organization/owners [{:userid "organization-owner2"}]
              :organization/review-emails []}
             "42" "owner")
-  (test-helpers/create-user! {:eppn "katherine" :mail "katherine.johnson@nasa.gov" :commonName "Katherine Johnson"})
+  (test-helpers/create-user! {:userid "katherine" :email "katherine.johnson@nasa.gov" :name "Katherine Johnson"})
   (let [workflow-id (test-helpers/create-workflow! {:organization {:organization/id "test-organization"}})
         invitation-id (:invitation/id (with-user "owner"
                                         (invitation/create-invitation! {:userid "owner"

--- a/test/clj/rems/api/test_organizations.clj
+++ b/test/clj/rems/api/test_organizations.clj
@@ -23,10 +23,10 @@
                                         nil
                                         api-key userid))]
     (api-key/add-api-key! api-key)
-    (test-helpers/create-user! {:eppn user})
-    (test-helpers/create-user! {:eppn owner :commonName "Owner" :mail "owner@example.com"} :owner)
-    (test-helpers/create-user! {:eppn org-owner1 :commonName "Organization Owner 1" :mail "organization-owner1@example.com"})
-    (test-helpers/create-user! {:eppn org-owner2 :commonName "Organization Owner 2" :mail "organization-owner2@example.com"})
+    (test-helpers/create-user! {:userid user})
+    (test-helpers/create-user! {:userid owner :name "Owner" :email "owner@example.com"} :owner)
+    (test-helpers/create-user! {:userid org-owner1 :name "Organization Owner 1" :email "organization-owner1@example.com"})
+    (test-helpers/create-user! {:userid org-owner2 :name "Organization Owner 2" :email "organization-owner2@example.com"})
 
     (testing "fetch nonexistent"
       (let [resp (api-response :get "/api/organizations/9999999999999999"
@@ -162,7 +162,7 @@
 
 (deftest organization-api-status-test
   (api-key/add-api-key! "42")
-  (test-helpers/create-user! {:eppn "owner" :commonName "Owner" :mail "owner@example.com"} :owner)
+  (test-helpers/create-user! {:userid "owner" :name "Owner" :email "owner@example.com"} :owner)
   (api-call :post "/api/organizations/create"
             {:organization/id "organizations-api-test-org"
              :organization/name {:fi "Organisaatiot API Test ORG"
@@ -199,8 +199,8 @@
 
 (deftest organizations-api-security-test
   (api-key/add-api-key! "42")
-  (test-helpers/create-user! {:eppn "alice"})
-  (test-helpers/create-user! {:eppn "owner"} :owner)
+  (test-helpers/create-user! {:userid "alice"})
+  (test-helpers/create-user! {:userid "owner"} :owner)
   (testing "without authentication"
     (testing "list"
       (let [response (api-response :get "/api/organizations")]
@@ -299,8 +299,8 @@
         owner "owner"
         org-owner1 "organization-owner1"]
     (api-key/add-api-key! api-key)
-    (test-helpers/create-user! {:eppn owner} :owner)
-    (test-helpers/create-user! {:eppn org-owner1})
+    (test-helpers/create-user! {:userid owner} :owner)
+    (test-helpers/create-user! {:userid org-owner1})
     (testing "trying to create a duplicate fails" ; separate test because it will leave the transaction in an errored state
       (let [_response1 (api-call :post "/api/organizations/create"
                                  {:organization/id "duplicate-organizations-api-test-org"

--- a/test/clj/rems/api/test_over_http.clj
+++ b/test/clj/rems/api/test_over_http.clj
@@ -15,9 +15,9 @@
 
 (defn- create-test-data []
   (api-key/add-api-key! 42 {:comment "test data"})
-  (test-helpers/create-user! {:eppn "handler"})
-  (test-helpers/create-user! {:eppn "applicant"})
-  (test-helpers/create-user! {:eppn "developer"})
+  (test-helpers/create-user! {:userid "handler"})
+  (test-helpers/create-user! {:userid "applicant"})
+  (test-helpers/create-user! {:userid "developer"})
   (let [wfid (test-helpers/create-workflow! {:handlers ["handler"]})
         form (test-helpers/create-form! nil)
         res-id1 (test-helpers/create-resource! nil)

--- a/test/clj/rems/api/test_pdf.clj
+++ b/test/clj/rems/api/test_pdf.clj
@@ -18,9 +18,9 @@
 
 (defn- create-test-data []
   (api-key/add-api-key! 42 {:comment "test data"})
-  (test-helpers/create-user! {:eppn "handler"})
-  (test-helpers/create-user! {:eppn "reporter"})
-  (test-helpers/create-user! {:eppn "applicant"})
+  (test-helpers/create-user! {:userid "handler"})
+  (test-helpers/create-user! {:userid "reporter"})
+  (test-helpers/create-user! {:userid "applicant"})
   (let [wfid (test-helpers/create-workflow! {:handlers ["handler"]})
         form (test-helpers/create-form! nil)
         res-id1 (test-helpers/create-resource! nil)

--- a/test/clj/rems/api/test_resources.clj
+++ b/test/clj/rems/api/test_resources.clj
@@ -317,7 +317,7 @@
           (is (response-is-unauthorized? response))
           (is (= "Invalid anti-forgery token" (read-body response)))))))
 
-  (test-helpers/create-user! {:eppn "alice"})
+  (test-helpers/create-user! {:userid "alice"})
   (testing "without owner role"
     (let [user-id "alice"]
       (testing "list"

--- a/test/clj/rems/api/test_user_settings.clj
+++ b/test/clj/rems/api/test_user_settings.clj
@@ -21,7 +21,7 @@
 (deftest user-settings-api-test
   (test-data/create-test-api-key!)
   (let [user-id (str (UUID/randomUUID))]
-    (test-helpers/create-user! {:eppn user-id})
+    (test-helpers/create-user! {:userid user-id})
 
     (testing "default user settings without authentification"
       (is (= {:status 401
@@ -78,7 +78,7 @@
 (deftest test-generate-api-key
   (test-data/create-test-api-key!)
   (let [user-id (str (UUID/randomUUID))]
-    (test-helpers/create-user! {:eppn user-id :commonName "Test User" :mail "test.user@example.com"})
+    (test-helpers/create-user! {:userid user-id :name "Test User" :email "test.user@example.com"})
 
     (testing "without authentication"
       (let [{:keys [body] :as response} (-> (request :post "/api/user-settings/generate-ega-api-key")
@@ -134,8 +134,8 @@
   (test-data/create-test-api-key!)
   (let [user-id (str (UUID/randomUUID))
         handler-id (str (UUID/randomUUID))]
-    (test-helpers/create-user! {:eppn user-id :commonName "Test User" :mail "test.user@example.com"})
-    (test-helpers/create-user! {:eppn handler-id :commonName "Handler" :mail "handler@example.com"})
+    (test-helpers/create-user! {:userid user-id :name "Test User" :email "test.user@example.com"})
+    (test-helpers/create-user! {:userid handler-id :name "Handler" :email "handler@example.com"})
     (test-helpers/create-workflow! {:handlers [handler-id]})
 
     (testing "setup api-key to delete"

--- a/test/clj/rems/api/test_users.clj
+++ b/test/clj/rems/api/test_users.clj
@@ -142,7 +142,7 @@
                            +test-api-key+ "owner")))
           (is (= {:userid "alice" :name "Alice Applicant" :email "alice@example.com" :nickname "In Wonderland"}
                  (users/get-user "alice")
-                 (users/format-user (:identity (middleware/get-session cookie)))))
+                 (:identity (middleware/get-session cookie))))
           (is (= #{{:userid "alice" :name "Alice Applicant" :email "alice@example.com" :nickname "In Wonderland"}}
                  (set (api-call :get "/api/users/active" nil
                                 +test-api-key+ "owner")))
@@ -158,7 +158,7 @@
                  (user-mappings/get-user-mappings {:ext-id-attribute "elixirId" :ext-id-value "elixir-alice"})))
           (is (= {:userid "alice" :name "Elixir Alice" :email "alice@elixir-europe.org"}
                  (users/get-user "alice")
-                 (users/format-user (:identity (middleware/get-session cookie))))
+                 (:identity (middleware/get-session cookie)))
               "Attributes should be updated when logging in")
           (is (= #{{:userid "alice" :name "Alice Applicant" :email "alice@example.com" :nickname "In Wonderland"}
                    {:userid "alice" :name "Elixir Alice" :email "alice@elixir-europe.org"}}
@@ -250,14 +250,14 @@
           (assert-can-make-a-request! cookie)
           (is (= {:userid "alice" :name "Alice Applicant" :email "alice@example.com" :nickname "In Wonderland"}
                  (users/get-user "alice")
-                 (users/format-user (:identity (middleware/get-session cookie)))))))
+                 (:identity (middleware/get-session cookie))))))
 
       (testing "log in bob"
         (let [cookie (login-with-cookies "bob")]
           (assert-can-make-a-request! cookie)
           (is (= {:userid "bob" :name "Bob Applicant" :email "bob@example.com"}
                  (users/get-user "bob")
-                 (users/format-user (:identity (middleware/get-session cookie)))))))
+                 (:identity (middleware/get-session cookie))))))
 
       (testing "log in malice"
         (is (thrown? AssertionError (login-with-cookies "malice"))
@@ -273,14 +273,14 @@
           (assert-can-make-a-request! cookie)
           (is (= {:userid "alice" :name "Alice Applicant" :email "alice@example.com" :nickname "In Wonderland"}
                  (users/get-user "alice")
-                 (users/format-user (:identity (middleware/get-session cookie)))))))
+                 (:identity (middleware/get-session cookie))))))
 
       (testing "log in bob"
         (let [cookie (login-with-cookies "bob")]
           (assert-can-make-a-request! cookie)
           (is (= {:userid "bob" :name "Bob Applicant" :email "bob@example.com"}
                  (users/get-user "bob")
-                 (users/format-user (:identity (middleware/get-session cookie)))))))
+                 (:identity (middleware/get-session cookie))))))
 
       (testing "log in malice"
         (is (thrown? AssertionError (login-with-cookies "malice"))

--- a/test/clj/rems/api/test_util.clj
+++ b/test/clj/rems/api/test_util.clj
@@ -27,7 +27,7 @@
 
       (testing "and user has it"
         (binding [context/*roles* #{:role1}
-                  context/*user* {:eppn "user1"}]
+                  context/*user* {:userid "user1"}]
           (is (= {:status 200
                   :headers {}
                   :body {:success true}}
@@ -36,7 +36,7 @@
 
       (testing "but user doesn't have it"
         (binding [context/*roles* #{}
-                  context/*user* {:eppn "user1"}]
+                  context/*user* {:userid "user1"}]
           (is (thrown? ForbiddenException
                        (route {:request-method :get
                                :uri "/foo"})))))
@@ -64,14 +64,14 @@
       (is (= "Summary text (roles: role1)"
              (get-in route [:info :public :summary])))
       (binding [context/*roles* #{:role1}
-                context/*user* {:eppn "user1"}]
+                context/*user* {:userid "user1"}]
         (is (= {:status 200
                 :headers {}
                 :body {:success true}}
                (route {:request-method :get
                        :uri "/foo"}))))
       (binding [context/*roles* #{}
-                context/*user* {:eppn "user1"}]
+                context/*user* {:userid "user1"}]
         (is (thrown? ForbiddenException
                      (route {:request-method :get
                              :uri "/foo"}))))))

--- a/test/clj/rems/api/test_workflows.clj
+++ b/test/clj/rems/api/test_workflows.clj
@@ -187,7 +187,7 @@
 
 (deftest workflows-edit-test
   (create-handlers!)
-  (test-helpers/create-user! {:eppn "tester"})
+  (test-helpers/create-user! {:userid "tester"})
   (let [user-id "owner"
         wfid (test-helpers/create-workflow! {:organization {:organization/id "organization1"}
                                              :title "workflow title"

--- a/test/clj/rems/application/test_rejecter_bot.clj
+++ b/test/clj/rems/application/test_rejecter_bot.clj
@@ -16,13 +16,13 @@
 
 (deftest test-run-rejecter-bot
   (binding [command/*fail-on-process-manager-errors* true]
-    (test-helpers/create-user! {:eppn rejecter-bot/bot-userid})
-    (test-helpers/create-user! {:eppn "handler"})
-    (test-helpers/create-user! {:eppn "user1"})
-    (test-helpers/create-user! {:eppn "user2"})
-    (test-helpers/create-user! {:eppn "baddie"})
-    (test-helpers/create-user! {:eppn "accomplice"})
-    (test-helpers/create-user! {:eppn "innocent"})
+    (test-helpers/create-user! {:userid rejecter-bot/bot-userid})
+    (test-helpers/create-user! {:userid "handler"})
+    (test-helpers/create-user! {:userid "user1"})
+    (test-helpers/create-user! {:userid "user2"})
+    (test-helpers/create-user! {:userid "baddie"})
+    (test-helpers/create-user! {:userid "accomplice"})
+    (test-helpers/create-user! {:userid "innocent"})
     (let [res1 (test-helpers/create-resource! {:resource-ext-id "res1"})
           res2 (test-helpers/create-resource! {:resource-ext-id "res2"})
           wf (test-helpers/create-workflow! {:type :workflow/default

--- a/test/clj/rems/auth/test_oidc.clj
+++ b/test/clj/rems/auth/test_oidc.clj
@@ -63,7 +63,7 @@
                 :body ""
                 :session
                 {:access-token "special.access-token"
-                 :identity {:eppn "does-not-exist" :commonName "Does Not Exist" :mail "does-not-exist@example.com"}}}
+                 :identity {:userid "does-not-exist" :name "Does Not Exist" :email "does-not-exist@example.com"}}}
                response)
             "created and allowed in")))))
 
@@ -75,9 +75,9 @@
         (catch clojure.lang.ExceptionInfo e
           (is (= {:key :t.login.errors/invalid-user
                   :args [:t.login.errors/name :t.login.errors/email]
-                  :user {:eppn "has-no-details"
-                         :commonName nil
-                         :mail nil}}
+                  :user {:userid "has-no-details"
+                         :name nil
+                         :email nil}}
                  (ex-data e))))))))
 
 (deftest test-no-code

--- a/test/clj/rems/browser_test_util.clj
+++ b/test/clj/rems/browser_test_util.clj
@@ -174,7 +174,7 @@
   (test-helpers/create-user! (get test-users/+fake-user-data+ "carl"))
   (test-helpers/create-user! (get test-users/+fake-user-data+ "handler"))
   (test-helpers/create-user! (get test-users/+fake-user-data+ "reporter") :reporter)
-  (test-helpers/create-user! {:eppn "applicant" :organizations [{:organization/id "default"}]})
+  (test-helpers/create-user! {:userid "applicant" :organizations [{:organization/id "default"}]})
   (test-helpers/create-user! (get test-users/+fake-user-data+ "alice"))
   (test-helpers/create-user! (get test-users/+fake-user-data+ "developer"))
   (test-helpers/create-workflow! nil) ;;master workflow

--- a/test/clj/rems/db/test_applications.clj
+++ b/test/clj/rems/db/test_applications.clj
@@ -82,7 +82,7 @@
     (is (= "1981/4" (application-external-id! (DateTime. #inst "1981-04-01"))))))
 
 (deftest test-delete-application-and-reload-cache!!
-  (test-helpers/create-user! {:eppn "applicant"})
+  (test-helpers/create-user! {:userid "applicant"})
   (let [app-id (test-helpers/create-application! {:actor "applicant"})]
     (is (applications/get-application app-id))
     (applications/delete-application-and-reload-cache! app-id)

--- a/test/clj/rems/db/test_blacklist.clj
+++ b/test/clj/rems/db/test_blacklist.clj
@@ -11,9 +11,9 @@
   rollback-db-fixture)
 
 (deftest test-blacklist-event-storage
-  (test-helpers/create-user! {:eppn "user1"})
-  (test-helpers/create-user! {:eppn "user2"})
-  (test-helpers/create-user! {:eppn "handler"})
+  (test-helpers/create-user! {:userid "user1"})
+  (test-helpers/create-user! {:userid "user2"})
+  (test-helpers/create-user! {:userid "handler"})
   (test-helpers/create-resource! {:resource-ext-id "urn.fi/123"})
   (test-helpers/create-resource! {:resource-ext-id "urn.fi/124"})
 
@@ -78,7 +78,7 @@
                  :event/time (time/now)
                  :resource/ext-id resource-ext-id
                  :userid user-id}]
-    (test-helpers/create-user! {:eppn user-id})
+    (test-helpers/create-user! {:userid user-id})
     (test-helpers/create-resource! {:resource-ext-id resource-ext-id})
 
     (testing "user and resource both exist"

--- a/test/clj/rems/db/test_csv.clj
+++ b/test/clj/rems/db/test_csv.clj
@@ -78,7 +78,7 @@
 ;; TODO: This could be non-integration non-db test if the application was
 ;;       created from events.
 (deftest test-applications-to-csv
-  (test-helpers/create-user! {:eppn applicant :commonName "Alice Applicant" :mail "alice@applicant.com"})
+  (test-helpers/create-user! {:userid applicant :name "Alice Applicant" :email "alice@applicant.com"})
   (let [form-id (test-helpers/create-form!
                  {:form/fields [{:field/title {:en "Application title"
                                                :fi "Hakemuksen otsikko"

--- a/test/clj/rems/db/test_entitlements.clj
+++ b/test/clj/rems/db/test_entitlements.clj
@@ -110,9 +110,9 @@
                                                              :license-ids [lic-id1]})
                 :form-id form-id
                 :workflow-id wfid})]
-    (test-helpers/create-user! {:eppn applicant :mail "b@o.b" :commonName "Bob"})
-    (test-helpers/create-user! {:eppn member :mail "e.l@s.a" :commonName "Elsa"})
-    (test-helpers/create-user! {:eppn admin :mail "o.w@n.er" :commonName "Owner"})
+    (test-helpers/create-user! {:userid applicant :email "b@o.b" :name "Bob"})
+    (test-helpers/create-user! {:userid member :email "e.l@s.a" :name "Elsa"})
+    (test-helpers/create-user! {:userid admin :email "o.w@n.er" :name "Owner"})
 
     (entitlements/process-outbox!) ;; empty outbox from pending posts
 

--- a/test/clj/rems/db/test_users.clj
+++ b/test/clj/rems/db/test_users.clj
@@ -10,13 +10,13 @@
 (use-fixtures :each rollback-db-fixture)
 
 (deftest test-users
-  ;; TODO: enforce that userid and eppn must be same?
-  (users/add-user-raw! "user1" {:eppn "whatever"
-                                :commonName "What Ever"
+  ;; TODO: enforce that userid must be same?
+  (users/add-user-raw! "user1" {:userid "whatever"
+                                :name "What Ever"
                                 :some-attr "some value"})
-  (users/add-user-raw! "user-with-org" {:eppn "user-with-org"
-                                        :commonName "User Org"
-                                        :mail "user@org"
+  (users/add-user-raw! "user-with-org" {:userid "user-with-org"
+                                        :name "User Org"
+                                        :email "user@org"
                                         ;;:notification-email "user@alt"
                                         :organizations [{:organization/id "org"}]})
 
@@ -44,13 +44,13 @@
         "default is returned for notification-email"))
 
   (testing "get-raw-user-attributes"
-    (is (= {:eppn "whatever"
-            :commonName "What Ever"
+    (is (= {:userid "whatever"
+            :name "What Ever"
             :some-attr "some value"}
            (#'users/get-raw-user-attributes "user1")))
-    (is (= {:eppn "user-with-org"
-            :commonName "User Org"
-            :mail "user@org"
+    (is (= {:userid "user-with-org"
+            :name "User Org"
+            :email "user@org"
             :organizations [{:organization/id "org"}]}
            (#'users/get-raw-user-attributes "user-with-org"))))
 
@@ -88,8 +88,8 @@
               :organizations [#:organization{:id "org"}]}} (set (users/get-deciders)))))
 
   (testing "update user with add-user-raw!"
-    (users/add-user-raw! "user1" {:eppn "user1"
-                                  :commonName "new name"})
+    (users/add-user-raw! "user1" {:userid "user1"
+                                  :name "new name"})
     (is (= {:userid "user1"
             :name "new name"
             :email nil}

--- a/test/clj/rems/db/test_workflow.clj
+++ b/test/clj/rems/db/test_workflow.clj
@@ -11,7 +11,7 @@
   (is (= nil (workflow/get-all-workflow-roles "anyone")))
 
   (testing "handler role"
-    (test-helpers/create-user! {:eppn "handler-user"})
+    (test-helpers/create-user! {:userid "handler-user"})
     (test-helpers/create-workflow! {:handlers ["handler-user"]})
     (is (= #{:handler} (workflow/get-all-workflow-roles "handler-user")))))
 

--- a/test/clj/rems/test_browser.clj
+++ b/test/clj/rems/test_browser.clj
@@ -631,9 +631,9 @@
     (test-helpers/command! {:type :application.command/submit
                             :application-id (btu/context-getx :application-id)
                             :actor "alice"})
-    (test-helpers/create-user! {:eppn "ionna" :commonName "Ionna Insprucker" :mail "ionna@ins.mail"})
-    (test-helpers/create-user! {:eppn "jade" :commonName "Jade Jenner" :mail "jade80@mail.name"})
-    (test-helpers/create-user! {:eppn "kayla" :commonName "Kayla Kale" :mail "kale@is.good"})
+    (test-helpers/create-user! {:userid "ionna" :name "Ionna Insprucker" :email "ionna@ins.mail"})
+    (test-helpers/create-user! {:userid "jade" :name "Jade Jenner" :email "jade80@mail.name"})
+    (test-helpers/create-user! {:userid "kayla" :name "Kayla Kale" :email "kale@is.good"})
     (test-helpers/command! {:type :application.command/add-member
                             :application-id (btu/context-getx :application-id)
                             :member {:userid "ionna"}
@@ -696,7 +696,7 @@
                             :actor "alice"})
 
     (testing "disabling the 2nd item"
-      (binding [context/*user* {:eppn "owner"}
+      (binding [context/*user* {:userid "owner"}
                 context/*roles* #{:owner}]
         (catalogue/set-catalogue-item-enabled! {:id (btu/context-getx :catalogue-id2) :enabled false}))))
 
@@ -786,7 +786,7 @@
                                                                     [(btu/context-getx :catalogue-id)]
                                                                     "test-invite-decider"))
     (test-helpers/submit-application (btu/context-getx :application-id) "alice")
-    (test-helpers/create-user! {:eppn "new-decider" :commonName "New Decider" :mail "new-decider@example.com"}))
+    (test-helpers/create-user! {:userid "new-decider" :name "New Decider" :email "new-decider@example.com"}))
   (btu/with-postmortem
     (testing "handler invites decider"
       (login-as "developer")
@@ -859,7 +859,7 @@
     (btu/context-assoc! :workflow-id (test-helpers/create-workflow! {:title (btu/context-getx :workflow-title) :handlers []}))
     (btu/context-assoc! :catalogue-id (test-helpers/create-catalogue-item! {:form-id (btu/context-getx :form-id)
                                                                             :workflow-id (btu/context-getx :workflow-id)}))
-    (test-helpers/create-user! {:eppn "invited-person-id" :commonName "Invited Person Name" :mail "invited-person-id@example.com"})
+    (test-helpers/create-user! {:userid "invited-person-id" :name "Invited Person Name" :email "invited-person-id@example.com"})
     (with-user "owner"
       (btu/context-assoc! :invitation-id (getx (invitations/create-invitation! {:userid "owner"
                                                                                 :name "Dorothy Vaughan"
@@ -2364,14 +2364,14 @@
                     str/split-lines)))))))
 
 (deftest test-organizations
-  (test-helpers/create-user! {:eppn "organization-owner1"
-                              :commonName "Organization Owner 1"
-                              :mail "organization-owner1@example.com"
+  (test-helpers/create-user! {:userid "organization-owner1"
+                              :name "Organization Owner 1"
+                              :email "organization-owner1@example.com"
                               :organizations [{:organization/id "Default"}]}
                              :owner)
-  (test-helpers/create-user! {:eppn "organization-owner2"
-                              :commonName "Organization Owner 2"
-                              :mail "organization-owner2@example.com"
+  (test-helpers/create-user! {:userid "organization-owner2"
+                              :name "Organization Owner 2"
+                              :email "organization-owner2@example.com"
                               :organizations [{:organization/id "Default"}]}
                              :owner)
 
@@ -2683,7 +2683,7 @@
                       (slurp-rows :catalogue-tree)))
           "can't see root category either because it's empty")
 
-      (binding [context/*user* {:eppn "owner"}
+      (binding [context/*user* {:userid "owner"}
                 context/*roles* #{:owner}]
         (catalogue/set-catalogue-item-enabled! {:id (btu/context-getx :catalogue-id) :enabled true}))
 

--- a/test/clj/rems/test_db.clj
+++ b/test/clj/rems/test_db.clj
@@ -32,8 +32,8 @@
           "should find same catalogue item by id"))))
 
 (deftest test-multi-applications
-  (test-helpers/create-user! {:eppn "test-user" :mail "test-user@test.com" :commonName "Test-user"})
-  (test-helpers/create-user! {:eppn "handler" :mail "handler@test.com" :commonName "Handler"})
+  (test-helpers/create-user! {:userid "test-user" :email "test-user@test.com" :name "Test-user"})
+  (test-helpers/create-user! {:userid "handler" :email "handler@test.com" :name "Handler"})
   (let [applicant "test-user"
         wfid (test-helpers/create-workflow! {:handlers ["handler"]})
         res1 (test-helpers/create-resource! {:resource-ext-id "resid111"})
@@ -66,9 +66,9 @@
   (is (thrown? RuntimeException (roles/add-role! "pekka" :unknown-role))))
 
 (deftest test-get-entitlements-for-export
-  (test-helpers/create-user! {:eppn "handler" :mail "handler@test.com" :commonName "Handler"})
-  (test-helpers/create-user! {:eppn "jack" :mail "jack@test.com" :commonName "Jack"})
-  (test-helpers/create-user! {:eppn "jill" :mail "jill@test.com" :commonName "Jill"})
+  (test-helpers/create-user! {:userid "handler" :email "handler@test.com" :name "Handler"})
+  (test-helpers/create-user! {:userid "jack" :email "jack@test.com" :name "Jack"})
+  (test-helpers/create-user! {:userid "jill" :email "jill@test.com" :name "Jill"})
   (let [wf (test-helpers/create-workflow! {:handlers ["handler"]})
         form-id (test-helpers/create-form! {})
         res1 (test-helpers/create-resource! {:resource-ext-id "resource1"})

--- a/test/clj/rems/test_pdf.clj
+++ b/test/clj/rems/test_pdf.clj
@@ -41,9 +41,9 @@
     (is (some? (with-language :en #(pdf/application-to-pdf-bytes data))))))
 
 (deftest test-pdf-private-form-fields
-  (test-helpers/create-user! {:eppn "alice" :commonName "Alice Applicant" :mail "alice@example.com"})
-  (test-helpers/create-user! {:eppn "carl" :commonName "Carl Reviewer" :mail "carl@example.com"})
-  (test-helpers/create-user! {:eppn "david" :commonName "David Decider" :mail "david@example.com"})
+  (test-helpers/create-user! {:userid "alice" :name "Alice Applicant" :email "alice@example.com"})
+  (test-helpers/create-user! {:userid "carl" :name "Carl Reviewer" :email "carl@example.com"})
+  (test-helpers/create-user! {:userid "david" :name "David Decider" :email "david@example.com"})
   (let [resource (test-helpers/create-resource! {:resource-ext-id "pdf-resource-ext"})
         resource-2 (test-helpers/create-resource! {:resource-ext-id "pdf-resource-2-ext"})
         wfid (test-helpers/create-workflow! {})
@@ -242,9 +242,9 @@
                      (#'pdf/render-application (applications/get-application-for-user "carl" application-id)))))))))))
 
 (deftest test-pdf-gold-standard
-  (test-helpers/create-user! {:eppn "alice" :commonName "Alice Applicant" :mail "alice@example.com"})
-  (test-helpers/create-user! {:eppn "beth" :commonName "Beth Applicant" :mail "beth@example.com"})
-  (test-helpers/create-user! {:eppn "david" :commonName "David Decider" :mail "david@example.com"})
+  (test-helpers/create-user! {:userid "alice" :name "Alice Applicant" :email "alice@example.com"})
+  (test-helpers/create-user! {:userid "beth" :name "Beth Applicant" :email "beth@example.com"})
+  (test-helpers/create-user! {:userid "david" :name "David Decider" :email "david@example.com"})
   (let [lic1 (test-helpers/create-license! {:license/type :link
                                             :license/title {:en "Google license"
                                                             :fi "Google-lisenssi"}

--- a/test/clj/rems/test_redirects.clj
+++ b/test/clj/rems/test_redirects.clj
@@ -91,7 +91,7 @@
 
 (deftest test-attachment-download
   (api-key/add-api-key! "42" {})
-  (test-helpers/create-user! {:eppn "alice"})
+  (test-helpers/create-user! {:userid "alice"})
   (with-redefs [attachment/get-application-attachment (fn [& args]
                                                         (is (= ["alice" 123] args))
                                                         dummy-attachment)]
@@ -119,7 +119,7 @@
 
 (deftest test-license-attachment-download
   (api-key/add-api-key! "42" {})
-  (test-helpers/create-user! {:eppn "alice"})
+  (test-helpers/create-user! {:userid "alice"})
   (with-redefs [licenses/get-application-license-attachment (fn [& args]
                                                               (is (= ["alice" 1023 3 :en] args))
                                                               dummy-attachment)]


### PR DESCRIPTION
Closes #2377 

Changes are:
- `eppn -> userid`
- `commonName -> name`
- `displayName -> name`
- `mail -> email`
- `:mail` will still be used in entitlements
- migration for user attributes
- documented leftover about theoretically unnecessary
  - `format-user`
  - `unformat-user`

# Checklist for author

Remove items that aren't applicable, check items that are done.

## Reviewability
- [x] Link to issue

## Backwards compatibility
- [x] Migrations exist

## Documentation
- [x] Update changelog if necessary

## Testing
- [x] Complex logic is unit tested
- [x] Valuable features are integration / browser / acceptance tested automatically

## Follow-up
- [x] New tasks are created for pending or remaining tasks (commented in code)
