### PR TITLE
Fix read-only checkbox visuals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Changes since v2.27
 
 ### Fixes
 - Add missing migration to remove organization modifier and last modified from the data. (#2964)
+- Read-only checkbox should look different from editable checkbox yet again. (#2974)
 
 ## v2.27 "Lauttasaaren silta" 2022-06-06
 

--- a/src/cljs/rems/atoms.cljs
+++ b/src/cljs/rems/atoms.cljs
@@ -87,7 +87,8 @@
               :aria-checked value
               :aria-label (if value
                             (text :t.form/checkbox-checked)
-                            (text :t.form/checkbox-unchecked))}
+                            (text :t.form/checkbox-unchecked))
+              :aria-readonly (nil? on-change)}
        on-change (assoc :on-click wrapped-on-change
                         :on-key-press #(when (= (.-key %) " ")
                                          (wrapped-on-change %))))]))

--- a/src/cljs/rems/atoms.cljs
+++ b/src/cljs/rems/atoms.cljs
@@ -82,7 +82,7 @@
                               (on-change value)))]
     [:i.far.fa-lg
      {:id id
-      :class [:checkbox class (if value :fa-check-square :fa-square) (when-not on-change :readonly-checkbox)]
+      :class [:checkbox class (if value :fa-check-square :fa-square)]
       :tabIndex 0
       :role :checkbox
       :aria-checked value
@@ -94,7 +94,8 @@
 (defn readonly-checkbox
   "Displays a readonly checkbox."
   [opts]
-  [checkbox opts])
+  [:span.readonly-checkbox
+   [checkbox (dissoc opts :on-change)]])
 
 (defn info-field
   "A component that shows a readonly field with title and value.

--- a/src/cljs/rems/atoms.cljs
+++ b/src/cljs/rems/atoms.cljs
@@ -78,18 +78,19 @@
   (let [wrapped-on-change (fn [e]
                             (.preventDefault e)
                             (.stopPropagation e)
-                            (when on-change
-                              (on-change value)))]
+                            (on-change value))]
     [:i.far.fa-lg
-     {:id id
-      :class [:checkbox class (if value :fa-check-square :fa-square)]
-      :tabIndex 0
-      :role :checkbox
-      :aria-checked value
-      :aria-label (if value (text :t.form/checkbox-checked) (text :t.form/checkbox-unchecked))
-      :on-click wrapped-on-change
-      :on-key-press #(when (= (.-key %) " ")
-                       (wrapped-on-change %))}]))
+     (cond-> {:id id
+              :class [:checkbox class (if value :fa-check-square :fa-square)]
+              :tabIndex 0
+              :role :checkbox
+              :aria-checked value
+              :aria-label (if value
+                            (text :t.form/checkbox-checked)
+                            (text :t.form/checkbox-unchecked))}
+       on-change (assoc :on-click wrapped-on-change
+                        :on-key-press #(when (= (.-key %) " ")
+                                         (wrapped-on-change %))))]))
 
 (defn readonly-checkbox
   "Displays a readonly checkbox."


### PR DESCRIPTION
# Checklist for author

relates #2974

- Readonly checkbox had incorrectly rendered background. This was due to `.readonly-checkbox` class being applied to `<i>` element, which had 1px height and thus rendered only single pixel height gray line instead of gray background. Quick fix to this was to add encompassing `<span>` element with the readonly-checkbox class.

Remove items that aren't applicable, check items that are done.

## Reviewability
- [x] Link to issue
- [x] Consider adding screenshots for ease of review

## Documentation
- [x] Update changelog if necessary

---
## Screenshots

### before
![Screenshot 2022-07-19 at 15 00 38](https://user-images.githubusercontent.com/794087/179745149-40b40422-aa6f-4e3d-aa55-332b3890eab6.png)

### after
![Screenshot 2022-07-19 at 15 00 13](https://user-images.githubusercontent.com/794087/179745145-03b22419-82ea-4a90-9a9b-60c8e03b1222.png)