### PR TITLE
Extra stylesheets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ Changes since v2.27
 - Validate organization when adding or editing it. (#2964)
 - Consecutive save events are compacted into one. This does not affect old save events. This is turned off by default, until the whole autosave feature is finished. (#2767)
 - Application licenses are now rendered alphabetically in UI and PDF render. (#2979)
-- Custom stylesheets can now be added using `:extra-stylesheets` configuration option. This can be used to include custom fonts, for example.
+- Custom stylesheets can now be added using `:extra-stylesheets` configuration option. This can be used to include custom fonts, for example. (#2869)
 
 ### Fixes
 - Add missing migration to remove organization modifier and last modified from the data. (#2964)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Changes since v2.27
 - Validate organization when adding or editing it. (#2964)
 - Consecutive save events are compacted into one. This does not affect old save events. This is turned off by default, until the whole autosave feature is finished. (#2767)
 - Application licenses are now rendered alphabetically in UI and PDF render. (#2979)
+- Custom stylesheets can now be added using `:extra-stylesheets` configuration option. This can be used to include custom fonts, for example.
 
 ### Fixes
 - Add missing migration to remove organization modifier and last modified from the data. (#2964)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ Changes since v2.27
 - Validate organization when adding or editing it. (#2964)
 - Consecutive save events are compacted into one. This does not affect old save events. This is turned off by default, until the whole autosave feature is finished. (#2767)
 - Application licenses are now rendered alphabetically in UI and PDF render. (#2979)
-- Custom stylesheets can now be added using `:extra-stylesheets` configuration option. This can be used to include custom fonts, for example. (#2869)
+- Custom stylesheets can now be added using `:extra-stylesheets` configuration option. This can be used to include custom fonts, for example. Example stylesheet is included in `config-defaults.edn` and is located in `example-theme/extra-styles.css`. (#2869)
 
 ### Fixes
 - Add missing migration to remove organization modifier and last modified from the data. (#2964)

--- a/example-theme/extra-styles.css
+++ b/example-theme/extra-styles.css
@@ -1,0 +1,31 @@
+@font-face {
+    font-family: "Lato";
+    font-style: normal;
+    font-weight: 300;
+    font-display: swap;
+    src: url('/font/Lato-Light.woff2') format('woff2'),
+         url('/font/Lato-Light.woff') format('woff');
+}
+@font-face {
+    font-family: "Lato";
+    font-style: normal;
+    font-weight: 400;
+    font-display: swap;
+    src: url('/font/Lato-Regular.woff2') format('woff2'),
+         url('/font/Lato-Regular.woff') format('woff');
+}
+@font-face {
+    font-family: "Lato";
+    font-style: normal;
+    font-weight: 700;
+    font-display: swap;
+    src: url('/font/Lato-Bold.woff2') format('woff2'),
+         url('/font/Lato-Bold.woff') format('woff');
+}
+@font-face {
+    font-family: "Roboto Slab";
+    font-style: normal;
+    font-weight: 400;
+    font-display: swap;
+    src: url('/font/Roboto-Slab.woff2') format('woff2');
+}

--- a/resources/config-defaults.edn
+++ b/resources/config-defaults.edn
@@ -304,6 +304,9 @@
 
  ;; Optional extra script files loaded when UI loads
  :extra-scripts {:root "/dev/null" :files []}
+ ;; Optional extra stylesheets loaded when UI loads.
+ ;; Use to set custom fonts for example
+ :extra-stylesheets {:root "/dev/null" :files []}
 
  ;; Optional extra pages shown in the navigation bar.
  ;;

--- a/resources/config-defaults.edn
+++ b/resources/config-defaults.edn
@@ -306,7 +306,7 @@
  :extra-scripts {:root "/dev/null" :files []}
  ;; Optional extra stylesheets loaded when UI loads.
  ;; Use to set custom fonts for example
- :extra-stylesheets {:root "/dev/null" :files []}
+ :extra-stylesheets {:root "./" :files ["/example-theme/extra-styles.css"]}
 
  ;; Optional extra pages shown in the navigation bar.
  ;;

--- a/src/clj/rems/css/styles.clj
+++ b/src/clj/rems/css/styles.clj
@@ -32,39 +32,6 @@
                                   :lg (u/px 1200)
                                   :xl (u/px 1600)})
 
-
-;; Fonts of the app
-
-(defn- at-font-faces
-  "The theme :font-family settings will override these fonts is set.
-
-  Reason for this function to be included into our screen.css
-   - because themes like Findata can use them since our theme.edn doesn't offer a possibility to add custom fonts
-   - all the fonts need to be 'built in' to REMS, even if they're not active
-   - bundling Robot Slab and Lato in REMS is a bit of a hack, made for Findata & THL to get the sort of styles they want"
-  []
-  (list
-   (stylesheet/at-font-face {:font-family "'Lato'"
-                             :font-style "normal"
-                             :font-weight 300
-                             :font-display :swap
-                             :src "url('/font/Lato-Light.woff2') format('woff2'), url('/font/Lato-Light.woff') format('woff')"})
-   (stylesheet/at-font-face {:font-family "'Lato'"
-                             :font-style "normal"
-                             :font-weight 400
-                             :font-display :swap
-                             :src "url('/font/Lato-Regular.woff2') format('woff2'), url('/font/Lato-Regular.woff') format('woff')"})
-   (stylesheet/at-font-face {:font-family "'Lato'"
-                             :font-style "normal"
-                             :font-weight 700
-                             :font-display :swap
-                             :src "url('/font/Lato-Bold.woff2') format('woff2'), url('/font/Lato-Bold.woff') format('woff')"})
-   (stylesheet/at-font-face {:font-family "'Roboto Slab'"
-                             :font-style "normal"
-                             :font-weight 400
-                             :font-display :swap
-                             :src "url('/font/Roboto-Slab.woff2') format('woff2')"})))
-
 (defn- form-placeholder-styles []
   (list
    [".form-control::placeholder" {:color "#555"}] ; Standard
@@ -372,7 +339,6 @@
 
 (defn build-screen []
   (list
-   (at-font-faces)
    [:* {:margin 0}]
    [:p:last-child {:margin-bottom 0}]
    [:a

--- a/src/clj/rems/handler.clj
+++ b/src/clj/rems/handler.clj
@@ -102,6 +102,12 @@
       (when (contains? files (:uri request))
         (file-response (:uri request) {:root root})))))
 
+(defn extra-stylesheet-routes [{:keys [root files]}]
+  (let [files (set files)]
+    (fn [request]
+      (when (contains? files (:uri request))
+        (file-response (:uri request) {:root root})))))
+
 (defn- static-resources [path]
   (if path
     (route/files "/" {:root path})
@@ -131,6 +137,7 @@
      styles/css-routes
      resource-handler
      (extra-script-routes (:extra-scripts env))
+     (extra-stylesheet-routes (:extra-stylesheets env))
      (static-resources (:extra-static-resources env))
      (static-resources (:theme-static-resources env))
      webjar-handler))

--- a/src/clj/rems/layout.clj
+++ b/src/clj/rems/layout.clj
@@ -77,7 +77,9 @@
                       [:title (text :t.header/title)]
                       (include-css "/assets/bootstrap/css/bootstrap.min.css")
                       (include-css "/assets/font-awesome/css/all.css")
-                      (include-css (cache-bust (css-filename context/*lang*)))]
+                      (include-css (cache-bust (css-filename context/*lang*)))
+                      (for [extra-stylesheet (get-in env [:extra-stylesheets :files])]
+                        (include-css (cache-bust extra-stylesheet)))]
                      (logo-preloads))
                [:body
                 [:div#app app-content]


### PR DESCRIPTION
relates #2869 

custom fonts and custom stylesheets have been a topic every now and then. would this solution work?

- added new config option `:extra-stylesheets` that works similarly to `:extra-scripts`, but includes css-files instead of javascript

# Checklist for author

Remove items that aren't applicable, check items that are done.

## Reviewability
- [x] Link to issue

## Documentation
- [x] Update changelog if necessary
- [x] New config options in config-defaults.edn
