### PR TITLE
fix indentation of not accepted licenses

### DIFF
--- a/src/cljs/rems/application.cljs
+++ b/src/cljs/rems/application.cljs
@@ -28,7 +28,7 @@
             [rems.administration.duo :refer [duo-field duo-info-field]]
             [rems.common.application-util :refer [accepted-licenses? form-fields-editable? get-member-name is-handler?]]
             [rems.common.attachment-types :as attachment-types]
-            [rems.atoms :refer [external-link expander file-download info-field readonly-checkbox document-title success-symbol empty-symbol]]
+            [rems.atoms :refer [external-link expander file-download info-field readonly-checkbox document-title success-symbol make-empty-symbol]]
             [rems.common.catalogue-util :refer [catalogue-item-more-info-url]]
             [rems.collapsible :as collapsible]
             [rems.common.form :as form]
@@ -435,7 +435,7 @@
    [:div.mr-2 (when show-accepted-licenses?
                 (if (:accepted license)
                   (success-symbol)
-                  (empty-symbol)))]
+                  (make-empty-symbol (success-symbol))))]
    (case (:license/type license)
      :link [link-license license]
      :text [text-license license]

--- a/src/cljs/rems/atoms.cljs
+++ b/src/cljs/rems/atoms.cljs
@@ -44,9 +44,6 @@
 (defn add-symbol []
   [:i.fa.fa-plus])
 
-(defn empty-symbol []
-  [:i.fa-stack])
-
 (defn collapse-symbol []
   [:i {:class "fas fa-compress-alt icon-link"
        :aria-label (text :t.collapse/hide)}])
@@ -54,6 +51,10 @@
 (defn expand-symbol []
   [:i {:class "fas fa-expand-alt icon-link"
        :aria-label (text :t.collapse/show)}])
+
+(defn make-empty-symbol [& [symbol]]
+  (let [symbol (or symbol (success-symbol))]
+    [:span {:style {:opacity 0}} symbol]))
 
 (defn textarea [attrs]
   [autosize/textarea (merge {:min-rows 5}


### PR DESCRIPTION
relates #2928

`rems.atoms/empty-symbol` uses `fa-stack` to represent empty state. however `fa-stack` is not an actual icon, but rather an mechanism to compose a new icon out of existing ones, and it has much larger width than default icons which have a varying width by themselves. 

- implement `rems.atoms/make-empty-symbol` that can create a new "empty symbol" out of any given element with `opacity: 0` which takes up the exact same space

# Checklist for author

Remove items that aren't applicable, check items that are done.

## Reviewability
- [x] Link to issue
- [x] Consider adding screenshots for ease of review

## Documentation
- [x] Components are added to guide page

## Screenshots
before
<img width="665" alt="Screenshot 2022-06-10 at 10 51 06" src="https://user-images.githubusercontent.com/794087/173023066-5022c54e-9c5c-485f-bd13-be30803ebe82.png">

---
after
<img width="670" alt="Screenshot 2022-06-10 at 11 57 41" src="https://user-images.githubusercontent.com/794087/173030266-0d2e6b27-cadd-4cd1-9342-c994e359821c.png">


