### PR TITLE
feat: empty accepted licenses after resources changed event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ NB: The login has changed to allow more configurable user identity and other att
 - Improve the accessibility of the small navbar. (#2907)
 - Load config overrides from system properties and env (#2917)
 - Application draft can now be saved even if there are validation warnings. (#2766)
+- Application accepted licenses are now emptied after changing resources. (#1373)
 
 ## v2.25 "Meripuistotie" 2022-02-15
 

--- a/src/clj/rems/application/model.clj
+++ b/src/clj/rems/application/model.clj
@@ -2,7 +2,7 @@
   (:require [clojure.set :as set]
             [clojure.test :refer [deftest is testing]]
             [com.rpl.specter :refer [ALL select transform]]
-            [medley.core :refer [find-first map-vals update-existing update-existing-in]]
+            [medley.core :refer [assoc-some find-first map-vals update-existing update-existing-in]]
             [rems.application.events :as events]
             [rems.application.master-workflow :as master-workflow]
             [rems.common.application-util :as application-util]
@@ -222,7 +222,8 @@
       (assoc :application/forms (vec (:application/forms event)))
       (assoc :application/resources (vec (:application/resources event)))
       (assoc :application/licenses (map #(select-keys % [:license/id])
-                                        (:application/licenses event)))))
+                                        (:application/licenses event)))
+      (assoc-some :application/accepted-licenses {})))
 
 (defmethod application-base-view :application.event/closed
   [application _event]

--- a/test/clj/rems/api/test_applications.clj
+++ b/test/clj/rems/api/test_applications.clj
@@ -335,9 +335,19 @@
                                             :catalogue-item-ids [cat-item-id2]}))))
 
     (testing "submitting again"
-      (is (= {:success true} (send-command user-id
-                                           {:type :application.command/submit
-                                            :application-id application-id}))))
+      (testing "fails because licenses are not accepted due to changing resources"
+        (is (= {:errors [{:type "t.actions.errors/licenses-not-accepted"}], :success false}
+               (send-command user-id
+                             {:type :application.command/submit
+                              :application-id application-id}))))
+      (testing "accepting licenses and submitting"
+        (is (= {:success true} (send-command user-id
+                                             {:type :application.command/accept-licenses
+                                              :application-id application-id
+                                              :accepted-licenses [license-id1 license-id2]})))
+        (is (= {:success true} (send-command user-id
+                                             {:type :application.command/submit
+                                              :application-id application-id})))))
 
     (testing "send commands with authorized user"
       (testing "even handler cannot review without request"
@@ -474,6 +484,7 @@
                     "application.event/external-id-assigned"
                     "application.event/returned"
                     "application.event/resources-changed"
+                    "application.event/licenses-accepted"
                     "application.event/submitted"
                     "application.event/review-requested"
                     "application.event/reviewed"
@@ -497,6 +508,7 @@
                     "application.event/external-id-assigned"
                     "application.event/returned"
                     "application.event/resources-changed"
+                    "application.event/licenses-accepted"
                     "application.event/submitted"
                     "application.event/licenses-added"
                     "application.event/licenses-accepted"

--- a/test/clj/rems/application/test_model.clj
+++ b/test/clj/rems/application/test_model.clj
@@ -765,7 +765,8 @@
                                                                        {:catalogue-item/id 40
                                                                         :resource/ext-id "urn:31"}])
                                        :application/licenses (conj (:application/licenses submitted-application)
-                                                                   {:license/id 34})})]
+                                                                   {:license/id 34})
+                                       :application/accepted-licenses {}})]
       (is (= expected-application (recreate expected-application)))))
   (testing "for approved application"
     (let [new-event {:event/type :application.event/resources-changed
@@ -792,7 +793,8 @@
                                        :application/licenses [{:license/id 30}
                                                               {:license/id 31}
                                                               {:license/id 32}
-                                                              {:license/id 34}]})]
+                                                              {:license/id 34}]
+                                       :application/accepted-licenses {}})]
       (is (= expected-application (recreate expected-application))))))
 
 (deftest test-application-view-licenses-accepted


### PR DESCRIPTION
relates #1373 

- `:application/accepted-licenses` is now emptied after processing `:application.event/resources-changed`

# Checklist for author

Remove items that aren't applicable, check items that are done.

## Reviewability
- [x] Link to issue

## Documentation
- [x] Update changelog if necessary

## Testing
- [x] Complex logic is unit tested
