### PR TITLE
Fix flaky test-catalogue-tree

### DIFF
--- a/test/clj/rems/api/services/test_dependencies.clj
+++ b/test/clj/rems/api/services/test_dependencies.clj
@@ -3,10 +3,13 @@
             [rems.api.services.dependencies :as dependencies]
             [rems.db.core :as db]
             [rems.db.test-data-helpers :as test-helpers]
-            [rems.db.testing :refer [test-db-fixture rollback-db-fixture]]))
+            [rems.db.testing :refer [caches-fixture test-db-fixture rollback-db-fixture]]))
 
 (use-fixtures :once test-db-fixture)
-(use-fixtures :each rollback-db-fixture)
+(use-fixtures
+  :each
+  rollback-db-fixture
+  caches-fixture)
 
 (deftest test-dependencies
   (let [shared-license (test-helpers/create-license! {})


### PR DESCRIPTION
relates #2970

- `rems.api.services.test-dependencies/test-dependencies` creates categories that were not cleared from cache. due to randomized test run order, this causes random failures in `rems.api.services.test-catalogue/test-get-catalogue-tree` because it expects a clear slate

# Checklist for author

Remove items that aren't applicable, check items that are done.

## Reviewability
- [x] Link to issue

## Testing
- [x] Valuable features are integration / browser / acceptance tested automatically
