### PR TITLE
Remove organization modifier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ have notable changes.
 
 Changes since v2.27
 
+**NB: This release contains migrations!**
+
 ### Additions
 - Application UI view is now visually more compact for non-handler users. State and members blocks are collapsed initially, and can be expanded to show more details. (#2871)
 - The packaged fonts are now only in WOFF and WOFF2 formats, as is required for extensive support these days. (#2592)
@@ -19,6 +21,10 @@ Changes since v2.27
 - Default metadata for the HTML index has been added under description and keywords tags. These can be overridden using extra translations (`:t.meta/description`, `:t.meta/keywords`) (#2679)
 - Default `robots.txt` has been included that indexes everything but the `/api`. NB: the bots are not able to index most pages as they are behind the login. (#2680)
 - HTTP/2 (and others) can be configured, see `:jetty-extra-params` in `config-defaults.edn`.
+- Validate organization when adding or editing it. (#2964)
+
+### Fixes
+- Add missing migration to remove organization modifier and last modified from the data. (#2964)
 
 ## v2.27 "Lauttasaaren silta" 2022-06-06
 

--- a/resources/migrations/20220615163311-remove-org-modifier.up.sql
+++ b/resources/migrations/20220615163311-remove-org-modifier.up.sql
@@ -1,0 +1,1 @@
+UPDATE organization SET data = data - 'organization/modifier' - 'organization/last-modified';

--- a/test/clj/rems/api/services/test_organizations.clj
+++ b/test/clj/rems/api/services/test_organizations.clj
@@ -19,6 +19,22 @@
     (let [org-id1 (test-helpers/create-organization! {:organization/id "test-org-1"})
           org-id2 (test-helpers/create-organization! {:organization/id "test-org-2"})]
 
+      (testing "with invalid data"
+        (is (thrown? clojure.lang.ExceptionInfo
+                     (organizations/add-organization! {:organization/id "invalid-org"
+                                                       :organization/short-name {:en "I" :fi "I" :sv "I"}
+                                                       :organization/name {:en "I" :fi "I" :sv "I"}
+                                                       :organization/invalid "should not work"}))
+            "can't include invalid fields")
+
+        (is (thrown? clojure.lang.ExceptionInfo
+                     (organizations/edit-organization! "owner"
+                                                       {:organization/id "test-org-1"
+                                                        :organization/short-name {:en "I" :fi "I" :sv "I"}
+                                                        :organization/name {:en "I" :fi "I" :sv "I"}
+                                                        :organization/invalid "should not work"}))
+            "can't edit invalid fields in"))
+
       (testing "new organizations are enabled and not archived"
         (is (= {:enabled true
                 :archived false}


### PR DESCRIPTION
Closes #2964 

There was potentially leftover data in the `:organization/modifier` and `:organization/last-modified` fields.

Added also validation with a test to make sure extra fields are not accidentally saved.

# Checklist for author

Remove items that aren't applicable, check items that are done.

## Reviewability
- [x] Link to issue

## Documentation
- [x] Update changelog if necessary

## Testing
- [x] Complex logic is unit tested
