### PR TITLE
release: v2.28

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,12 @@ have notable changes.
 
 ## Unreleased
 
-Changes since v2.27
+Changes since v2.28
+
+## v2.28 "Porkkalankatu" 2022-08-24
 
 **NB: This release contains migrations!**
+**NB: One of the migrations fixes organizations, that could be broken by previous features. **
 
 ### Additions
 - Application UI view is now visually more compact for non-handler users. State and members blocks are collapsed initially, and can be expanded to show more details. (#2871)

--- a/project.clj
+++ b/project.clj
@@ -1,5 +1,4 @@
-(defproject rems "0.1.0-SNAPSHOT"
-
+(defproject rems "2.28"
   :description "Resource Entitlement Management System is a tool for managing access rights to resources, such as research datasets."
   :url "https://github.com/CSCfi/rems"
 


### PR DESCRIPTION
Release v2.28

NB: I updated the `project.clj` version. This is not strictly necessary, but we could keep it up to date.