### PR TITLE
Workflow licenses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ Changes since v2.27
 
 **NB: This release contains migrations!**
 
+- `workflow_licenses` table has been removed and the data is migrated to `workflow` table.
+
 ### Additions
 - Application UI view is now visually more compact for non-handler users. State and members blocks are collapsed initially, and can be expanded to show more details. (#2871)
 - The packaged fonts are now only in WOFF and WOFF2 formats, as is required for extensive support these days. (#2592)
@@ -23,6 +25,7 @@ Changes since v2.27
 - HTTP/2 (and others) can be configured, see `:jetty-extra-params` in `config-defaults.edn`.
 - Validate organization when adding or editing it. (#2964)
 - Consecutive save events are compacted into one. This does not affect old save events. This is turned off by default, until the whole autosave feature is finished. (#2767)
+- Licenses can now be added to workflows through user interface and API. Workflow licenses are included in applications, similar to resource licenses. (#2158)
 
 ### Fixes
 - Add missing migration to remove organization modifier and last modified from the data. (#2964)

--- a/resources/migrations/20220621104646-refactor-workflow-licenses.edn
+++ b/resources/migrations/20220621104646-refactor-workflow-licenses.edn
@@ -1,0 +1,3 @@
+{:ns rems.migrations.refactor-workflow-licenses
+ :up-fn migrate-up
+ :down-fn nil}

--- a/resources/migrations/20220711142631-remove-workflow-licenses-table.down.sql
+++ b/resources/migrations/20220711142631-remove-workflow-licenses-table.down.sql
@@ -1,4 +1,4 @@
-CREATE TABLE workflow_licenses (
+CREATE TABLE if not exists workflow_licenses (
   id serial NOT NULL PRIMARY KEY,
   wfId integer DEFAULT NULL,
   licId integer DEFAULT NULL,

--- a/resources/migrations/20220711142631-remove-workflow-licenses-table.down.sql
+++ b/resources/migrations/20220711142631-remove-workflow-licenses-table.down.sql
@@ -1,0 +1,7 @@
+CREATE TABLE workflow_licenses (
+  id serial NOT NULL PRIMARY KEY,
+  wfId integer DEFAULT NULL,
+  licId integer DEFAULT NULL,
+  CONSTRAINT workflow_licenses_ibfk_1 FOREIGN KEY (wfId) REFERENCES workflow (id),
+  CONSTRAINT workflow_licenses_ibfk_2 FOREIGN KEY (licId) REFERENCES license (id)
+);

--- a/resources/migrations/20220711142631-remove-workflow-licenses-table.up.sql
+++ b/resources/migrations/20220711142631-remove-workflow-licenses-table.up.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS workflow_licenses;

--- a/resources/sql/queries.sql
+++ b/resources/sql/queries.sql
@@ -405,23 +405,12 @@ SET
   id = id
 WHERE id = :id;
 
--- :name create-workflow-license! :insert
-INSERT INTO workflow_licenses
-(wfid, licid)
-VALUES
-(:wfid, :licid);
-
 -- TODO: consider renaming this to link-resource-license!
 -- :name create-resource-license! :insert
 INSERT INTO resource_licenses
 (resid, licid)
 VALUES
 (:resid, :licid);
-
--- :name get-workflow-licenses :? :*
-SELECT licid
-FROM workflow_licenses
-WHERE wfid = :wfid
 
 -- :name get-workflow :? :1
 SELECT
@@ -448,14 +437,8 @@ FROM workflow wf;
 
 -- :name get-licenses :? :*
 -- :doc
--- - Gets application licenses by workflow and catalogue item ids
--- - :wfid workflow id for workflow licenses
+-- - Gets application licenses by catalogue item ids
 -- - :items vector of catalogue item ids for resource licenses
-SELECT lic.id, lic.type, lic.enabled, lic.archived, lic.organization
-FROM license lic
-INNER JOIN workflow_licenses wl ON lic.id = wl.licid
-WHERE wl.wfid = :wfid
-UNION
 SELECT lic.id, lic.type, lic.enabled, lic.archived, lic.organization
 FROM license lic
 INNER JOIN resource_licenses rl ON lic.id = rl.licid
@@ -484,9 +467,6 @@ FROM license_localization;
 
 -- :name get-resources-for-license :? :*
 SELECT resid FROM resource_licenses WHERE licid = :id;
-
--- :name get-workflows-for-license :? :*
-SELECT wfid FROM workflow_licenses WHERE licid = :id;
 
 -- :name get-all-roles :? :*
 SELECT userid, role

--- a/src/clj/rems/api/schema.clj
+++ b/src/clj/rems/api/schema.clj
@@ -107,22 +107,22 @@
    (s/optional-key :resource/duo) {:duo/codes [schema-base/DuoCodeFull]}})
 
 (s/defschema V2License
-  {:license/id s/Int
-   :license/type (s/enum :text :link :attachment)
-   :license/title schema-base/LocalizedString
-   (s/optional-key :license/link) schema-base/LocalizedString
-   (s/optional-key :license/text) schema-base/LocalizedString
-   (s/optional-key :license/attachment-id) schema-base/LocalizedInt
-   (s/optional-key :license/attachment-filename) schema-base/LocalizedString
-   :license/enabled s/Bool
-   :license/archived s/Bool})
+  (merge
+   schema-base/LicenseId
+   {:license/type (s/enum :text :link :attachment)
+    :license/title schema-base/LocalizedString
+    (s/optional-key :license/link) schema-base/LocalizedString
+    (s/optional-key :license/text) schema-base/LocalizedString
+    (s/optional-key :license/attachment-id) schema-base/LocalizedInt
+    (s/optional-key :license/attachment-filename) schema-base/LocalizedString
+    :license/enabled s/Bool
+    :license/archived s/Bool}))
 
 (s/defschema Workflow
   {:id s/Int
    :organization schema-base/OrganizationOverview
    :title s/Str
    :workflow s/Any
-   :licenses [License]
    :enabled s/Bool
    :archived s/Bool})
 

--- a/src/clj/rems/api/services/catalogue.clj
+++ b/src/clj/rems/api/services/catalogue.clj
@@ -35,7 +35,7 @@
     (-> item
         organizations/join-organization
         (update :categories category/enrich-categories)
-         ;; not used at the moment
+        ;; XXX: not used at the moment
         #_licenses/join-catalogue-item-licenses
         #_(transform [:licenses ALL] organizations/join-organization))))
 

--- a/src/clj/rems/api/services/dependencies.clj
+++ b/src/clj/rems/api/services/dependencies.clj
@@ -50,8 +50,9 @@
 
    (for [workflow (workflow/get-workflows {})
          dep (concat
-              (mapv (fn [lic] {:license/id (:id lic)}) (:licenses workflow))
-              (:forms (:workflow workflow))
+              (->> (get-in workflow [:workflow :licenses])
+                   (mapv #(select-keys % [:license/id])))
+              (get-in workflow [:workflow :forms])
               [(:organization workflow)])]
      {:from {:workflow/id (:id workflow)} :to dep})
 

--- a/src/clj/rems/api/services/workflow.clj
+++ b/src/clj/rems/api/services/workflow.clj
@@ -37,13 +37,12 @@
         {:success (not (nil? id))
          :id id})))
 
-(defn edit-workflow! [{:keys [id organization handlers licenses] :as cmd}]
+(defn edit-workflow! [{:keys [id organization handlers] :as cmd}]
   (let [workflow (workflow/get-workflow id)]
     (util/check-allowed-organization! (:organization workflow))
     (when organization
       (util/check-allowed-organization! organization))
     (or (invalid-users-error handlers)
-        (invalid-licenses-error licenses)
         (do
           (workflow/edit-workflow! (update cmd :licenses #(map :license/id %)))
           (applications/reload-cache!)

--- a/src/clj/rems/api/services/workflow.clj
+++ b/src/clj/rems/api/services/workflow.clj
@@ -5,10 +5,10 @@
             [rems.db.applications :as applications]
             [rems.db.core :as db]
             [rems.db.form :as form]
+            [rems.db.licenses :as licenses]
             [rems.db.organizations :as organizations]
             [rems.db.users :as users]
-            [rems.db.workflow :as workflow]
-            [rems.json :as json]))
+            [rems.db.workflow :as workflow]))
 
 (defn invalid-forms-error [forms]
   (let [invalid (seq (remove (comp form/get-form-template :form/id) forms))]
@@ -24,35 +24,35 @@
        :errors [{:type :invalid-user
                  :users invalid}]})))
 
-(defn create-workflow! [{:keys [organization handlers forms] :as cmd}]
+(defn invalid-licenses-error [licenses]
+  (let [ids (map :license/id licenses)]
+    (when-some [invalid (seq (remove licenses/license-exists? ids))]
+      {:success false
+       :errors [{:type :invalid-license
+                 :licenses invalid}]})))
+
+(defn create-workflow! [{:keys [organization handlers licenses forms] :as cmd}]
   (util/check-allowed-organization! organization)
   (or (invalid-users-error handlers)
       (invalid-forms-error forms)
-      (let [id (workflow/create-workflow! cmd)]
+      (invalid-licenses-error licenses)
+      (let [id (workflow/create-workflow! (-> cmd
+                                              (update :licenses #(map :license/id %))))]
         (dependencies/reset-cache!)
         {:success (not (nil? id))
          :id id})))
 
-(defn- unrich-workflow [workflow]
-  ;; TODO: keep handlers always in the same format, to avoid this conversion (we can ignore extra keys)
-  (if (get-in workflow [:workflow :handlers])
-    (update-in workflow [:workflow :handlers] #(map :userid %))
-    workflow))
-
-;; TODO: use rems.db.workflow/edit-workflow! and don't go directly to db fns, same for other fns
-(defn edit-workflow! [{:keys [id organization title handlers]}]
-  (let [workflow (unrich-workflow (workflow/get-workflow id))
-        workflow-body (cond-> (:workflow workflow)
-                        handlers (assoc :handlers handlers))]
+(defn edit-workflow! [{:keys [id organization handlers licenses] :as cmd}]
+  (let [workflow (workflow/get-workflow id)]
     (util/check-allowed-organization! (:organization workflow))
     (when organization
       (util/check-allowed-organization! organization))
-    (db/edit-workflow! {:id id
-                        :title title
-                        :organization (:organization/id organization)
-                        :workflow (json/generate-string workflow-body)}))
-  (applications/reload-cache!)
-  {:success true})
+    (or (invalid-users-error handlers)
+        (invalid-licenses-error licenses)
+        (let [_ (workflow/edit-workflow! (-> cmd
+                                             (update :licenses #(map :license/id %))))]
+          (applications/reload-cache!)
+          {:success true}))))
 
 (defn set-workflow-enabled! [{:keys [id enabled]}]
   (util/check-allowed-organization! (:organization (workflow/get-workflow id)))
@@ -79,8 +79,8 @@
     (->> workflow
          join-workflow-forms
          organizations/join-organization
-         workflow/join-workflow-licenses
-         (transform [:licenses ALL] organizations/join-organization))))
+         (transform [:workflow :licenses ALL] (comp organizations/join-organization
+                                                    licenses/join-license)))))
 
 (defn get-workflow [id]
   (->> (workflow/get-workflow id)
@@ -99,3 +99,4 @@
                            (get-in wf [:workflow :handlers]))
                          workflows)]
     (->> handlers distinct (sort-by :userid))))
+

--- a/src/clj/rems/api/workflows.clj
+++ b/src/clj/rems/api/workflows.clj
@@ -22,8 +22,7 @@
    (s/optional-key :organization) schema-base/OrganizationId
    ;; type can't change
    (s/optional-key :title) s/Str
-   (s/optional-key :handlers) [schema-base/UserId]
-   (s/optional-key :licenses) [schema-base/LicenseId]})
+   (s/optional-key :handlers) [schema-base/UserId]})
 
 (s/defschema CreateWorkflowResponse
   {:success s/Bool

--- a/src/clj/rems/api/workflows.clj
+++ b/src/clj/rems/api/workflows.clj
@@ -6,7 +6,6 @@
             [rems.application.events :as events]
             [rems.common.roles :refer [+admin-read-roles+ +admin-write-roles+]]
             [rems.schema-base :as schema-base]
-            [rems.util :refer [getx-user-id]]
             [ring.util.http-response :refer :all]
             [schema.core :as s]))
 
@@ -15,14 +14,16 @@
    :title s/Str
    (s/optional-key :forms) [{:form/id s/Int}]
    :type (apply s/enum events/workflow-types) ; TODO: exclude master workflow?
-   (s/optional-key :handlers) [schema-base/UserId]})
+   (s/optional-key :handlers) [schema-base/UserId]
+   (s/optional-key :licenses) [schema-base/LicenseId]})
 
 (s/defschema EditWorkflowCommand
   {:id s/Int
    (s/optional-key :organization) schema-base/OrganizationId
    ;; type can't change
    (s/optional-key :title) s/Str
-   (s/optional-key :handlers) [schema-base/UserId]})
+   (s/optional-key :handlers) [schema-base/UserId]
+   (s/optional-key :licenses) [schema-base/LicenseId]})
 
 (s/defschema CreateWorkflowResponse
   {:success s/Bool

--- a/src/clj/rems/application/commands.clj
+++ b/src/clj/rems/application/commands.clj
@@ -322,9 +322,8 @@
 (defn- build-licenses-list [catalogue-item-ids {:keys [get-catalogue-item-licenses]}]
   (->> catalogue-item-ids
        (mapcat get-catalogue-item-licenses)
-       distinct
-       (mapv (fn [license]
-               {:license/id (:id license)}))))
+       (distinct-by :license/id)
+       (mapv #(select-keys % [:license/id]))))
 
 (defn- entitlement-end-not-in-future-error
   "Checks that entitlement date time, if provided, is in the future."

--- a/src/clj/rems/db/applications.clj
+++ b/src/clj/rems/db/applications.clj
@@ -54,8 +54,7 @@
 
 (defn get-catalogue-item-licenses [catalogue-item-id]
   (let [item (catalogue/get-localized-catalogue-item catalogue-item-id {})
-        workflow-licenses (-> (:wfid item)
-                              workflow/get-workflow
+        workflow-licenses (-> (workflow/get-workflow (:wfid item))
                               (get-in [:workflow :licenses]))]
     (->> (licenses/get-licenses {:items [catalogue-item-id]})
          (keep-keys {:id :license/id})

--- a/src/clj/rems/db/applications.clj
+++ b/src/clj/rems/db/applications.clj
@@ -58,7 +58,7 @@
                               workflow/get-workflow
                               (get-in [:workflow :licenses]))]
     (->> (licenses/get-licenses {:items [catalogue-item-id]})
-         (map #(keep-keys {:id :license/id} %))
+         (keep-keys {:id :license/id})
          (into workflow-licenses)
          (distinct-by :license/id))))
 

--- a/src/clj/rems/db/licenses.clj
+++ b/src/clj/rems/db/licenses.clj
@@ -55,7 +55,6 @@
 
 (defn get-licenses
   "Get licenses. Params map can contain:
-     :wfid -- workflow to get workflow licenses for
      :items -- sequence of catalogue items to get resource licenses for"
   [params]
   (->> (db/get-licenses params)
@@ -67,10 +66,7 @@
   (assoc x :licenses (get-resource-licenses (:id x))))
 
 (defn join-catalogue-item-licenses [item]
-  (assoc item
-         :licenses
-         (get-licenses {:wfid (:wfid item)
-                        :items [(:id item)]})))
+  (assoc item :licenses (get-licenses {:items [(:id item)]})))
 
 (defn join-license [x]
   (-> (get-license (:license/id x))

--- a/src/clj/rems/db/licenses.clj
+++ b/src/clj/rems/db/licenses.clj
@@ -1,6 +1,6 @@
 (ns rems.db.licenses
   "querying localized licenses"
-  (:require [rems.common.util :refer [distinct-by]]
+  (:require [medley.core :refer [distinct-by]]
             [rems.db.core :as db]))
 
 (defn- format-license [license]

--- a/src/clj/rems/db/licenses.clj
+++ b/src/clj/rems/db/licenses.clj
@@ -68,8 +68,8 @@
 (defn join-catalogue-item-licenses [item]
   (assoc item :licenses (get-licenses {:items [(:id item)]})))
 
-(defn join-license [x]
-  (-> (get-license (:license/id x))
+(defn join-license [{:keys [license/id] :as x}]
+  (-> (get-license id)
       (dissoc :id)
       (merge x)))
 

--- a/src/clj/rems/db/licenses.clj
+++ b/src/clj/rems/db/licenses.clj
@@ -71,3 +71,12 @@
          :licenses
          (get-licenses {:wfid (:wfid item)
                         :items [(:id item)]})))
+
+(defn join-license [x]
+  (-> (get-license (:license/id x))
+      (dissoc :id)
+      (merge x)))
+
+(defn license-exists? [id]
+  (some? (db/get-license {:id id})))
+

--- a/src/clj/rems/db/test_data_helpers.clj
+++ b/src/clj/rems/db/test_data_helpers.clj
@@ -116,9 +116,6 @@
                         :license/text {:fi "fi" :en "en"}
                         :license/attachment-id {:fi fi-attachment :en en-attachment}}))))
 
-(defn create-workflow-licence! [wfid licid]
-  (db/create-workflow-license! {:wfid wfid :licid licid}))
-
 (defn create-form! [{:keys [actor organization]
                      :form/keys [internal-name external-title fields]
                      :as command}]
@@ -146,7 +143,7 @@
     (assert (:success result) {:command command :result result})
     (:id result)))
 
-(defn create-workflow! [{:keys [actor organization title type handlers forms]
+(defn create-workflow! [{:keys [actor organization title type handlers forms licenses]
                          :as command}]
   (let [actor (or actor (create-owner!))
         result (with-user actor
@@ -157,7 +154,8 @@
                    :forms forms
                    :handlers (or handlers
                                  (do (create-user! (get +fake-user-data+ "developer"))
-                                     ["developer"]))}))]
+                                     ["developer"]))
+                   :licenses (mapv (fn [id] {:license/id id}) licenses)}))]
     (assert (:success result) {:command command :result result})
     (:id result)))
 

--- a/src/clj/rems/db/workflow.clj
+++ b/src/clj/rems/db/workflow.clj
@@ -1,12 +1,11 @@
 (ns rems.db.workflow
   (:require [rems.application.events :as events]
             [rems.db.core :as db]
-            [rems.db.licenses :as licenses]
             [rems.db.users :as users]
             [rems.json :as json]
-            [rems.util :refer [getx]]
             [schema.coerce :as coerce]
-            [schema.core :as s]))
+            [schema.core :as s]
+            [medley.core :refer [update-existing-in]]))
 
 (s/defschema WorkflowBody
   {:type (apply s/enum events/workflow-types)
@@ -20,24 +19,21 @@
 (def ^:private validate-workflow-body
   (s/validator WorkflowBody))
 
-(defn create-workflow! [{:keys [organization type title handlers forms]}]
+(defn create-workflow! [{:keys [organization type title handlers forms licenses]}]
   (let [body {:type type
               :handlers handlers
-              :forms forms}]
+              :forms forms
+              :licenses licenses}]
     (:id (db/create-workflow! {:organization (:organization/id organization)
                                :title title
                                :workflow (json/generate-string
                                           (validate-workflow-body body))}))))
 
-(defn- get-workflow-licenses [id]
-  (->> (db/get-workflow-licenses {:wfid id})
-       (mapv #(licenses/get-license (getx % :licid)))))
-
 (defn- enrich-and-format-workflow [wf]
   (-> wf
       (update :workflow #(coerce-workflow-body (json/parse-string %)))
       (update :organization (fn [id] {:organization/id id}))
-      (assoc :licenses (get-workflow-licenses (:id wf)))
+      (update-in [:workflow :licenses] #(mapv (fn [id] {:license/id id}) %))
       (update-in [:workflow :handlers] #(mapv users/get-user %))))
 
 (defn get-workflow [id]
@@ -49,27 +45,25 @@
        (map enrich-and-format-workflow)
        (db/apply-filters filters)))
 
-(defn join-workflow-licenses [workflow]
-  (assoc workflow :licenses (get-workflow-licenses (:id workflow))))
-
 (defn get-all-workflow-roles [userid]
   (when (some #(contains? (set (map :userid (get-in % [:workflow :handlers]))) userid)
               (get-workflows nil))
     #{:handler}))
 
 (defn- unrich-workflow [workflow]
-  ;; TODO: service does this too
   ;; TODO: keep handlers always in the same format, to avoid this conversion (we can ignore extra keys)
-  (if (get-in workflow [:workflow :handlers])
-    (update-in workflow [:workflow :handlers] #(map :userid %))
-    workflow))
+  (-> workflow
+      (update-existing-in [:workflow :handlers] #(map :userid %))
+      (update-existing-in [:workflow :licenses] #(map :license/id %))))
 
-(defn edit-workflow! [{:keys [id organization title handlers]}]
+(defn edit-workflow! [{:keys [id organization title handlers licenses]}]
   (let [workflow (unrich-workflow (get-workflow id))
         workflow-body (cond-> (:workflow workflow)
-                        handlers (assoc :handlers handlers))]
+                        handlers (assoc :handlers handlers)
+                        licenses (assoc :licenses licenses))]
     (db/edit-workflow! {:id (or id (:id workflow))
                         :title (or title (:title workflow))
-                        :organization (or (:organization/id organization) (get-in workflow [:organization :organization/id]))
+                        :organization (or (:organization/id organization)
+                                          (get-in workflow [:organization :organization/id]))
                         :workflow (json/generate-string workflow-body)}))
   {:success true})

--- a/src/clj/rems/db/workflow.clj
+++ b/src/clj/rems/db/workflow.clj
@@ -11,7 +11,8 @@
 (s/defschema WorkflowBody
   {:type (apply s/enum events/workflow-types)
    :handlers [s/Str]
-   (s/optional-key :forms) [{:form/id s/Num}]})
+   (s/optional-key :forms) [{:form/id s/Num}]
+   (s/optional-key :licenses) [s/Int]})
 
 (def ^:private coerce-workflow-body
   (coerce/coercer! WorkflowBody coerce/string-coercion-matcher))

--- a/src/clj/rems/db/workflow.clj
+++ b/src/clj/rems/db/workflow.clj
@@ -56,11 +56,10 @@
       (update-existing-in [:workflow :handlers] #(map :userid %))
       (update-existing-in [:workflow :licenses] #(map :license/id %))))
 
-(defn edit-workflow! [{:keys [id organization title handlers licenses]}]
+(defn edit-workflow! [{:keys [id organization title handlers]}]
   (let [workflow (unrich-workflow (get-workflow id))
         workflow-body (cond-> (:workflow workflow)
-                        handlers (assoc :handlers handlers)
-                        licenses (assoc :licenses licenses))]
+                        handlers (assoc :handlers handlers))]
     (db/edit-workflow! {:id (or id (:id workflow))
                         :title (or title (:title workflow))
                         :organization (or (:organization/id organization)

--- a/src/clj/rems/middleware.clj
+++ b/src/clj/rems/middleware.clj
@@ -14,8 +14,7 @@
             [rems.db.organizations :as organizations]
             [rems.db.roles :as roles]
             [rems.db.user-settings :as user-settings]
-            [rems.db.users :as users]
-            [rems.db.workflow :as workflows]
+            [rems.db.workflow :as workflow]
             [rems.layout :refer [error-page]]
             [rems.logging :refer [with-mdc]]
             [rems.middleware.dev :refer [wrap-dev]]
@@ -71,7 +70,7 @@
                                (when context/*user*
                                  (set/union (roles/get-roles (getx-user-id))
                                             (organizations/get-all-organization-roles (getx-user-id))
-                                            (workflows/get-all-workflow-roles (getx-user-id))
+                                            (workflow/get-all-workflow-roles (getx-user-id))
                                             (applications/get-all-application-roles (getx-user-id))))
                                (when (:uses-valid-api-key? request)
                                  #{:api-key}))]

--- a/src/clj/rems/migrations/refactor_workflow_licenses.clj
+++ b/src/clj/rems/migrations/refactor_workflow_licenses.clj
@@ -1,0 +1,55 @@
+(ns rems.migrations.refactor-workflow-licenses
+  (:require [clojure.test :refer [deftest is]]
+            [hugsql.core :as hugsql]
+            [rems.json :as json]
+            [rems.common.util :refer [build-index]]))
+
+(hugsql/def-db-fns-from-string
+  "
+-- :name get-workflow-licenses :*
+SELECT wfid, licid FROM workflow_licenses;
+   
+-- :name get-workflow :? :1
+SELECT id, workflowbody::TEXT
+FROM workflow
+WHERE id = :id;
+   
+-- :name set-workflow-body! :!
+UPDATE workflow
+SET workflowBody = :workflowbody::jsonb
+WHERE id = :id;
+")
+
+(defn migrate-workflow-licenses [workflow licenses]
+  (assoc-in workflow [:workflowbody :licenses] (sort licenses)))
+
+(defn migrate-workflows! [conn workflow-licenses]
+  (let [workflows (->> workflow-licenses
+                       (build-index {:keys [:wfid]
+                                     :value-fn :licid
+                                     :collect-fn set}))]
+    (doseq [[wfid licenses] workflows
+            :let [workflow (get-workflow conn {:id wfid})
+                  _ (assert workflow)
+                  workflow (update workflow :workflowbody json/parse-string)]]
+      (set-workflow-body! conn (update (migrate-workflow-licenses workflow licenses)
+                                       :workflowbody
+                                       json/generate-string)))))
+
+(deftest test-migrate-workflows!
+  (let [workflow-licenses [{:wfid 1 :licid 10}
+                           {:wfid 1 :licid 11}
+                           {:wfid 2 :licid 12}]
+        workflows (atom [])]
+    (with-redefs [get-workflow (fn [_ {:keys [id]}]
+                                 {:id id
+                                  :workflowbody (json/generate-string {})})
+                  set-workflow-body! (fn [_ wf] (swap! workflows conj wf))]
+      (migrate-workflows! nil workflow-licenses)
+      (is (= [{:id 1 :workflowbody {:licenses [10 11]}}
+              {:id 2 :workflowbody {:licenses [12]}}]
+             (->> @workflows
+                  (mapv #(update % :workflowbody json/parse-string))))))))
+
+(defn migrate-up [{:keys [conn]}]
+  (migrate-workflows! conn (get-workflow-licenses conn)))

--- a/src/clj/rems/schema_base.clj
+++ b/src/clj/rems/schema_base.clj
@@ -114,3 +114,6 @@
   (merge Category
          {(s/optional-key :category/children) [Category]}))
 
+(s/defschema LicenseId
+  {:license/id s/Int})
+

--- a/src/cljc/rems/common/util.cljc
+++ b/src/cljc/rems/common/util.cljc
@@ -1,5 +1,5 @@
 (ns rems.common.util
-  (:require [medley.core :refer [map-vals]]
+  (:require [medley.core :refer [map-keys map-vals remove-keys]]
             [clojure.set :as set]
             [clojure.string :as str]
             [clojure.test :refer [deftest is testing]]))
@@ -608,3 +608,12 @@
     (is (= "id_123-element" (escape-element-id "123-element")))
     (is (= "id__123-element" (escape-element-id " 123-element")))))
 
+(defn keep-keys [f coll]
+  (->> coll
+       (map-keys f)
+       (remove-keys nil?)))
+
+(deftest test-keep-keys
+  (is (= {} (keep-keys {} {})))
+  (is (= {:b 1 :c 2} (keep-keys {:a :b :b :c} {:a 1 :b 2})))
+  (is (= {:b 1} (keep-keys {:a :b} {:a 1 :b 2}))))

--- a/src/cljc/rems/common/util.cljc
+++ b/src/cljc/rems/common/util.cljc
@@ -382,14 +382,6 @@
                         {:id 4 :unrelated "is destroyed in a cycle"}
                         {:id 5 :unrelated "survives"}])))))
 
-(defn distinct-by
-  "Remove duplicates from sequence, comparing the value returned by key-fn.
-   The first element that key-fn returns a given value for is retained.
-
-   Order of sequence is not preserved in any way."
-  [key-fn sequence]
-  (map first (vals (group-by key-fn sequence))))
-
 (defn andstr
   "Like `apply str coll` but only produces something if all the
   values are truthy like with `and`.
@@ -545,7 +537,10 @@
   (is (= "src/foo/bar.clj" (normalize-file-path "/home/john/rems/src/foo/bar.clj")))
   (is (= "src/foo/bar.clj" (normalize-file-path "C:\\Users\\john\\rems\\src\\foo/bar.clj"))))
 
-(defn assoc-some-in [m ks v]
+(defn assoc-some-in
+  "Like `clojure.core/assoc-in`, but only associates value `v` in key path
+   `ks` of associate collection `m` when `(true? (some? v)))`."
+  [m ks v]
   (if (some? v)
     (assoc-in m ks v)
     m))
@@ -594,7 +589,10 @@
   (is (= {:a 1 :b true} (update-present {:a 1 :b nil} :b (constantly true)))))
 
 ;; https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/id
-(defn escape-element-id [id]
+(defn escape-element-id
+  "Replaces non-conforming characters from string `id` for the purpose
+   of creating an identifier suitable for HTML element id."
+  [id]
   (when (string? id)
     (-> id
         (str/replace #"[^A-Za-z0-9\-\_]" "_") ; "only ASCII letters, digits, '_', and '-' should be used,"
@@ -608,12 +606,17 @@
     (is (= "id_123-element" (escape-element-id "123-element")))
     (is (= "id__123-element" (escape-element-id " 123-element")))))
 
-(defn keep-keys [f coll]
+(defn keep-keys
+  "Takes a sequence of associative collections and maps function `f`
+   over keys of each, returning a new associative collection with
+   non-nil keys. Useful for renaming and selecting only a subset of
+   associative collection keys."
+  [f coll]
   (->> coll
-       (map-keys f)
-       (remove-keys nil?)))
+       (map (partial map-keys f))
+       (map (partial remove-keys nil?))))
 
 (deftest test-keep-keys
-  (is (= {} (keep-keys {} {})))
-  (is (= {:b 1 :c 2} (keep-keys {:a :b :b :c} {:a 1 :b 2})))
-  (is (= {:b 1} (keep-keys {:a :b} {:a 1 :b 2}))))
+  (is (= [] (keep-keys {} [])))
+  (is (= [{:b 1}] (keep-keys {:a :b} [{:a 1}])))
+  (is (= [{:b 1} {:c 2}] (keep-keys {:a :b :b :c} [{:a 1} {:b 2}]))))

--- a/src/cljs/rems/administration/create_workflow.cljs
+++ b/src/cljs/rems/administration/create_workflow.cljs
@@ -76,8 +76,7 @@
                   :title (trim-when-string (:title form))
                   :type (:type form)
                   :forms (mapv #(select-keys % [:form/id]) (:forms form))
-                  :licenses (->> (:licenses form)
-                                 (mapv #(keep-keys {:id :license/id} %)))}
+                  :licenses (vec (keep-keys {:id :license/id} (:licenses form)))}
                  (when (needs-handlers? (:type form))
                    {:handlers (map :userid (:handlers form))}))]
     (when (valid-create-request? request)

--- a/src/cljs/rems/administration/create_workflow.cljs
+++ b/src/cljs/rems/administration/create_workflow.cljs
@@ -93,9 +93,7 @@
   (let [request {:organization {:organization/id (get-in form [:organization :organization/id])}
                  :id id
                  :title (:title form)
-                 :handlers (map :userid (:handlers form))
-                 :licenses (->> (:licenses form)
-                                (map #(keep-keys {:id :license/id} %)))}]
+                 :handlers (map :userid (:handlers form))}]
     (when (valid-edit-request? request)
       request)))
 

--- a/src/cljs/rems/administration/workflow.cljs
+++ b/src/cljs/rems/administration/workflow.cljs
@@ -63,19 +63,19 @@
                                                                          (str/join ", "))]
               [inline-info-field (text :t.administration/active) [readonly-checkbox {:value (status-flags/active? workflow)}]]
               [inline-info-field (text :t.administration/forms)
-               (into [:ul.list-group]
-                     (for [form (get-in workflow [:workflow :forms])
-                           :let [uri (str "/administration/forms/" (:form/id form))
-                                 title (:form/internal-name form)]]
-                       [:li.list-group-item [atoms/link nil uri title]]))
-               {:box? false}]
+               (->> (for [form (get-in workflow [:workflow :forms])
+                          :let [uri (str "/administration/forms/" (:form/id form))
+                                title (:form/internal-name form)]]
+                      [atoms/link nil uri title])
+                    (interpose ", ")
+                    (into [:<>]))]
               [inline-info-field (text :t.administration/licenses)
-               (into [:ul.list-group]
-                     (for [license (get-in workflow [:workflow :licenses])
-                           :let [uri (str "/administration/licenses/" (:license/id license))
-                                 title (:title (localized (:localizations license)))]]
-                       [:li.list-group-item [atoms/link nil uri title]]))
-               {:box? false}]]}]
+               (->> (for [license (get-in workflow [:workflow :licenses])
+                          :let [uri (str "/administration/licenses/" (:license/id license))
+                                title (:title (localized (:localizations license)))]]
+                      [atoms/link nil uri title])
+                    (interpose ", ")
+                    (into [:<>]))]]}]
    (let [id (:id workflow)]
      [:div.col.commands
       [administration/back-button "/administration/workflows"]

--- a/src/cljs/rems/administration/workflow.cljs
+++ b/src/cljs/rems/administration/workflow.cljs
@@ -68,7 +68,7 @@
                      (for [form (get-in workflow [:workflow :forms])]
                        [:li.list-group-item [atoms/link nil (str "/administration/forms/" (:form/id form)) (:form/internal-name form)]]))
                {:box? false}]]}]
-   [licenses-view (:licenses workflow) language]
+   [licenses-view (get-in workflow [:workflow :licenses]) language]
    (let [id (:id workflow)]
      [:div.col.commands
       [administration/back-button "/administration/workflows"]

--- a/src/cljs/rems/administration/workflow.cljs
+++ b/src/cljs/rems/administration/workflow.cljs
@@ -3,7 +3,6 @@
             [re-frame.core :as rf]
             [rems.administration.administration :as administration]
             [rems.administration.components :refer [inline-info-field]]
-            [rems.administration.license :refer [licenses-view]]
             [rems.administration.status-flags :as status-flags]
             [rems.atoms :as atoms :refer [document-title enrich-user readonly-checkbox]]
             [rems.collapsible :as collapsible]
@@ -11,7 +10,7 @@
             [rems.flash-message :as flash-message]
             [rems.common.roles :as roles]
             [rems.spinner :as spinner]
-            [rems.text :refer [text]]
+            [rems.text :refer [localized text]]
             [rems.util :refer [fetch]]))
 
 (rf/reg-event-fx
@@ -65,10 +64,18 @@
               [inline-info-field (text :t.administration/active) [readonly-checkbox {:value (status-flags/active? workflow)}]]
               [inline-info-field (text :t.administration/forms)
                (into [:ul.list-group]
-                     (for [form (get-in workflow [:workflow :forms])]
-                       [:li.list-group-item [atoms/link nil (str "/administration/forms/" (:form/id form)) (:form/internal-name form)]]))
+                     (for [form (get-in workflow [:workflow :forms])
+                           :let [uri (str "/administration/forms/" (:form/id form))
+                                 title (:form/internal-name form)]]
+                       [:li.list-group-item [atoms/link nil uri title]]))
+               {:box? false}]
+              [inline-info-field (text :t.administration/licenses)
+               (into [:ul.list-group]
+                     (for [license (get-in workflow [:workflow :licenses])
+                           :let [uri (str "/administration/licenses/" (:license/id license))
+                                 title (:title (localized (:localizations license)))]]
+                       [:li.list-group-item [atoms/link nil uri title]]))
                {:box? false}]]}]
-   [licenses-view (get-in workflow [:workflow :licenses]) language]
    (let [id (:id workflow)]
      [:div.col.commands
       [administration/back-button "/administration/workflows"]

--- a/test/clj/rems/api/services/test_dependencies.clj
+++ b/test/clj/rems/api/services/test_dependencies.clj
@@ -22,7 +22,9 @@
         cat-form (test-helpers/create-form! {})
         unused-form (test-helpers/create-form! {})
         wf-1 (test-helpers/create-workflow! {:forms [{:form/id shared-form}]})
-        wf-2 (test-helpers/create-workflow! {:forms [{:form/id wf-form} {:form/id shared-form}]})
+        wf-2 (test-helpers/create-workflow! {:forms [{:form/id wf-form}
+                                                     {:form/id shared-form}]
+                                             :licenses [shared-license]})
         category-1 (test-helpers/create-category! {:category/title {:fi "Testikategoria"
                                                                     :en "Test category"
                                                                     :sv "Test kategori"}
@@ -40,8 +42,6 @@
         cat-2 (test-helpers/create-catalogue-item! {:resource-id res-1
                                                     :form-id shared-form
                                                     :workflow-id wf-2})]
-    ;; TODO no public way to set workflow licenses for now
-    (db/create-workflow-license! {:wfid wf-2 :licid shared-license})
 
     (testing "dependencies"
       (is (= {:dependencies

--- a/test/clj/rems/api/services/test_workflow.clj
+++ b/test/clj/rems/api/services/test_workflow.clj
@@ -92,11 +92,12 @@
   (with-user "owner"
     (test-helpers/create-organization! {:organization/id "abc" :organization/name {:en "ABC"} :organization/short-name {:en "ABC"}})
     (testing "change title"
-      (let [wf-id (test-helpers/create-workflow! {:organization {:organization/id "abc"}
+      (let [licid (test-helpers/create-license! {:organization {:organization/id "abc"}})
+            wf-id (test-helpers/create-workflow! {:organization {:organization/id "abc"}
                                                   :type :workflow/master
                                                   :title "original title"
                                                   :handlers ["user1"]
-                                                  :licenses [1]})]
+                                                  :licenses [licid]})]
         (workflow/edit-workflow! {:id wf-id
                                   :title "changed title"})
         (is (= {:id wf-id
@@ -104,9 +105,11 @@
                 :workflow {:type :workflow/master
                            :handlers [{:userid "user1" :name "User 1" :email "user1@example.com"}]
                            :forms []
-                           :licenses [{:license/id 1}]}}
+                           :licenses [{:license/id licid}]}}
                (-> (workflow/get-workflow wf-id)
-                   (select-keys [:id :title :workflow]))))))
+                   (select-keys [:id :title :workflow])
+                   (update-in [:workflow :licenses]
+                              (partial map #(select-keys % [:license/id]))))))))
 
     (testing "change handlers"
       (let [wf-id (test-helpers/create-workflow! {:organization {:organization/id "abc"}

--- a/test/clj/rems/api/services/test_workflow.clj
+++ b/test/clj/rems/api/services/test_workflow.clj
@@ -95,7 +95,8 @@
       (let [wf-id (test-helpers/create-workflow! {:organization {:organization/id "abc"}
                                                   :type :workflow/master
                                                   :title "original title"
-                                                  :handlers ["user1"]})]
+                                                  :handlers ["user1"]
+                                                  :licenses [1]})]
         (workflow/edit-workflow! {:id wf-id
                                   :title "changed title"})
         (is (= {:id wf-id
@@ -103,7 +104,7 @@
                 :workflow {:type :workflow/master
                            :handlers [{:userid "user1" :name "User 1" :email "user1@example.com"}]
                            :forms []
-                           :licenses []}}
+                           :licenses [{:license/id 1}]}}
                (-> (workflow/get-workflow wf-id)
                    (select-keys [:id :title :workflow]))))))
 
@@ -120,40 +121,6 @@
                            :handlers [{:userid "user2" :name "User 2" :email "user2@example.com"}]
                            :forms []
                            :licenses []}}
-               (-> (workflow/get-workflow wf-id)
-                   (select-keys [:id :title :workflow]))))))
-
-    (testing "change licenses"
-      (let [licid (test-helpers/create-license! {:organization {:organization/id "abc"}})
-            licid-2 (test-helpers/create-license! {:organization {:organization/id "abc"}})
-            wf-id (test-helpers/create-workflow! {:organization {:organization/id "abc"}
-                                                  :type :workflow/master
-                                                  :title "original title"
-                                                  :handlers ["user1"]
-                                                  :licenses [licid]})
-            get-license (fn [id]
-                          {:license/id id
-                           :archived false
-                           :enabled true
-                           :licensetype "text"
-                           :localizations {}
-                           :organization {:organization/id "abc"
-                                          :organization/name {:en "ABC"}
-                                          :organization/short-name {:en "ABC"}}})
-            expected {:id wf-id
-                      :title "original title"
-                      :workflow {:type :workflow/master
-                                 :handlers [{:userid "user1"
-                                             :name "User 1"
-                                             :email "user1@example.com"}]
-                                 :forms []
-                                 :licenses [(get-license licid)]}}]
-        (is (= expected (-> (workflow/get-workflow wf-id)
-                            (select-keys [:id :title :workflow]))))
-        (is (:success (workflow/edit-workflow! {:id wf-id
-                                                :licenses [{:license/id licid-2}]})))
-        (is (= (-> expected
-                   (assoc-in [:workflow :licenses] [(get-license licid-2)]))
                (-> (workflow/get-workflow wf-id)
                    (select-keys [:id :title :workflow]))))))))
 

--- a/test/clj/rems/api/test_administration.clj
+++ b/test/clj/rems/api/test_administration.clj
@@ -3,6 +3,7 @@
   (:require [clojure.test :refer :all]
             [rems.api.testing :refer :all]
             [rems.db.core :as db]
+            [rems.db.workflow :as workflow]
             [rems.db.testing :refer [owners-fixture +test-api-key+]]))
 
 (use-fixtures
@@ -32,7 +33,9 @@
         workflow-id (:id (api-call :post "/api/workflows/create"
                                    {:organization {:organization/id "organization2"} :title "default workflow"
                                     :forms [{:form/id wf-form-id}]
-                                    :type :workflow/default :handlers ["owner"]}
+                                    :type :workflow/default
+                                    :handlers ["owner"]
+                                    :licenses [{:license/id license-id}]}
                                    +test-api-key+ "owner"))
         catalogue-id (:id (api-call :post "/api/catalogue-items/create"
                                     {:form form-id
@@ -96,9 +99,6 @@
     (is form-id)
     (is workflow-id)
     (is catalogue-id)
-
-    ;; no api for this yet
-    (db/create-workflow-license! {:wfid workflow-id :licid license-id})
 
     (testing "can disable a resource"
       (is (:success (resource-enabled! false))))

--- a/test/clj/rems/application/test_commands.clj
+++ b/test/clj/rems/application/test_commands.clj
@@ -116,11 +116,11 @@
                  id))))
 
 (defn- dummy-get-catalogue-item-licenses [id]
-  (getx {1 [{:id 1}]
-         2 [{:id 2}]
-         3 [{:id 1}
-            {:id 2}
-            {:id 3}]
+  (getx {1 [{:license/id 1}]
+         2 [{:license/id 2}]
+         3 [{:license/id 1}
+            {:license/id 2}
+            {:license/id 3}]
          4 []
          5 []
          6 []} id))
@@ -577,10 +577,10 @@
                      cat-3-other-workflow {:id cat-3-other-workflow :resid "res3" :formid form-1 :wfid wf-2}
                      cat-4-other-form {:id cat-4-other-form :resid "res4" :formid form-2 :wfid wf-1}}
                     :get-catalogue-item-licenses
-                    {cat-1 [{:id license-1}]
-                     cat-2-other-license [{:id license-2}]
-                     cat-3-other-workflow [{:id license-1}]
-                     cat-4-other-form [{:id license-1}]}
+                    {cat-1 [{:license/id license-1}]
+                     cat-2-other-license [{:license/id license-2}]
+                     cat-3-other-workflow [{:license/id license-1}]
+                     cat-4-other-form [{:license/id license-1}]}
                     :valid-user? (:valid-user? injections)}]
 
     (testing "applicant can add resources to a draft application"

--- a/test/clj/rems/application/test_model.clj
+++ b/test/clj/rems/application/test_model.clj
@@ -569,10 +569,10 @@
                                            :application/modified (DateTime. 3500)
                                            :application/events (conj (:application/events submitted-application)
                                                                      licenses-added-event)
-                                           :application/licenses [{:license/id 30}
+                                           :application/licenses [{:license/id 33}
+                                                                  {:license/id 30}
                                                                   {:license/id 31}
-                                                                  {:license/id 32}
-                                                                  {:license/id 33}]})]
+                                                                  {:license/id 32}]})]
     (is (= licenses-added-application (recreate licenses-added-application)))))
 
 (deftest test-application-view-copied

--- a/test/clj/rems/application/test_model.clj
+++ b/test/clj/rems/application/test_model.clj
@@ -222,8 +222,8 @@
        :organization {:organization/id "org" :organization/name {:fi "Organisaatio" :en "Organization"} :organization/short-name {:fi "ORG" :en "ORG"}}
        :title "workflow title"
        :workflow {:type "workflow/dynamic"
-                  :handlers [(get-user "handler")]}
-       :licenses nil
+                  :handlers [(get-user "handler")]
+                  :licenses []}
        :enabled true
        :archived false}})
 
@@ -569,10 +569,10 @@
                                            :application/modified (DateTime. 3500)
                                            :application/events (conj (:application/events submitted-application)
                                                                      licenses-added-event)
-                                           :application/licenses [{:license/id 33}
-                                                                  {:license/id 30}
+                                           :application/licenses [{:license/id 30}
                                                                   {:license/id 31}
-                                                                  {:license/id 32}]})]
+                                                                  {:license/id 32}
+                                                                  {:license/id 33}]})]
     (is (= licenses-added-application (recreate licenses-added-application)))))
 
 (deftest test-application-view-copied

--- a/test/clj/rems/browser_test_util.clj
+++ b/test/clj/rems/browser_test_util.clj
@@ -192,12 +192,16 @@
                                             :license/text {:en (apply str (repeat 10 "License text in English. "))
                                                            :fi (apply str (repeat 10 "Suomenkielinen lisenssiteksti. "))
                                                            :sv (apply str (repeat 10 "Licens på svenska. "))}})
-        wfid (test-helpers/create-workflow! {:type :workflow/default :title "Default workflow" :handlers ["handler" "developer"]})
+        wfid (test-helpers/create-workflow! {:type :workflow/default
+                                             :title "Default workflow"
+                                             :handlers ["handler" "developer"]
+                                             :licenses [link text]})
         decider-wf (test-helpers/create-workflow! {:actor "owner"
                                                    :organization {:organization/id "nbn"}
                                                    :title "Decider workflow"
                                                    :type :workflow/decider
-                                                   :handlers ["carl" "handler"]})
+                                                   :handlers ["carl" "handler"]
+                                                   :licenses [link text]})
         form (test-data/create-all-field-types-example-form! "owner" {:organization/id "nbn"} "Example form with all field types" {:en "Example form with all field types"
                                                                                                                                    :fi "Esimerkkilomake kaikin kenttätyypein"
                                                                                                                                    :sv "Exempelblankett med alla fälttyper"})
@@ -247,10 +251,6 @@
         ;; item-id3 (test-helpers/create-catalogue-item! {:form-id _simple-form :workflow-id wfid :title {:en "Default workflow with DUO codes" :fi "Oletustyövuo DUO-koodeilla"
         ;;                                                                                                :sv "Standard blankettarbetsflöde med DUO-koder"} :resource-id duo-resource})
         app-id (test-helpers/create-draft! "applicant" [item-id1] "draft")]
-    (test-helpers/create-workflow-licence! wfid link)
-    (test-helpers/create-workflow-licence! wfid text)
-    (test-helpers/create-workflow-licence! decider-wf link)
-    (test-helpers/create-workflow-licence! decider-wf text)
     (test-helpers/submit-application {:application-id app-id
                                       :actor "applicant"}))
   (f))

--- a/test/clj/rems/db/test_applications.clj
+++ b/test/clj/rems/db/test_applications.clj
@@ -8,6 +8,7 @@
             [rems.db.events :as db-events]
             [rems.db.test-data-helpers :as test-helpers]
             [rems.db.testing :refer [test-db-fixture rollback-db-fixture]]
+            [rems.db.workflow :as workflow]
             [rems.util :refer [try-catch-ex]]
             [schema-generators.generators :as sg])
   (:import [clojure.lang ExceptionInfo]
@@ -61,8 +62,7 @@
 
     (testing "workflow licenses"
       (let [lic-id (test-helpers/create-license! {})
-            wf-id (test-helpers/create-workflow! {})
-            _ (db/create-workflow-license! {:wfid wf-id :licid lic-id})
+            wf-id (test-helpers/create-workflow! {:licenses [lic-id]})
             res-id (test-helpers/create-resource! {:resource-ext-id (str (UUID/randomUUID))})
             cat-id (test-helpers/create-catalogue-item! {:resource-id res-id
                                                          :form-id form-id

--- a/test/clj/rems/db/test_applications.clj
+++ b/test/clj/rems/db/test_applications.clj
@@ -8,7 +8,6 @@
             [rems.db.events :as db-events]
             [rems.db.test-data-helpers :as test-helpers]
             [rems.db.testing :refer [test-db-fixture rollback-db-fixture]]
-            [rems.db.workflow :as workflow]
             [rems.util :refer [try-catch-ex]]
             [schema-generators.generators :as sg])
   (:import [clojure.lang ExceptionInfo]

--- a/test/clj/rems/db/test_applications.clj
+++ b/test/clj/rems/db/test_applications.clj
@@ -58,7 +58,7 @@
                                                          :form-id form-id
                                                          :workflow-id wf-id})]
         (is (= [lic-id]
-               (map :id (applications/get-catalogue-item-licenses cat-id))))))
+               (map :license/id (applications/get-catalogue-item-licenses cat-id))))))
 
     (testing "workflow licenses"
       (let [lic-id (test-helpers/create-license! {})
@@ -68,7 +68,7 @@
                                                          :form-id form-id
                                                          :workflow-id wf-id})]
         (is (= [lic-id]
-               (map :id (applications/get-catalogue-item-licenses cat-id))))))))
+               (map :license/id (applications/get-catalogue-item-licenses cat-id))))))))
 
 (deftest test-application-external-id!
   (let [application-external-id! @#'applications/application-external-id!]

--- a/test/clj/rems/db/test_workflow.clj
+++ b/test/clj/rems/db/test_workflow.clj
@@ -22,16 +22,17 @@
                                          :type :workflow/default
                                          :title "test-crud-workflow-title"
                                          :handlers ["bob" "handler"]
-                                         :forms []})]
+                                         :forms []
+                                         :licenses []})]
       (is (number? id))
       (is (= {:archived false
-              :licenses []
               :organization {:organization/id "abc"}
               :title "test-crud-workflow-title"
               :workflow {:type :workflow/default
                          :handlers [{:userid "bob" :name nil :email nil}
                                     {:userid "handler" :name nil :email nil}]
-                         :forms []}
+                         :forms []
+                         :licenses []}
               :id id
               :enabled true}
              (workflow/get-workflow id)))
@@ -40,14 +41,14 @@
         (workflow/edit-workflow! {:id id
                                   :handlers ["bob" "handler" "alice"]})
         (is (= {:archived false
-                :licenses []
                 :organization {:organization/id "abc"}
                 :title "test-crud-workflow-title"
                 :workflow {:type :workflow/default
                            :handlers [{:userid "bob" :name nil :email nil}
                                       {:userid "handler" :name nil :email nil}
                                       {:userid "alice" :name nil :email nil}]
-                           :forms []}
+                           :forms []
+                           :licenses []}
                 :id id
                 :enabled true}
                (workflow/get-workflow id)))))))

--- a/test/clj/rems/test_browser.clj
+++ b/test/clj/rems/test_browser.clj
@@ -2239,11 +2239,9 @@
               "Type" "Decider workflow"
               "Handlers" "Carl Reviewer (carl@example.com), Hannah Handler (handler@example.com)"
               "Forms" "Simple form"
+              "Licenses" "General Terms of Use"
               "Active" true}
-             (slurp-fields :workflow)))
-      (is (= ["License \"General Terms of Use\""]
-             (->> (btu/query-all {:class :license-title})
-                  (map btu/get-element-text-el)))))
+             (slurp-fields :workflow))))
     (testing "edit workflow"
       (btu/scroll-and-click {:fn/has-class :edit-workflow})
       (is (btu/eventually-visible? {:tag :h1 :fn/text "Edit workflow"}))
@@ -2268,12 +2266,9 @@
               "Type" "Decider workflow"
               "Handlers" "Carl Reviewer (carl@example.com), Hannah Handler (handler@example.com), Reporter (reporter@example.com)"
               "Forms" "Simple form"
+              "Licenses" "CC Attribution 4.0\nGeneral Terms of Use"
               "Active" true}
              (slurp-fields :workflow)))
-      (is (= ["License \"CC Attribution 4.0\""
-              "License \"General Terms of Use\""]
-             (->> (btu/query-all {:class :license-title})
-                  (map btu/get-element-text-el))))
       (is (btu/visible? {:tag :a :fn/text "Simple form"})))))
 
 (deftest test-blacklist

--- a/test/clj/rems/test_browser.clj
+++ b/test/clj/rems/test_browser.clj
@@ -900,7 +900,8 @@
                 "Type" "Master workflow"
                 "Handlers" "Invited Person Name (invite-person-id@example.com)"
                 "Active" true
-                "Forms" ""}
+                "Forms" ""
+                "Licenses" ""}
                (slurp-fields :workflow)))))))
 
 (deftest test-invite-reviewer

--- a/test/clj/rems/test_browser.clj
+++ b/test/clj/rems/test_browser.clj
@@ -1207,6 +1207,7 @@
               "Type" "Default workflow"
               "Handlers" "Hannah Handler (handler@example.com)"
               "Forms" ""
+              "Licenses" ""
               "Active" true}
              (slurp-fields :workflow)))
       (go-to-admin "Workflows")

--- a/test/clj/rems/test_browser.clj
+++ b/test/clj/rems/test_browser.clj
@@ -2226,6 +2226,7 @@
       (select-option "Handlers" "handler")
       (select-option "Handlers" "carl")
       (select-option "Forms" "Simple form")
+      (select-option "Licenses" "General Terms of Use")
       (btu/screenshot "test-workflow-create-edit-1.png")
       (btu/scroll-and-click :save))
     (testing "view workflow"
@@ -2239,7 +2240,10 @@
               "Handlers" "Carl Reviewer (carl@example.com), Hannah Handler (handler@example.com)"
               "Forms" "Simple form"
               "Active" true}
-             (slurp-fields :workflow))))
+             (slurp-fields :workflow)))
+      (is (= ["License \"General Terms of Use\""]
+             (->> (btu/query-all {:class :license-title})
+                  (map btu/get-element-text-el)))))
     (testing "edit workflow"
       (btu/scroll-and-click {:fn/has-class :edit-workflow})
       (is (btu/eventually-visible? {:tag :h1 :fn/text "Edit workflow"}))
@@ -2251,6 +2255,7 @@
       ;; removing an item is hard to script reliably, so let's just add one
       (select-option "Handlers" "reporter")
       (is (= "Simple form" (btu/get-element-text {:tag :div :id :workflow-forms}))) ; readonly field
+      (select-option "Licenses" "CC Attribution 4.0")
       (btu/screenshot "test-workflow-create-edit-4.png")
       (btu/scroll-and-click :save))
     (testing "view workflow again"
@@ -2265,6 +2270,10 @@
               "Forms" "Simple form"
               "Active" true}
              (slurp-fields :workflow)))
+      (is (= ["License \"CC Attribution 4.0\""
+              "License \"General Terms of Use\""]
+             (->> (btu/query-all {:class :license-title})
+                  (map btu/get-element-text-el))))
       (is (btu/visible? {:tag :a :fn/text "Simple form"})))))
 
 (deftest test-blacklist

--- a/test/clj/rems/test_browser.clj
+++ b/test/clj/rems/test_browser.clj
@@ -2255,7 +2255,7 @@
       ;; removing an item is hard to script reliably, so let's just add one
       (select-option "Handlers" "reporter")
       (is (= "Simple form" (btu/get-element-text {:tag :div :id :workflow-forms}))) ; readonly field
-      (is (= "CC Attribution 4.0" (btu/get-element-text {:tag :div :id :workflow-licenses}))) ; readonly field
+      (is (= "General Terms of Use" (btu/get-element-text {:tag :div :id :workflow-licenses}))) ; readonly field
       (btu/screenshot "test-workflow-create-edit-4.png")
       (btu/scroll-and-click :save))
     (testing "view workflow again"

--- a/test/clj/rems/test_browser.clj
+++ b/test/clj/rems/test_browser.clj
@@ -2326,7 +2326,7 @@
               "Type" "Decider workflow"
               "Handlers" "Carl Reviewer (carl@example.com), Hannah Handler (handler@example.com), Reporter (reporter@example.com)"
               "Forms" "Simple form"
-              "Licenses" "CC Attribution 4.0"
+              "Licenses" "General Terms of Use"
               "Active" true}
              (slurp-fields :workflow)))
       (is (btu/visible? {:tag :a :fn/text "Simple form"})))))

--- a/test/clj/rems/test_browser.clj
+++ b/test/clj/rems/test_browser.clj
@@ -2255,7 +2255,7 @@
       ;; removing an item is hard to script reliably, so let's just add one
       (select-option "Handlers" "reporter")
       (is (= "Simple form" (btu/get-element-text {:tag :div :id :workflow-forms}))) ; readonly field
-      (select-option "Licenses" "CC Attribution 4.0")
+      (is (= "CC Attribution 4.0" (btu/get-element-text {:tag :div :id :workflow-licenses}))) ; readonly field
       (btu/screenshot "test-workflow-create-edit-4.png")
       (btu/scroll-and-click :save))
     (testing "view workflow again"
@@ -2268,7 +2268,7 @@
               "Type" "Decider workflow"
               "Handlers" "Carl Reviewer (carl@example.com), Hannah Handler (handler@example.com), Reporter (reporter@example.com)"
               "Forms" "Simple form"
-              "Licenses" "CC Attribution 4.0\nGeneral Terms of Use"
+              "Licenses" "CC Attribution 4.0"
               "Active" true}
              (slurp-fields :workflow)))
       (is (btu/visible? {:tag :a :fn/text "Simple form"})))))

--- a/test/cljc/rems/common/test_util.cljc
+++ b/test/cljc/rems/common/test_util.cljc
@@ -1,6 +1,6 @@
 (ns rems.common.test-util
   (:require [clojure.test :refer [deftest is testing]]
-            [rems.common.util :refer [select-vals distinct-by]]))
+            [rems.common.util :refer [select-vals]]))
 
 (deftest select-vals-test
   (is (= [] (select-vals nil nil)))
@@ -11,6 +11,3 @@
     (is (= [1 3 2 :nope 3]
            (select-vals {:e 3 :b 2 :c 3 :a 1} [:a :e :b :d :e] :nope)))))
 
-(deftest test-distinct-by
-  (is (= [1 2]
-         (sort (distinct-by even? [1 2 3 4])))))

--- a/test/cljs/rems/administration/test_create_workflow.cljs
+++ b/test/cljs/rems/administration/test_create_workflow.cljs
@@ -8,9 +8,12 @@
                 :title "workflow title"
                 :type :workflow/default
                 :forms [{:form/id 123}]
-                :handlers ["bob"]}]
+                :handlers ["bob"]
+                :licenses [{:id 1}]}]
       (is (not (nil? (build-create-request form))))
-      (is (not (nil? (build-create-request (dissoc form :forms)))))
+      (is (not (nil? (build-create-request (dissoc form :forms :licenses)))))
+      (is (= {:licenses [{:license/id 1}]}
+             (select-keys (build-create-request form) [:licenses])))
       (testing "missing organization"
         (is (nil? (build-create-request (assoc form :organization nil)))))
       (testing "missing title"
@@ -74,9 +77,11 @@
   (is (= {:id 3
           :organization {:organization/id "o"}
           :title "t"
-          :handlers ["a" "b"]
-          :licenses []}
-         (build-edit-request 3 {:organization {:organization/id "o"} :title "t" :handlers [{:userid "a"} {:userid "b"}]})))
+          :handlers ["a" "b"]}
+         (build-edit-request 3 {:organization {:organization/id "o"}
+                                :title "t"
+                                :handlers [{:userid "a"} {:userid "b"}]
+                                :licenses [{:id 1}]}))) ; licenses should not be mapped
   (is (nil? (build-edit-request nil {:title "t" :handlers [{:userid "a"} {:userid "b"}]})))
   (is (nil? (build-edit-request 3 {:title "t" :handlers [{:userid "a"} {:userid "b"}]})))
   (is (nil? (build-edit-request 3 {:organization {:organization/id "o"} :title "" :handlers [{:userid "a"} {:userid "b"}]})))

--- a/test/cljs/rems/administration/test_create_workflow.cljs
+++ b/test/cljs/rems/administration/test_create_workflow.cljs
@@ -31,7 +31,8 @@
                 :title "workflow title"
                 :type :workflow/default
                 :forms [{:form/id 13}]
-                :handlers ["bob" "carl"]}
+                :handlers ["bob" "carl"]
+                :licenses []}
                (build-create-request form))))
       (testing "missing handlers"
         (is (nil? (build-create-request (assoc-in form [:handlers] [])))))))
@@ -47,7 +48,8 @@
                 :title "workflow title"
                 :type :workflow/decider
                 :forms [{:form/id 13}]
-                :handlers ["bob" "carl"]}
+                :handlers ["bob" "carl"]
+                :licenses []}
                (build-create-request form))))
       (testing "missing handlers"
         (is (nil? (build-create-request (assoc-in form [:handlers] [])))))))
@@ -62,13 +64,18 @@
                 :title "workflow title"
                 :type :workflow/master
                 :forms []
-                :handlers ["bob" "carl"]}
+                :handlers ["bob" "carl"]
+                :licenses []}
                (build-create-request form))))
       (testing "missing handlers"
         (is (nil? (build-create-request (assoc-in form [:handlers] []))))))))
 
 (deftest build-edit-request-test
-  (is (= {:id 3 :organization {:organization/id "o"} :title "t" :handlers ["a" "b"]}
+  (is (= {:id 3
+          :organization {:organization/id "o"}
+          :title "t"
+          :handlers ["a" "b"]
+          :licenses []}
          (build-edit-request 3 {:organization {:organization/id "o"} :title "t" :handlers [{:userid "a"} {:userid "b"}]})))
   (is (nil? (build-edit-request nil {:title "t" :handlers [{:userid "a"} {:userid "b"}]})))
   (is (nil? (build-edit-request 3 {:title "t" :handlers [{:userid "a"} {:userid "b"}]})))


### PR DESCRIPTION
relates #2158

Add support for creating/editing licenses into workflows. Workflow licenses have existed before in some form ( `workflow_licenses` table), so this needed some migration work. Application model enrichment is updated to use workflow licenses.

some larger changes:
- removed `workflow_licenses` table and related queries
- migrated data to `workflow` table json column

api changes:
- remove `licenses` from workflow (it is now under `[:workflow :licenses]`)

feature:
- update workflow DB layer to serialize/deserialize licenses
- update workflow service layer to join license dependencies
- create UI to allow administration to create and edit workflows to include licenses
- update workflow API & related commands to accept and validate licenses
- update application model to enrich workflow licenses
- update dependencies to compute workflow licenses

# Checklist for author

Remove items that aren't applicable, check items that are done.

## Reviewability
- [x] Link to issue
- [x] Consider adding screenshots for ease of review

## Backwards compatibility
- [ ] API is backwards compatible or completely new
- [ ] Feature appears correctly in PDF print

## Documentation
- [x] Update changelog if necessary
- [ ] API is documented and shows up in Swagger UI

## Testing
- [x] Complex logic is unit tested
- [x] Valuable features are integration / browser / acceptance tested automatically

## Follow-up
- [ ] New tasks are created for pending or remaining tasks

---
## Screenshots

![Screenshot 2022-07-18 at 14 39 34](https://user-images.githubusercontent.com/794087/179504138-4769941f-edfb-46de-9dec-79b6273e2228.png)

edit workflow
<img width="1188" alt="Screenshot 2022-09-06 at 16 42 33" src="https://user-images.githubusercontent.com/794087/188650704-f860f778-1a2c-432b-844c-85d032d5eafa.png">
