### PR TITLE
Configurable application list columns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ have notable changes.
 
 ## Unreleased
 
+### Additions
+- Application list in UI can now be configured to hide certain columns using config option `:application-list-hidden-columns`. (#2861)
+
 Changes since v2.28
 
 ## v2.28 "Porkkalankatu" 2022-08-24

--- a/resources/config-defaults.edn
+++ b/resources/config-defaults.edn
@@ -395,4 +395,8 @@
 
  :enable-cart true ; show shopping cart and allow bundling multiple resources into one application
 
- :enable-save-compaction nil} ; whether to merge consecutive saves into one event (EXPERIMENTAL)
+ :enable-save-compaction nil ; whether to merge consecutive saves into one event (EXPERIMENTAL)
+
+ ; which columns in applications list(s) should be hidden in UI
+ ; allowed values: [:description :resource :applicant :handlers :state :todo :created :submitted :last-activity :view]
+ :application-list-hidden-columns []} 

--- a/src/clj/rems/api/public.clj
+++ b/src/clj/rems/api/public.clj
@@ -37,7 +37,8 @@
    (s/optional-key :enable-catalogue-table) s/Bool
    (s/optional-key :enable-catalogue-tree) s/Bool
    (s/optional-key :catalogue-tree-show-matching-parents) s/Bool
-   (s/optional-key :enable-cart) s/Bool})
+   (s/optional-key :enable-cart) s/Bool
+   (s/optional-key :application-list-hidden-columns) [s/Keyword]})
 
 (def translations-api
   (context "/translations" []

--- a/src/clj/rems/api/services/public.clj
+++ b/src/clj/rems/api/services/public.clj
@@ -27,7 +27,8 @@
                     :enable-catalogue-table
                     :enable-catalogue-tree
                     :catalogue-tree-show-matching-parents
-                    :enable-cart]))
+                    :enable-cart
+                    :application-list-hidden-columns]))
 
 (defn get-config-full []
   (assoc env

--- a/src/clj/rems/css/styles.clj
+++ b/src/clj/rems/css/styles.clj
@@ -378,7 +378,7 @@
      {:left (u/em 0)}]]
    [:#main-content {:display :flex
                     :flex-direction :column
-                    :flex-wrap :none
+                    :flex-wrap :no-wrap
                     :min-height (u/px 300)
                     :max-width content-width
                     :flex-grow 1

--- a/src/cljs/rems/application_list.cljs
+++ b/src/cljs/rems/application_list.cljs
@@ -171,7 +171,8 @@
 (defn- application-list-defaults []
   (let [config @(rf/subscribe [:rems.config/config])
         id-column (get config :application-id-column :id)]
-    {:visible-columns #{id-column :description :resource :applicant :handlers :state :todo :created :submitted :last-activity :view}
+    {:visible-columns (set/difference #{id-column :description :resource :applicant :handlers :state :todo :created :submitted :last-activity :view}
+                                      (set (get config :application-list-hidden-columns)))
      :default-sort-column :created
      :default-sort-order :desc}))
 


### PR DESCRIPTION
implements #2861 

add new config option `:application-list-hidden-columns` to allow configuring which columns to hide in application list component, e.g. `:description`. some application lists hide columns using `:hidden-columns` option, which is applied after `:application-list-hidden-columns`.

# Checklist for author

Remove items that aren't applicable, check items that are done.

## Reviewability
- [x] Link to issue

## Backwards compatibility
- [x] Config is backwards compatible

## Documentation
- [x] Update changelog if necessary
- [x] New config options in config-defaults.edn
