### PR TITLE
Optional shopping basket

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ have notable changes.
 
 Changes since v2.26
 
+### Additions
+- Bundling resources to application can now be enabled or disabled in user interface with configuration option `:enable-cart`, which defaults to `true`. (#2720)
+
 ## v2.26 "Lauttasaarentie" 2022-05-25
 
 **NB: This release contains migrations!**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ have notable changes.
 Changes since v2.26
 
 ### Additions
-- Bundling resources to application can now be enabled or disabled in user interface with configuration option `:enable-cart`, which defaults to `true`. (#2720)
+- Shopping cart can now be enabled or disabled in user interface with configuration option `:enable-cart`, which defaults to `true`. (#2720)
 
 ## v2.26 "Lauttasaarentie" 2022-05-25
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -164,10 +164,14 @@ REMS uses [Logback](https://logback.qos.ch/) for logging. By default everything 
 
 ## Application expiration scheduler
 
-REMS can be configured to delete applications after a set period of time has passed. Expiration can be defined for application states with ISO-8601 duration formatting. Application expiration scheduler is disabled by default. See `:application-expiration` in [config-defaults.edn](https://github.com/CSCfi/rems/blob/master/resources/config-defaults.edn) for details.
+REMS can be configured to delete applications after a set period of time has passed since last activity. Expiration can be defined for application states with ISO-8601 duration formatting, and optionally email notification can be configured to be sent to applicant and members before deletion. Application expiration scheduler is disabled by default. See `:application-expiration` in [config-defaults.edn](https://github.com/CSCfi/rems/blob/master/resources/config-defaults.edn) for details.
 
 ```clojure
 {:application-expiration
- {:application.state/draft "P90D" ;; delete draft applications that are over 90 days old
-  :application.state/closed "P7D"}} ;; delete closed applications that are over 7 days old
+ {:application.state/draft {:delete-after "P90D" :reminder-before "P7D"} ; delete draft applications that are over 90 days old, and send reminder emails 7 days before deletion
+  :application.state/closed {:delete-after "P7D"}}} ; delete closed applications that are over 7 days old
 ```
+
+## Shopping cart
+
+REMS has a shopping cart feature which allows bundling multiple resources into single application. Shopping cart is enabled by default, and it can be enabled or disabled using the `:shopping-cart` key in your `config.edn`. See [config-defaults.edn](https://github.com/CSCfi/rems/blob/master/resources/config-defaults.edn) for details.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -174,4 +174,4 @@ REMS can be configured to delete applications after a set period of time has pas
 
 ## Shopping cart
 
-REMS has a shopping cart feature which allows bundling multiple resources into single application. Shopping cart is enabled by default, and it can be enabled or disabled using the `:shopping-cart` key in your `config.edn`. See [config-defaults.edn](https://github.com/CSCfi/rems/blob/master/resources/config-defaults.edn) for details.
+REMS has a shopping cart feature which allows bundling multiple resources into single application. Shopping cart is enabled by default, and it can be enabled or disabled using the `:enable-cart` key in your `config.edn`. See [config-defaults.edn](https://github.com/CSCfi/rems/blob/master/resources/config-defaults.edn) for details.

--- a/resources/config-defaults.edn
+++ b/resources/config-defaults.edn
@@ -387,4 +387,4 @@
  :enable-catalogue-tree false ; show catalogue page tree of items
  :catalogue-tree-show-matching-parents true ; should parent categories be shown if children match?
  
- :enable-cart true} ; allow bundling multiple items to application
+ :enable-cart true} ; show shopping cart and allow bundling multiple resources into one application

--- a/resources/config-defaults.edn
+++ b/resources/config-defaults.edn
@@ -385,4 +385,6 @@
 
  :enable-catalogue-table true ; show catalogue page table of items
  :enable-catalogue-tree false ; show catalogue page tree of items
- :catalogue-tree-show-matching-parents true} ; should parent categories be shown if children match?
+ :catalogue-tree-show-matching-parents true ; should parent categories be shown if children match?
+ 
+ :enable-cart true} ; allow bundling multiple items to application

--- a/src/clj/rems/api/public.clj
+++ b/src/clj/rems/api/public.clj
@@ -37,7 +37,8 @@
    (s/optional-key :enable-duo) s/Bool
    (s/optional-key :enable-catalogue-table) s/Bool
    (s/optional-key :enable-catalogue-tree) s/Bool
-   (s/optional-key :catalogue-tree-show-matching-parents) s/Bool})
+   (s/optional-key :catalogue-tree-show-matching-parents) s/Bool
+   (s/optional-key :enable-cart) s/Bool})
 
 (def translations-api
   (context "/translations" []
@@ -81,7 +82,8 @@
                             :attachment-max-size
                             :enable-catalogue-table
                             :enable-catalogue-tree
-                            :catalogue-tree-show-matching-parents])))
+                            :catalogue-tree-show-matching-parents
+                            :enable-cart])))
 
     (GET "/full" []
       :summary "Get (almost) full configuration"

--- a/src/cljs/rems/actions/change_resources.cljs
+++ b/src/cljs/rems/actions/change_resources.cljs
@@ -79,7 +79,8 @@
         compatible-first-sort-fn #(if (compatible-item? % original-workflow-id) -1 1)
         sorted-selected-catalogue (->> catalogue
                                        (sort-by #(get-localized-title % language))
-                                       (sort-by compatible-first-sort-fn))]
+                                       (sort-by compatible-first-sort-fn))
+        config @(rf/subscribe [:rems.config/config])]
     [action-form-view action-form-id
      (text :t.actions/change-resources)
      [[button-wrapper {:id "change-resources"
@@ -107,9 +108,10 @@
            :item-key :id
            :item-label #(get-localized-title % language)
            :item-selected? #(contains? (set selected-resources) (% :id))
-           :multi? true
-           :on-change on-set-resources}]]
-        (text :t.actions/bundling-intro)])]))
+           :multi? (:enable-cart config)
+           :on-change #(on-set-resources (flatten (list %)))}]] ; single resource or list
+        (when (:enable-cart config)
+          (text :t.actions/bundling-intro))])]))
 
 (defn change-resources-form [application can-comment? on-finished]
   (let [initial-resources @(rf/subscribe [::initial-resources])

--- a/src/cljs/rems/catalogue.cljs
+++ b/src/cljs/rems/catalogue.cljs
@@ -2,7 +2,7 @@
   (:require [re-frame.core :as rf]
             [rems.application-list :as application-list]
             [rems.common.application-util :refer [form-fields-editable?]]
-            [rems.atoms :refer [external-link document-title document-title]]
+            [rems.atoms :as atoms :refer [external-link document-title document-title]]
             [rems.cart :as cart]
             [rems.common.catalogue-util :refer [catalogue-item-more-info-url]]
             [rems.fetcher :as fetcher]
@@ -11,7 +11,7 @@
             [rems.spinner :as spinner]
             [rems.table :as table]
             [rems.tree :as tree]
-            [rems.text :refer [text get-localized-title]]))
+            [rems.text :refer [text text-format get-localized-title]]))
 
 (rf/reg-event-fx
  ::enter-page
@@ -56,6 +56,14 @@
                          (text :t.link/opens-in-new-window))}
        [external-link] " " (text :t.catalogue/more-info)])))
 
+(defn- apply-button [item language]
+  [atoms/link {:class "btn btn-primary apply-for-catalogue-item"
+               :aria-label (text-format :t.label/default
+                                        (text :t.cart/apply)
+                                        (get-localized-title item language))}
+   (str "/application?items=" (:id item))
+   (text :t.cart/apply)])
+
 (rf/reg-sub
  ::catalogue-table-rows
  (fn [_ _]
@@ -72,9 +80,11 @@
              :commands {:td [:td.commands
                              [catalogue-item-more-info item language config]
                              (when logged-in?
-                               (if (contains? cart-item-ids (:id item))
-                                 [cart/remove-from-cart-button item language]
-                                 [cart/add-to-cart-button item language]))]}})
+                               (if (:enable-cart config)
+                                 (if (contains? cart-item-ids (:id item))
+                                   [cart/remove-from-cart-button item language]
+                                   [cart/add-to-cart-button item language])
+                                 (apply-button item language)))]}})
           catalogue))))
 
 (defn draft-application-list []
@@ -132,9 +142,11 @@
                                           [:div.commands.w-100
                                            [catalogue-item-more-info % language config]
                                            (when logged-in?
-                                             (if (contains? cart-item-ids (:id %))
-                                               [cart/remove-from-cart-button % language]
-                                               [cart/add-to-cart-button % language]))])
+                                             (if (:enable-cart config)
+                                               (if (contains? cart-item-ids (:id %))
+                                                 [cart/remove-from-cart-button % language]
+                                                 [cart/add-to-cart-button % language])
+                                               (apply-button % language)))])
                               :sortable? false
                               :filterable? false}]
                    :children #(concat (:category/items %) (:category/children %))
@@ -163,7 +175,8 @@
         (when @(rf/subscribe [:logged-in])
           [:<>
            [draft-application-list]
-           [cart/cart-list-container]
+           (when (:enable-cart config)
+             [cart/cart-list-container])
            [:h2 (text :t.catalogue/apply-resources)]])
         (when (:enable-catalogue-tree config)
           [catalogue-tree])


### PR DESCRIPTION
relates #2720 

add new configuration option `:enable-cart`

if `:enable-cart` is true:
- show shopping cart in catalogue
- allow selecting multiple resources in application `change resources`

if `:enable-cart` is false:
- hide shopping cart in catalogue
- replace `"Add to cart"` with `"Apply"` buttons for resources in catalogue
- allow selecting only single resource in application `change resources` and hide `:t.actions/bundling-intro` text

also update documentation `configuration.md` regarding application expiration

# Checklist for author

Remove items that aren't applicable, check items that are done.

## Reviewability
- [x] Link to issue
- [x] Consider adding screenshots for ease of review

## Backwards compatibility
- [x] Config is backwards compatible

## Documentation
- [x] Update changelog if necessary
- [x] New config options in config-defaults.edn

## Testing
- [ ] Complex logic is unit tested
- [ ] Valuable features are integration / browser / acceptance tested automatically

## Follow-up
- [ ] New tasks are created for pending or remaining tasks

---
## Screenshots
:enable-cart true (application -> change resources)
![Screenshot 2022-05-25 at 15 42 26](https://user-images.githubusercontent.com/794087/170265167-ef1f3c41-7820-40c1-ad7d-e69442db661f.png)
---
:enable-cart false (application -> change resources)
![Screenshot 2022-05-25 at 15 42 35](https://user-images.githubusercontent.com/794087/170265173-c24fa16b-cd22-470a-b54d-ce874390635a.png)
---
:enable-cart true (catalogue)
![Screenshot 2022-05-25 at 15 43 20](https://user-images.githubusercontent.com/794087/170265175-c9e88689-66ed-4984-ba73-09248048abc3.png)
---
:enable-cart false (catalogue)
![Screenshot 2022-05-25 at 15 43 46](https://user-images.githubusercontent.com/794087/170265178-1fe02fc2-7c92-4efd-a7b4-09af88eb6d45.png)
---
