### PR TITLE
Sort application licenses by title

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Changes since v2.27
 - HTTP/2 (and others) can be configured, see `:jetty-extra-params` in `config-defaults.edn`.
 - Validate organization when adding or editing it. (#2964)
 - Consecutive save events are compacted into one. This does not affect old save events. This is turned off by default, until the whole autosave feature is finished. (#2767)
+- Application licenses are now rendered alphabetically in UI and PDF render. (#2979)
 
 ### Fixes
 - Add missing migration to remove organization modifier and last modified from the data. (#2964)

--- a/src/clj/rems/pdf.clj
+++ b/src/clj/rems/pdf.clj
@@ -152,10 +152,11 @@
           [:paragraph (localized (:license/attachment-filename license))])))
 
 (defn- render-licenses [application]
-  (list [:heading heading-style (text :t.form/licenses)]
-        (doall
-         (for [license (getx application :application/licenses)]
-           (render-license license)))))
+  (let [licenses (getx application :application/licenses)]
+    (list [:heading heading-style (text :t.form/licenses)]
+          (doall
+           (for [license (sort-by #(-> % :license/title localized) licenses)]
+             (render-license license))))))
 
 (defn- render-application [application]
   [{}

--- a/src/cljs/rems/application.cljs
+++ b/src/cljs/rems/application.cljs
@@ -526,7 +526,7 @@
          [flash-message/component :accept-licenses]
          [:p (text :t.form/must-accept-licenses)]
          (into [:div#licenses]
-               (for [license licenses]
+               (for [license (sort-by #(-> % :license/title localized) licenses)]
                  [license-field
                   application
                   (assoc license


### PR DESCRIPTION
relates #2979 

- application licenses are now sorted by localized title in UI and PDF render

# Checklist for author

Remove items that aren't applicable, check items that are done.

## Reviewability
- [x] Link to issue
- [x] Consider adding screenshots for ease of review

## Backwards compatibility
- [x] Feature appears correctly in PDF print

## Documentation
- [x] Update changelog if necessary

---
## Screenshots

### before
<img width="579" alt="Screenshot 2022-08-16 at 10 59 14" src="https://user-images.githubusercontent.com/794087/184830782-24e8c65b-ae18-4bb8-9b02-1a34f024b7bc.png">
<img width="732" alt="Screenshot 2022-08-16 at 11 14 18" src="https://user-images.githubusercontent.com/794087/184831427-e58fdd3d-abb6-4dec-806d-307b629f73a1.png">

### after
<img width="581" alt="Screenshot 2022-08-16 at 10 59 23" src="https://user-images.githubusercontent.com/794087/184830790-baea2102-57bc-4e96-9464-6b151107af3f.png">
<img width="731" alt="Screenshot 2022-08-16 at 11 14 31" src="https://user-images.githubusercontent.com/794087/184831438-4a83d85c-c8f4-4aeb-866a-3d82a6ef0127.png">

