### PR TITLE
fix: only fetch catalogue table/tree if needed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ NB: New feature, reminder email for application expiration uses new email templa
 - Application draft can now be saved even if there are validation warnings. (#2766)
 - New application page no longer displays "Application: Success" message. (#2838)
 - Blacklist API now returns HTTP 422 status if user or resource does not exist when adding or removing blacklist entry. (#2835)
+- Only fetch the catalogue tree (or table) if it is shown (or otherwise needed). (#2930)
 
 ## v2.25 "Meripuistotie" 2022-02-15
 

--- a/src/cljs/rems/catalogue.cljs
+++ b/src/cljs/rems/catalogue.cljs
@@ -17,8 +17,10 @@
  ::enter-page
  (fn [{:keys [db]} _]
    {:db (dissoc db ::catalogue ::draft-applications)
-    :dispatch-n [[::full-catalogue]
-                 [::full-catalogue-tree]
+    :dispatch-n [(when (:enable-catalogue-table (:config db))
+                   [::full-catalogue])
+                 (when (:enable-catalogue-tree (:config db))
+                   [::full-catalogue-tree])
                  (when (roles/is-logged-in? (get-in db [:identity :roles])) [::draft-applications])
                  [:rems.table/reset]]}))
 


### PR DESCRIPTION
Closes #2930 

- Using change resources will potentially fetch the flat catalogue, even if
  tree is generally used.
- The separate catalogue items API is used in the owner page.

# Checklist for author

Remove items that aren't applicable, check items that are done.

## Reviewability
- [x] Link to issue

## Documentation
- [x] Update changelog if necessary

## Testing
- Not tested specifically outside the regular tests, just manually.