### PR TITLE
Fix catalogue tree nil

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,7 +44,7 @@ NB: New feature, reminder email for application expiration uses new email templa
 - Application draft can now be saved even if there are validation warnings. (#2766)
 - New application page no longer displays "Application: Success" message. (#2838)
 - Blacklist API now returns HTTP 422 status if user or resource does not exist when adding or removing blacklist entry. (#2835)
-- Fix the catalogue tree nodes sometimes being empty when fetcing it from the API (#2931)
+- Fix the catalogue tree nodes sometimes being empty when fetching it from the API (#2931)
 
 ## v2.25 "Meripuistotie" 2022-02-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ NB: New feature, reminder email for application expiration uses new email templa
 - Application draft can now be saved even if there are validation warnings. (#2766)
 - New application page no longer displays "Application: Success" message. (#2838)
 - Blacklist API now returns HTTP 422 status if user or resource does not exist when adding or removing blacklist entry. (#2835)
+- Fix the catalogue tree nodes sometimes being empty when fetcing it from the API (#2931)
 
 ## v2.25 "Meripuistotie" 2022-02-15
 

--- a/src/clj/rems/api/services/category.clj
+++ b/src/clj/rems/api/services/category.clj
@@ -1,9 +1,10 @@
 (ns rems.api.services.category
-  (:require [rems.db.category :as category]
+  (:require [medley.core :refer [update-existing-in]]
+            [rems.db.category :as category]
             [rems.api.services.dependencies :as dependencies]))
 
 (defn join-categories [m ks]
-  (update-in m ks category/enrich-categories))
+  (update-existing-in m ks category/enrich-categories))
 
 (defn get-category [id]
   (when-let [category (category/get-category id)]

--- a/src/cljc/rems/common/util.cljc
+++ b/src/cljc/rems/common/util.cljc
@@ -291,19 +291,21 @@
   `:children-fn`     - gives the children of a tree node, single or seq value allowed
   `:set-children-fn` - sets the children of a tree node
   `:value-fn`        - the value of a tree node, defaults to `identity`
+  `:filter-fn`       - function called to check should the node be included, defaults to `(constantly true)`
 
   Results is nested map, e.g.
     (build-dags {:id-fn :a
                  :children-fn :c}
                  [{:a 1} {:a 2 :c [1]}])
       ==> {:a 2 :c [{:a 1}]}"
-  [{:keys [id-fn child-id-fn children-fn set-children-fn value-fn]
+  [{:keys [id-fn child-id-fn children-fn set-children-fn value-fn filter-fn]
     :or {child-id-fn identity
          set-children-fn (fn [node children]
                            (if (seq children)
                              (assoc node children-fn children)
-                             node))
-         value-fn identity}}
+                             (dissoc node children-fn)))
+         value-fn identity
+         filter-fn (constantly true)}}
    coll]
   (let [children-set (set (for [x coll
                                 child (children-fn x)
@@ -313,9 +315,16 @@
         node-by-id (index-by [id-fn] coll)]
     (letfn [(expand-node [node]
               (set-children-fn (value-fn node)
-                               (mapv (comp value-fn expand-node node-by-id child-id-fn)
-                                     (children-fn node))))]
-      (mapv expand-node roots))))
+                               (->> node
+                                    children-fn
+                                    (map (comp node-by-id child-id-fn))
+                                    (remove nil?)
+                                    (filter filter-fn)
+                                    (mapv (comp value-fn expand-node)))))]
+      (->> roots
+           (map expand-node)
+           (filter filter-fn)
+           vec))))
 
 (deftest test-build-dags
   (is (= [{:id 3
@@ -340,13 +349,27 @@
                       {:id 2
                        :unrelated "z"
                        :children [{:id 1
-                                   :unrelated "x"}]}]}]
+                                   :unrelated "x"}]}]}
+          {:id 4}]
          (build-dags {:id-fn :id
                       :child-id-fn :id
                       :children-fn :children}
                      [{:id 1 :unrelated "x"}
                       {:id 2 :unrelated "z" :children [{:id 1}]}
-                      {:id 3 :children [{:id 1} {:id 2}]}])))
+                      {:id 3 :children [{:id 1} {:id 2}]}
+                      {:id 4 :children [{:id :not-found}]}])))
+
+  (testing "filtering"
+    (is (= [{:id 3
+             :children [{:id 1
+                         :unrelated "x"}]}]
+           (build-dags {:id-fn :id
+                        :children-fn :children
+                        :filter-fn (comp odd? :id)}
+                       [{:id 1 :unrelated "x"}
+                        {:id 2 :unrelated "z" :children [1]}
+                        {:id 3 :children [1 2]}
+                        {:id 4 :unrelated "y"}]))))
 
   (testing "cyclic data"
     (is (= [{:id 5 :unrelated "survives"}]

--- a/src/cljc/rems/text.cljc
+++ b/src/cljc/rems/text.cljc
@@ -106,6 +106,11 @@
   #?(:clj (time-format/unparse (time-format/formatter "yyyy-MM-dd") time)
      :cljs (time-format/unparse (time-format/formatter "yyyy-MM-dd") (time-coerce/to-local-date time))))
 
+(defn format-utc-datetime
+  "For a given time instant, format it in UTC."
+  [time]
+  (time-format/unparse (time-format/formatters :date-time) time))
+
 (deftest test-localize-utc-date []
   (is (= "2020-09-29" (localize-utc-date (time/date-time 2020 9 29 1 1))))
   (is (= "2020-09-29" (localize-utc-date (time/date-time 2020 9 29 23 59))))

--- a/test/clj/rems/api/services/test_catalogue.clj
+++ b/test/clj/rems/api/services/test_catalogue.clj
@@ -6,6 +6,7 @@
             [rems.api.services.resource :as resource]
             [rems.api.services.workflow :as workflow]
             [rems.db.core :as db]
+            [rems.db.category :as category]
             [rems.db.test-data-helpers :as test-helpers]
             [rems.db.testing :refer [caches-fixture rollback-db-fixture test-db-fixture]]
             [rems.testing-util :refer [with-user]])
@@ -183,3 +184,62 @@
       (is (= [] (map :id (catalogue/get-localized-catalogue-items))))
       (is (= [item-id] (map :id (catalogue/get-localized-catalogue-items {:archived true}))))
       (is (= [] (map :id (catalogue/get-localized-catalogue-items {:archived false})))))))
+
+(deftest test-get-catalogue-tree
+  (is (= {:roots []} (catalogue/get-catalogue-tree nil)))
+  (is (= {:roots []} (catalogue/get-catalogue-tree {:expand-catalogue-data? true})))
+
+  (let [get-item (fn [id]
+                   (-> (catalogue/get-localized-catalogue-item id)
+                       (dissoc :resource-name :form-name :workflow-name)))
+        get-category (fn [category]
+                       (-> (category/get-category (:category/id category))))
+        child {:category/id (test-helpers/create-category! {})}
+        parent {:category/id (test-helpers/create-category! {:category/children [child]})}
+        _empty {:category/id (test-helpers/create-category! {})} ; should not be seen
+        item1 (get-item (test-helpers/create-catalogue-item! {}))
+        item2 (get-item (test-helpers/create-catalogue-item! {:enabled false}))
+        item3 (get-item (test-helpers/create-catalogue-item! {:categories []}))
+        item4 (assoc (get-item (test-helpers/create-catalogue-item! {:categories [child]}))
+                     :categories [(get-category child)])
+        item5 (get-item (test-helpers/create-catalogue-item! {:categories [] :enabled false}))
+        item6 (assoc (get-item (test-helpers/create-catalogue-item! {:categories [child] :enabled false}))
+                     :categories [(get-category child)])
+        item7 (assoc (get-item (test-helpers/create-catalogue-item! {:categories [parent]}))
+                     :categories [(get-category parent)])
+        item8 (assoc (get-item (test-helpers/create-catalogue-item! {:categories [parent] :enabled false}))
+                     :categories [(get-category parent)])]
+
+    (is (= {:roots [(assoc (get-category parent)
+                           :category/children [(assoc (get-category child) :category/items [item4 item6])]
+                           :category/items [item7 item8])
+                    item1
+                    item2
+                    item3
+                    item5]}
+           (catalogue/get-catalogue-tree {:archived false
+                                          :expand-catalogue-data? true
+                                          :empty false})))
+
+    (is (= {:roots [(assoc (get-category parent)
+                           :category/children [(assoc (get-category child) :category/items [item4])]
+                           :category/items [item7])
+                    item1
+                    item3]}
+           (catalogue/get-catalogue-tree {:archived false
+                                          :expand-catalogue-data? true
+                                          :empty false
+                                          :enabled true})))
+
+    (with-user "owner"
+      (catalogue/set-catalogue-item-enabled! {:id (:id item1) :enabled false}) ; top level
+      (catalogue/set-catalogue-item-enabled! {:id (:id item4) :enabled false})) ; inside category
+
+    (is (= {:roots [(-> (get-category parent)
+                        (assoc :category/items [item7])
+                        (dissoc :category/children)) ; child does not have visible items
+                    item3]}
+           (catalogue/get-catalogue-tree {:archived false
+                                          :expand-catalogue-data? true
+                                          :empty false
+                                          :enabled true})))))

--- a/test/clj/rems/api/services/test_catalogue.clj
+++ b/test/clj/rems/api/services/test_catalogue.clj
@@ -221,25 +221,30 @@
                                           :expand-catalogue-data? true
                                           :empty false})))
 
-    (is (= {:roots [(assoc (get-category parent)
-                           :category/children [(assoc (get-category child) :category/items [item4])]
-                           :category/items [item7])
-                    item1
-                    item3]}
-           (catalogue/get-catalogue-tree {:archived false
-                                          :expand-catalogue-data? true
-                                          :empty false
-                                          :enabled true})))
+    (testing "showing only enabled"
+      (is (= {:roots [(assoc (get-category parent)
+                             :category/children [(assoc (get-category child) :category/items [item4
+                                                                                              ;; item 6 is not seen as it's not enabled
+                                                                                              ])]
+                             :category/items [item7])
+                      item1
+                      ;; item 2 is not seen as it's not enabled
+                      item3]}
+             (catalogue/get-catalogue-tree {:archived false
+                                            :expand-catalogue-data? true
+                                            :empty false
+                                            :enabled true}))))
 
-    (with-user "owner"
-      (catalogue/set-catalogue-item-enabled! {:id (:id item1) :enabled false}) ; top level
-      (catalogue/set-catalogue-item-enabled! {:id (:id item4) :enabled false})) ; inside category
+    (testing "disabling more items"
+      (with-user "owner"
+        (catalogue/set-catalogue-item-enabled! {:id (:id item1) :enabled false}) ; top level
+        (catalogue/set-catalogue-item-enabled! {:id (:id item4) :enabled false})) ; inside category
 
-    (is (= {:roots [(-> (get-category parent)
-                        (assoc :category/items [item7])
-                        (dissoc :category/children)) ; child does not have visible items
-                    item3]}
-           (catalogue/get-catalogue-tree {:archived false
-                                          :expand-catalogue-data? true
-                                          :empty false
-                                          :enabled true})))))
+      (is (= {:roots [(-> (get-category parent)
+                          (assoc :category/items [item7])
+                          (dissoc :category/children)) ; child does not have visible items anymore
+                      item3]}
+             (catalogue/get-catalogue-tree {:archived false
+                                            :expand-catalogue-data? true
+                                            :empty false
+                                            :enabled true}))))))

--- a/test/clj/rems/api/test_catalogue.clj
+++ b/test/clj/rems/api/test_catalogue.clj
@@ -1,17 +1,20 @@
 (ns ^:integration rems.api.test-catalogue
-  (:require [clojure.string :as str]
-            [clojure.test :refer :all]
+  (:require [clojure.test :refer :all]
+            [rems.api.services.catalogue :as catalogue]
             [rems.api.testing :refer :all]
+            [rems.db.category :as category]
             [rems.db.test-data :as test-data]
             [rems.db.test-data-helpers :as test-helpers]
             [rems.handler :refer [handler]]
+            [rems.testing-util :refer [with-user]]
+            [rems.text :refer [format-utc-datetime]]
             [ring.mock.request :refer :all]))
 
 (use-fixtures
   :each
   api-fixture)
 
-(deftest catalogue-api-test
+(deftest test-catalogue-api
   (test-data/create-test-api-key!)
   (test-data/create-test-users-and-roles!)
   (let [res (test-helpers/create-resource! {:resource-ext-id "urn:1234"})]
@@ -22,7 +25,7 @@
                   read-ok-body)]
     (is (= ["urn:1234"] (map :resid items)))))
 
-(deftest catalogue-api-no-form
+(deftest test-catalogue-api-no-form
   (test-data/create-test-api-key!)
   (test-data/create-test-users-and-roles!)
   (let [form-id (test-helpers/create-form! {})
@@ -35,7 +38,7 @@
             (map #(select-keys % [:resid :formid])
                  (api-call :get "/api/catalogue/" nil test-data/+test-api-key+ "alice")))))))
 
-(deftest catalogue-api-security-test
+(deftest test-catalogue-api-security
   (test-data/create-test-api-key!)
   (test-data/create-test-users-and-roles!)
   (testing "catalogue-is-public true"
@@ -49,3 +52,56 @@
       (is (= "unauthorized" (read-body (api-response :get "/api/catalogue" nil nil nil))) "should be unauthorized without authentication")
       (is (= "unauthorized" (read-body (api-response :get "/api/catalogue" nil "invalid-api-key" nil))) "should not work with wrong api key")
       (is (= "unauthorized" (read-body (api-response :get "/api/catalogue" nil "42" nil))) "should not work without a user"))))
+
+(deftest test-get-catalogue-tree
+  (test-data/create-test-api-key!)
+  (test-data/create-test-users-and-roles!)
+
+  (let [get-item (fn [id]
+                   (-> (catalogue/get-localized-catalogue-item id)
+                       (update :start format-utc-datetime)
+                       (dissoc :resource-name :form-name :workflow-name)))
+        get-category (fn [category]
+                       (-> (category/get-category (:category/id category))))
+        child {:category/id (test-helpers/create-category! {})}
+        parent {:category/id (test-helpers/create-category! {:category/children [child]})}
+        _empty {:category/id (test-helpers/create-category! {})} ; should not be seen
+        item1 (get-item (test-helpers/create-catalogue-item! {}))
+        item2 (get-item (test-helpers/create-catalogue-item! {:enabled false}))
+        item3 (get-item (test-helpers/create-catalogue-item! {:categories []}))
+        item4 (assoc (get-item (test-helpers/create-catalogue-item! {:categories [child]}))
+                     :categories [(get-category child)])
+        item5 (get-item (test-helpers/create-catalogue-item! {:categories [] :enabled false}))
+        item6 (assoc (get-item (test-helpers/create-catalogue-item! {:categories [child] :enabled false}))
+                     :categories [(get-category child)])
+        item7 (assoc (get-item (test-helpers/create-catalogue-item! {:categories [parent]}))
+                     :categories [(get-category parent)])
+        item8 (assoc (get-item (test-helpers/create-catalogue-item! {:categories [parent] :enabled false}))
+                     :categories [(get-category parent)])]
+    (is (= {:roots [(assoc (get-category parent)
+                           :category/children [(assoc (get-category child) :category/items [item4 item6])]
+                           :category/items [item7 item8])
+                    item1
+                    item2
+                    item3
+                    item5]}
+           (api-call :get "/api/catalogue/tree" nil test-data/+test-api-key+ "owner")))
+
+    (testing "a regular user doesn't see disabled"
+      (is (= {:roots [(assoc (get-category parent)
+                             :category/children [(assoc (get-category child) :category/items [item4])]
+                             :category/items [item7])
+                      item1
+                      item3]}
+             (api-call :get "/api/catalogue/tree" nil test-data/+test-api-key+ "alice")))
+
+      (testing "even after disabling more"
+        (with-user "owner"
+          (catalogue/set-catalogue-item-enabled! {:id (:id item1) :enabled false}) ; top level
+          (catalogue/set-catalogue-item-enabled! {:id (:id item4) :enabled false})) ; inside category
+
+        (is (= {:roots [(-> (get-category parent)
+                            (assoc :category/items [item7])
+                            (dissoc :category/children)) ; child does not have visible items
+                        item3]}
+               (api-call :get "/api/catalogue/tree" nil test-data/+test-api-key+ "alice")))))))


### PR DESCRIPTION
Fix #2931.

The filtering of the empty nodes must be done in the whole tree. Previously, the code looked at each category by itself. Hence a root category, with a middle category, with an empty child, wasn't being detected, since it had the middle category as child, which ended up empty later. Now we work at the tree level in the `build-dags`. The existing browser test actually caught this as it has the three part hierarchy. But I fixed the small other problems first, that fixed the `nil`.

# Checklist for author

Remove items that aren't applicable, check items that are done.

## Reviewability
- [x] Link to issue

## Backwards compatibility
- [x] API is backwards compatible or completely new

## Documentation
- [x] Update changelog if necessary

## Testing
- [x] Complex logic is unit tested
- [x] Valuable features are integration / browser / acceptance tested automatically
