### PR TITLE
feat: remove flash message from successful new application page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ NB: The login has changed to allow more configurable user identity and other att
 - Improve the accessibility of the small navbar. (#2907)
 - Load config overrides from system properties and env (#2917)
 - Application draft can now be saved even if there are validation warnings. (#2766)
+- New application page no longer displays "Application: Success" message. (#2838)
 
 ## v2.25 "Meripuistotie" 2022-02-15
 

--- a/src/cljs/rems/new_application.cljs
+++ b/src/cljs/rems/new_application.cljs
@@ -13,15 +13,13 @@
 (rf/reg-event-fx
  ::enter-new-application-page
  (fn [{:keys [db]} [_ catalogue-item-ids]]
-   (let [description [text :t.applications/application]]
-     (post! "/api/applications/create"
-            {:params {:catalogue-item-ids catalogue-item-ids}
-             :handler (flash-message/default-success-handler
-                       :top description
-                       (fn [response]
-                         (remove-catalogue-items-from-cart! catalogue-item-ids)
-                         (replace-url! (str "/application/" (:application-id response)))))
-             :error-handler (flash-message/default-error-handler :top description)}))
+   (post! "/api/applications/create"
+          {:params {:catalogue-item-ids catalogue-item-ids}
+           :handler (fn [response]
+                      (remove-catalogue-items-from-cart! catalogue-item-ids)
+                      (replace-url! (str "/application/" (:application-id response))))
+           :error-handler (flash-message/default-error-handler
+                           :top [text :t.applications/application])})
    {}))
 
 (defn new-application-page []


### PR DESCRIPTION
relates #2838 

- removed flash message `"Application: Success"` from new application page on successful application create, as the message was deemed unnecessary and rather confusing

# Checklist for author

Remove items that aren't applicable, check items that are done.

## Reviewability
- [x] Link to issue
- [x] Consider adding screenshots for ease of review
