### PR TITLE
Unify license and catalogue item localized fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ have notable changes.
 
 ## Unreleased
 
+### Fixes
+- License, create/edit license and create/edit catalogue item administrator views have been updated to display localized fields the same way other administrator views do. (#1334)
+
 Changes since v2.28
 
 ## v2.28 "Porkkalankatu" 2022-08-24

--- a/resources/translations/en.edn
+++ b/resources/translations/en.edn
@@ -130,7 +130,7 @@
                    :license-field "License \"%1\""
                    :licenses "Licenses"
                    :manage-categories "Manage categories"
-                   :more-info "More info URL (optional)"
+                   :more-info "More info URL"
                    :name "Name"
                    :no-categories "No categories"
                    :no-form "No form"

--- a/resources/translations/fi.edn
+++ b/resources/translations/fi.edn
@@ -127,7 +127,7 @@
                    :license-field "Lisenssi \"%1\""
                    :licenses "Lisenssit"
                    :manage-categories "Hallinnoi kategorioita"
-                   :more-info "Lisätietoja-URL (valinnainen)"
+                   :more-info "Lisätietoja-URL"
                    :name "Nimi"
                    :no-categories "Ei kategorioita"
                    :no-form "Ei lomaketta"

--- a/resources/translations/sv.edn
+++ b/resources/translations/sv.edn
@@ -127,7 +127,7 @@
                    :license-field "Licens \"%1\""
                    :licenses "Licenser"
                    :manage-categories "Administrera kategorier"
-                   :more-info "Webbadress för tilläggsinformation (valfritt)"
+                   :more-info "Webbadress för tilläggsinformation"
                    :name "Namn"
                    :no-categories "Inga kategorier"
                    :no-form "Ingen blankett"

--- a/src/cljs/rems/administration/components.cljs
+++ b/src/cljs/rems/administration/components.cljs
@@ -212,13 +212,18 @@
 
 (defn localized-info-field
   "An info field for displaying text in all supported languages.
-  The data is passed in as a map of language to text."
-  [m {:keys [label]}]
+  The data is passed in as a map of language to text.
+  If :localizations-key is passed in opts, language to text is
+  mapped from `[:localizations lang localizations-key]` instead."
+  [m {:keys [label localizations-key] :as opts}]
   (let [languages @(rf/subscribe [:languages])
         to-label #(str label " (" (str/upper-case (name %)) ")")]
     (into [:<>]
-          (for [lang languages]
-            [inline-info-field (to-label lang) (get m lang)]))))
+          (for [lang languages
+                :let [value (if (some? localizations-key)
+                              (get-in m [:localizations lang localizations-key])
+                              (get m lang))]]
+            [inline-info-field (to-label lang) value]))))
 
 (defn organization-field [context {:keys [keys readonly]}]
   (let [label (text :t.administration/organization)

--- a/src/cljs/rems/administration/components.cljs
+++ b/src/cljs/rems/administration/components.cljs
@@ -102,14 +102,47 @@
                                           (.. % -target -value)])}]
      [field-validation-message error label]]))
 
-(defn- localized-text-field-lang [context {:keys [keys-prefix label lang]}]
+(defn localized-textarea-autosize
+  "A textarea for inputting text in all supported languages.
+  Has a separate textareas for each language. The data is stored
+  in the form as a map of language to text. If `:localizations-key` is
+  provided in opts, languages are mapped from `[:localizations lang localizations-key]`
+  path."
+  [context {:keys [keys localizations-key label placeholder]}]
+  (into [:div.form-group.localized-field
+         [:label.administration-field-label label]]
+        (for [language @(rf/subscribe [:languages])]
+          (let [form @(rf/subscribe [(:get-form context)])
+                form-errors (when (:get-form-errors context)
+                              @(rf/subscribe [(:get-form-errors context)]))
+                keys (if (some? localizations-key)
+                       [:localizations language localizations-key]
+                       (conj keys language))
+                id (keys-to-id (if (some? localizations-key)
+                                 [:localizations language localizations-key]
+                                 keys))
+                error (get-in form-errors keys)]
+            [:div.row.mb-0
+             [:label.col-sm-1.col-form-label {:for id}
+              (str/upper-case (name language))]
+             [:div.col-sm-11
+              [textarea {:id id
+                         :placeholder placeholder
+                         :value (get-in form keys)
+                         :class (when error "is-invalid")
+                         :on-change #(rf/dispatch [(:update-form context)
+                                                   keys
+                                                   (.. % -target -value)])}]
+              [field-validation-message error label]]]))))
+
+(defn- localized-text-field-lang [context {:keys [localization-keys keys-prefix label lang]}]
   (let [form @(rf/subscribe [(:get-form context)])
         form-errors (when (:get-form-errors context)
                       @(rf/subscribe [(:get-form-errors context)]))
-        keys (conj keys-prefix lang)
+        keys (or localization-keys (conj keys-prefix lang))
         id (keys-to-id keys)
         error (get-in form-errors keys)]
-    [:div.form-group.row.mb-0
+    [:div.row.mb-0
      [:label.col-sm-1.col-form-label {:for id}
       (str/upper-case (name lang))]
      [:div.col-sm-11
@@ -125,24 +158,28 @@
 (defn localized-text-field
   "A text field for inputting text in all supported languages.
   Has a separate text fields for each language. The data is stored
-  in the form as a map of language to text."
-  [context {:keys [keys label collapse?]}]
+  in the form as a map of language to text. If `:localizations-key` is
+  provided in opts, languages are mapped from `[:localizations lang localizations-key]`
+  path."
+  [context {:keys [keys label localizations-key collapse?] :as opts}]
   (let [languages @(rf/subscribe [:languages])
-        id (keys-to-id keys)
+        id (keys-to-id (if (some? localizations-key) [localizations-key] keys))
         fields (into [:<>]
-                     (for [lang languages]
-                       [localized-text-field-lang context {:keys-prefix keys
-                                                           :label label
-                                                           :lang lang}]))]
+                     (for [lang languages
+                           :let [localization-opts (if (some? localizations-key)
+                                                     {:localization-keys [:localizations lang localizations-key]}
+                                                     {:keys-prefix keys})]]
+                       [localized-text-field-lang context (merge {:label label :lang lang}
+                                                                 localization-opts)]))]
     (if collapse?
-      [:div.form-group.field.mb-1
+      [:div.form-group.localized-field.mb-1
        [:label.administration-field-label
         label
         " "
         [collapsible/controls id (text :t.collapse/show) (text :t.collapse/hide)]]
        [:div.collapse {:id id}
         fields]]
-      [:div.form-group.field
+      [:div.form-group.localized-field
        [:label.administration-field-label label]
        fields])))
 

--- a/src/cljs/rems/administration/components.cljs
+++ b/src/cljs/rems/administration/components.cljs
@@ -14,7 +14,6 @@
               analogous to the `get-in` and `assoc-in` parameters.
     :label  - String, shown to the user as-is."
   (:require [clojure.string :as str]
-            [medley.core :refer [assoc-some]]
             [re-frame.core :as rf]
             [rems.atoms :refer [info-field textarea]]
             [rems.collapsible :as collapsible]

--- a/src/cljs/rems/administration/create_catalogue_item.cljs
+++ b/src/cljs/rems/administration/create_catalogue_item.cljs
@@ -3,7 +3,7 @@
             [medley.core :refer [find-first map-vals]]
             [re-frame.core :as rf]
             [rems.administration.administration :as administration]
-            [rems.administration.components :refer [organization-field text-field]]
+            [rems.administration.components :refer [localized-text-field organization-field]]
             [rems.atoms :as atoms :refer [document-title]]
             [rems.collapsible :as collapsible]
             [rems.dropdown :as dropdown]
@@ -157,17 +157,14 @@
 (defn- catalogue-item-organization-field []
   [organization-field context {:keys [:organization]}])
 
-(defn- catalogue-item-title-field [language]
-  [text-field context {:keys [:title language]
-                       :label (str (text :t.administration/title)
-                                   " (" (str/upper-case (name language)) ")")
-                       :placeholder (text :t.administration/title)}])
+(defn- catalogue-item-title-field []
+  [localized-text-field context {:keys [:title]
+                                 :label (text :t.administration/title)}])
 
-(defn- catalogue-item-infourl-field [language]
-  [text-field context {:keys [:infourl language]
-                       ;; no placeholder to make clear that field is optional
-                       :label (str (text :t.administration/more-info)
-                                   " (" (str/upper-case (name language)) ")")}])
+(defn- catalogue-item-infourl-field []
+  [localized-text-field context {:keys [:infourl]
+                                 :label (str (text :t.administration/more-info) " "
+                                             (text :t.administration/optional))}])
 
 (defn- catalogue-item-workflow-field []
   (let [workflows @(rf/subscribe [::workflows])
@@ -311,10 +308,8 @@
                   [:div#catalogue-item-loader [spinner/big]]
                   [:div#catalogue-item-editor.fields
                    [catalogue-item-organization-field]
-                   (for [language languages]
-                     [:<> {:key language}
-                      [catalogue-item-title-field language]
-                      [catalogue-item-infourl-field language]])
+                   [catalogue-item-title-field]
+                   [catalogue-item-infourl-field]
                    [catalogue-item-workflow-field]
                    [catalogue-item-resource-field]
                    [catalogue-item-form-field]

--- a/test/clj/rems/browser_test_util.clj
+++ b/test/clj/rems/browser_test_util.clj
@@ -321,6 +321,7 @@
 (def wait-predicate et/wait-predicate) ; does not need driver
 (def has-text? (wrap-etaoin et/has-text?))
 (def has-class? (wrap-etaoin et/has-class?))
+(def has-class-el? (wrap-etaoin et/has-class-el?))
 (def disabled? (wrap-etaoin et/disabled?))
 (def clear (wrap-etaoin et/clear))
 (def clear-el (wrap-etaoin et/clear-el))


### PR DESCRIPTION
relates #1334 #2881 

**background**: Localized text fields were implemented slightly differently for create/edit catalogue item and create license views (than other create/edit views). License view (read-only) additionally has some extra logic related to displaying localized links and attachments.

To unify look & feel, `[localized-text-field]` component is modified to accept `:localizations-key` option that queries `[:localizations langcode :localizations-key]` path of object. License API currently returns localizations this way, which will be refactored at some point. The same modification was done to `[localized-info-field]` component so that license view (read-only) has similar look to other read-only views with localized fields.

Additionally, `[localized-textarea-autosize]` component is implemented for create/edit license view as generic component. Attachments are quite complex to implement in generic way, so licenses currently have more custom logic. This could be a good refactoring ticket.

Browser tests are implemented for create/edit licenses with regard to different license types (link/text/attachment).

# Checklist for author

Remove items that aren't applicable, check items that are done.

## Reviewability
- [x] Link to issue
- [x] Consider adding screenshots for ease of review

## Backwards compatibility
- [x] Feature appears correctly in PDF print

## Documentation
- [x] Update changelog if necessary
- [ ] Components are added to guide page (components don't have a guide page, neither do licenses. maybe they should?)

## Testing
- [x] Valuable features are integration / browser / acceptance tested automatically

## Follow-up
- [ ] New tasks are created for pending or remaining tasks

---
## Screenshots (click to enlarge)

### License view (read-only)

<img src="https://user-images.githubusercontent.com/794087/187930447-287ed775-5b1a-4a44-acc2-569567f60c61.png" width="250px"> <img src="https://user-images.githubusercontent.com/794087/187930455-b4128330-c669-4c7a-b1fa-84f2101c5a6a.png" width="250px"> <img src="https://user-images.githubusercontent.com/794087/187930459-42228f48-34ff-4971-a4ce-33c319f2f14c.png" width="250px">

### Create license view (edit)

<img src="https://user-images.githubusercontent.com/794087/187930464-9bfc7bb6-cb44-49e2-812d-1d3f62979db1.png" width="250px"> <img src="https://user-images.githubusercontent.com/794087/187930469-2ab09c8e-dd49-4d8b-bc18-cd1907ebceb2.png" width="250px"> <img src="https://user-images.githubusercontent.com/794087/187930472-648bce96-c4d6-405b-8e9e-c29d3d454a21.png" width="250px">

### Create catalogue item (edit)

<img src="https://user-images.githubusercontent.com/794087/187932541-8482743f-277b-4117-b410-835c7a20cc16.png" width="300px">