### PR TITLE
Make DUOs read-only when application fields are not editable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ Changes since v2.29
 - License, create/edit license and create/edit catalogue item administrator views have been updated to display localized fields the same way other administrator views do. (#1334)
 - Don't needlessly complain about the config keys that are passed automatically from system properties and the environment. (#2935)
 - Application warning and error links were not functioning correctly for attachment fields. This is now fixed. (#2955)
+- DUO fields are no longer editable in the UI when application is not in editable state. (#2997)
 
 ## v2.29 "Länsisatamankatu" 2022-09-12
 

--- a/src/cljs/rems/application.cljs
+++ b/src/cljs/rems/application.cljs
@@ -112,7 +112,7 @@
 (rf/reg-sub ::application-id (fn [db _] (::application-id db)))
 (rf/reg-sub ::application (fn [db [_ k]] (get-in db [::application (or k :data)])))
 (rf/reg-sub ::edit-application (fn [db _] (::edit-application db)))
-(rf/reg-sub ::editable? :<- [::application] form-fields-editable?)
+(rf/reg-sub ::readonly? :<- [::application] (comp not form-fields-editable?))
 
 (rf/reg-event-fx
  ::enter-application-page
@@ -506,7 +506,6 @@
         field-validations (index-by [:form-id :field-id]
                                     (some seq [(:errors validations) (:warnings validations)]))
         attachments (index-by [:attachment/id] (:application/attachments application))
-        readonly? (not @(rf/subscribe [::editable?]))
         language @(rf/subscribe [:language])]
     (into [:div]
           (for [form (:application/forms application)
@@ -528,7 +527,7 @@
 
                                                     :diff (get show-diff field-id)
                                                     :validation (get-in field-validations [form-id field-id])
-                                                    :readonly readonly?
+                                                    :readonly @(rf/subscribe [::readonly?])
                                                     :app-id (:application/id application)
                                                     :on-change #(rf/dispatch [::set-field-value form-id field-id %])
                                                     :on-toggle-diff #(rf/dispatch [::toggle-diff field-id])}
@@ -554,8 +553,7 @@
           show-accepted-licenses? (or (contains? roles :member)
                                       (contains? roles :applicant))
           accepted-licenses (get (:application/accepted-licenses application) userid)
-          permissions (:application/permissions application)
-          readonly? (not @(rf/subscribe [::editable?]))]
+          permissions (:application/permissions application)]
       [collapsible/component
        {:id "application-licenses"
         :title (text :t.form/licenses)
@@ -569,7 +567,7 @@
                   application
                   (assoc license
                          :accepted (contains? accepted-licenses (:license/id license))
-                         :readonly readonly?)
+                         :readonly @(rf/subscribe [::readonly?]))
                   show-accepted-licenses?]))
          (when (contains? permissions :application.command/add-licenses)
            [:<>
@@ -1092,10 +1090,9 @@
      [:div.mt-3 [applicants-info application userid]]
      [:div.mt-3 [applied-resources application userid language]]
      (when (:enable-duo config)
-       (if (and @(rf/subscribe [::editable?])
-                (= userid (get-in application [:application/applicant :userid])))
-         [:div.mt-3 [edit-application-duo-codes]]
-         [:div.mt-3 [application-duo-codes]]))
+       (if @(rf/subscribe [::readonly?])
+         [:div.mt-3 [application-duo-codes]]
+         [:div.mt-3 [edit-application-duo-codes]]))
      (when (contains? (:application/permissions application) :see-everything)
        [:div.mt-3 [previous-applications (get-in application [:application/applicant :userid])]])
      [:div.my-3 [application-licenses application userid]]


### PR DESCRIPTION
relates #2997 

Introduce re-frame subscription `[::readonly?]` to simplify controlling when application can be edited. Both form and DUO fields are editable in the same time. Underlying `rems.common.application-util/form-fields-editable?` checks that current user really has rights to edit the application.

# Checklist for author

Remove items that aren't applicable, check items that are done.

## Reviewability
- [x] Link to issue

## Documentation
- [x] Update changelog if necessary

## Follow-up
- [ ] New tasks are created for pending or remaining tasks
