### PR TITLE
HTTP/2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Changes since v2.27
   - Some dependencies have been dropped resulting in a smaller bundle.
 - Default metadata for the HTML index has been added under description and keywords tags. These can be overridden using extra translations (`:t.meta/description`, `:t.meta/keywords`) (#2679)
 - Default `robots.txt` has been included that indexes everything but the `/api`. NB: the bots are not able to index most pages as they are behind the login. (#2680)
+- HTTP/2 (and others) can be configured, see `:jetty-extra-params` in `config-defaults.edn`.
 
 ## v2.27 "Lauttasaaren silta" 2022-06-06
 

--- a/resources/config-defaults.edn
+++ b/resources/config-defaults.edn
@@ -11,6 +11,10 @@
  :ssl-keystore nil ; Java keystore file
  :ssl-keystore-password nil ; (optional) password of key file
 
+ ;; Extra parameters to override HTTP server parameters
+ ;; A useful parameter could be `{:h2? true}` to enable HTTP/2 if you have SSL configured
+ :jetty-extra-params {}
+
  ;; Url for this REMS installation. Should end with a /.
  ;; Used for generating links in emails, in OpenId authentication (:oidc),
  ;; and in the `iss` and `source` of generated GA4GH visas (see /api/permissions).

--- a/src/clj/rems/standalone.clj
+++ b/src/clj/rems/standalone.clj
@@ -61,7 +61,8 @@
                        {:ssl? true
                         :ssl-port (:ssl-port env)
                         :keystore (:ssl-keystore env)
-                        :key-password (:ssl-keystore-password env)})))
+                        :key-password (:ssl-keystore-password env)})
+                     (:jetty-extra-params env)))
   :stop
   (when http-server (http/stop http-server)))
 


### PR DESCRIPTION
Enable configuring more unspecified Jetty parameters, which our adapter https://github.com/sunng87/ring-jetty9-adapter supports, e.g. HTTP/2. It is useful when someone doesn't want to have SSL offload / stuff before REMS at the edge.

Tested with
```clj
 :port nil
 :ssl-port 3000
 :ssl-keystore "rems.keystore"
 :ssl-keystore-password "..."
 :jetty-extra-params {:h2? true}
 ```

```sh
curl -k -vvv https://rems.example.com:3000/api/config
*   Trying 127.0.0.1:3000...
* Connected to rems.example.com (127.0.0.1) port 3000 (#0)
* ALPN, offering h2
* ALPN, offering http/1.1
```


# Checklist for author

Remove items that aren't applicable, check items that are done.

## Reviewability
- [x] Note if PR is on top of other PR (on top of #2959)

## Documentation
- [x] Update changelog if necessary
