### PR TITLE
fix: don't complain about system prop and env config keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ have notable changes.
 
 ### Fixes
 - License, create/edit license and create/edit catalogue item administrator views have been updated to display localized fields the same way other administrator views do. (#1334)
+- Don't needlessly complain about the config keys that are passed automatically from system properties and the environment. (#2935)
 
 Changes since v2.28
 


### PR DESCRIPTION
Fixes #2935.

The keys are automatically passed in, so we shouldn't complain about them.

# Checklist for author

Remove items that aren't applicable, check items that are done.

## Reviewability
- [x] Link to issue

## Backwards compatibility
- [x] Config is backwards compatible

## Documentation
- [x] Update changelog if necessary

## Testing
- [ ] Complex logic is unit tested (not sure if it's worthwhile)
