### PR TITLE
Fix version number not showing in console

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ Changes since v2.27
 ### Fixes
 - Add missing migration to remove organization modifier and last modified from the data. (#2964)
 - Applicant member details now always have border in application user interface, even when there are no other members. (#2975)
+- Version number is shown again in browser console instead of message "Version information not available". This was due to change in build logic introduced by Shadow-CLJS. (#2984)
 
 ## v2.27 "Lauttasaaren silta" 2022-06-06
 

--- a/shadow-cljs.edn
+++ b/shadow-cljs.edn
@@ -13,7 +13,12 @@
                 [venantius/accountant "0.2.5"]
                 [prismatic/schema "1.2.1"]]
 
- :source-paths ["env/dev/clj" "src/cljs" "src/cljc" "src/clj" "test/cljs"]
+ :source-paths ["target/uberjar/resources"
+                "env/dev/clj"
+                "src/cljs"
+                "src/cljc"
+                "src/clj"
+                "test/cljs"]
 
  :nrepl {:port 7002}
 

--- a/src/cljs/rems/spa.cljs
+++ b/src/cljs/rems/spa.cljs
@@ -166,7 +166,7 @@
 
 (defn version-info []
   (if-let [{:keys [version revision]} git/+version+]
-    (do (println "Version: " version)
+    (do (println "Version:" version)
         (println (str git/+commits-url+ revision)))
     (println "Version information not available")))
 


### PR DESCRIPTION
fixes #2984 

Shadow-CLJS was unable to slurp git describe and revision files because the folder containing these files was not included in it's classpath. This resulted in displaying the message "Version information not available" in browser console.

- `target/uberjar/resources` folder is now included in Shadow-CLJS config `:source-paths` key, so it is available for slurp

# Checklist for author

Remove items that aren't applicable, check items that are done.

## Reviewability
- [x] Link to issue

## Documentation
- [x] Update changelog if necessary
