### PR TITLE
feat: add extra-styles to Docker image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Changes since v2.27
 - Consecutive save events are compacted into one. This does not affect old save events. This is turned off by default, until the whole autosave feature is finished. (#2767)
 - Application licenses are now rendered alphabetically in UI and PDF render. (#2979)
 - Custom stylesheets can now be added using `:extra-stylesheets` configuration option. This can be used to include custom fonts, for example. Example stylesheet is included in `config-defaults.edn` and is located in `example-theme/extra-styles.css`. (#2869)
+- Example custom stylesheet `example-theme/extra-styles.css` is included in Docker images built using `Dockerfile` and `docker-compose-config.yml`, so that default REMS fonts are automatically included when running REMS for the first time, for example. (#2869)
 
 ### Fixes
 - Add missing migration to remove organization modifier and last modified from the data. (#2964)

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ WORKDIR /rems
 ENTRYPOINT ["bash","./docker-entrypoint.sh"]
 
 COPY empty-config.edn /rems/config/config.edn
+COPY example-theme/extra-styles.css /rems/example-theme/extra-styles.css
 COPY target/uberjar/rems.jar /rems/rems.jar
 COPY docker-entrypoint.sh /rems/docker-entrypoint.sh
 

--- a/docker-compose-config.yml
+++ b/docker-compose-config.yml
@@ -12,6 +12,7 @@ services:
       - "127.0.0.1:3000:3000"
     volumes:
       - ./simple-config.edn:/rems/config/config.edn
+      - ./example-theme/extra-styles.css:/rems/example-theme/extra-styles.css
 
   db:
     image: postgres:13

--- a/docs/installing-upgrading.md
+++ b/docs/installing-upgrading.md
@@ -54,7 +54,7 @@ Generally the database must be started, migrated and populated first.
 
 ### Option 1: Run REMS from Docker Hub
 
-This tries to fetch the latest REMS image from Docker Hub. This uses the default `docker-compose.yml` file.
+This tries to fetch the latest REMS image from Docker Hub. This uses the default `docker-compose.yml` file. It doesn't include files referred to in default config, such as `example-theme/extra-styles.css`, which includes default fonts.
 
     docker-compose up -d db
     docker-compose run --rm -e CMD="migrate;test-data" app
@@ -62,7 +62,7 @@ This tries to fetch the latest REMS image from Docker Hub. This uses the default
     
 ### Option 2: Use config file simple-config.edn instead of environment variables
 
-The other build file `docker-compose-config.yml` shows how to configure an external config file named `simple-config.edn`. The file is provided through a volume mounted to the correct place in the container. Don't forget to map all the files you refer to in the config (like `theme.edn`) with similar volumes. Alternatively, you could build your own image on top of our base image, so that it includes the files inside. We prefer to have one image that is same in all environments and use mappings to provide the varying data (config).
+The other build file `docker-compose-config.yml` shows how to configure an external config file named `simple-config.edn`, and custom stylesheet file named `extra-styles.css` which includes default fonts. The files are provided through volumes mounted to the correct place in the container. Don't forget to map all the files you refer to in the config (like `theme.edn`) with similar volumes. Alternatively, you could build your own image on top of our base image, so that it includes the files inside. We prefer to have one image that is same in all environments and use mappings to provide the varying data (config).
 
     docker-compose -f docker-compose-config.yml up -d db
     docker-compose -f docker-compose-config.yml run --rm -e CMD="migrate;test-data" app

--- a/simple-config.edn
+++ b/simple-config.edn
@@ -2,4 +2,5 @@
  :database-url "postgresql://db:5432/rems?user=rems&password=remspassword"
  :search-index-path "/tmp/rems-search-index"
  :authentication :fake
- :public-url "http://localhost:3000/"}
+ :public-url "http://localhost:3000/"
+ :extra-stylesheets {:root "./" :files ["/example-theme/extra-styles.css"]}}


### PR DESCRIPTION
relates #2869 

- add `example-theme/extra-styles.css` to both `Dockerfile` and `docker-compose-config.yml` so that default REMS fonts are included when REMS is built & run with Docker
- update `simple-config.edn` to include `:extra-stylesheets` key (duplicated from `config-defaults.edn`)

# Checklist for author

Remove items that aren't applicable, check items that are done.

## Reviewability
- [x] Link to issue
- [x] Note if related change in rems-deploy repo (pending #2989)

## Documentation
- [x] Update changelog if necessary
- [x] Update docs/ (if applicable)

## Follow-up
- [ ] New tasks are created for pending or remaining tasks
