### PR TITLE
Allow organization owner to edit own organizations owners

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Changes since v2.29
   - In the future, autosave may become the default mode. (#2767)
   - Applications don't yet automatically get reloaded, should another person be viewing the same application.
     This is a potential future feature. (see #2622, #2244)
+- Organization owners are now allowed to edit their own organizations owners. (#2828)
 
 ### Fixes
 - License, create/edit license and create/edit catalogue item administrator views have been updated to display localized fields the same way other administrator views do. (#1334)

--- a/src/clj/rems/api/services/organizations.clj
+++ b/src/clj/rems/api/services/organizations.clj
@@ -58,16 +58,16 @@
                :organization/id (:organization/id org)}]}))
 
 (defn edit-organization! [userid org]
-  (organizations/update-organization! (:organization/id org)
-                                      (fn [db-organization]
-                                        (let [organization-owners (set (map :userid (:organization/owners db-organization)))
-                                              organization-owner? (contains? organization-owners userid)
-                                              owner? (contains? context/*roles* :owner)]
-                                          (merge db-organization
-                                                 (remove-keys (if (and organization-owner? (not owner?))
-                                                                #{:organization/id :organization/owners} ; org owner can't update owners
-                                                                #{:organization/id})
-                                                              org)))))
+  (organizations/update-organization!
+   (:organization/id org)
+   (fn [db-organization]
+     (let [organization-owners (set (map :userid (:organization/owners db-organization)))
+           organization-owner? (contains? organization-owners userid)
+           owner? (contains? context/*roles* :owner)]
+       (merge db-organization
+              (cond-> org
+                true (dissoc :organization/id)
+                (not (or organization-owner? owner?)) (dissoc :organization/owners))))))
   {:success true
    :organization/id (:organization/id org)})
 

--- a/src/cljs/rems/administration/create_organization.cljs
+++ b/src/cljs/rems/administration/create_organization.cljs
@@ -193,7 +193,8 @@
        :item-label :display
        :item-selected? #(contains? selected-owners (% :userid))
        :multi? true
-       :disabled? (not org-owner?)
+       :disabled? (and @(rf/subscribe [::editing?])
+                       (not org-owner?))
        :on-change #(rf/dispatch [::set-owners %])}]]))
 
 (defn- remove-review-email-button [field-index]

--- a/src/cljs/rems/administration/create_organization.cljs
+++ b/src/cljs/rems/administration/create_organization.cljs
@@ -179,10 +179,9 @@
   (let [form @(rf/subscribe [::form])
         all-owners @(rf/subscribe [::available-owners])
         selected-owners (set (map :userid (get-in form [:organization/owners])))
-        roles @(rf/subscribe [:roles])
-        owner? (contains? roles :owner)
-        organization-owner? (-> selected-owners
-                                (contains? (:userid @(rf/subscribe [:user]))))]
+        organization-id (:organization/id form)
+        org-owner? (->> @(rf/subscribe [:owned-organizations])
+                        (some (comp #{organization-id} :organization/id)))]
     [:div.form-group
      [:label.administration-field-label
       {:for owners-dropdown-id}
@@ -194,7 +193,7 @@
        :item-label :display
        :item-selected? #(contains? selected-owners (% :userid))
        :multi? true
-       :disabled? (not (or organization-owner? owner?))
+       :disabled? (not org-owner?)
        :on-change #(rf/dispatch [::set-owners %])}]]))
 
 (defn- remove-review-email-button [field-index]

--- a/src/cljs/rems/administration/create_organization.cljs
+++ b/src/cljs/rems/administration/create_organization.cljs
@@ -43,8 +43,6 @@
 (fetcher/reg-fetcher ::organization "/api/organizations/:id" {:path-params (fn [db] {:id (::organization-id db)})
                                                               :on-success #(rf/dispatch [::fetch-organization-success %])})
 
-
-
 ;;; form submit
 
 (defn- valid-review-email? [languages review-email]
@@ -180,7 +178,10 @@
   (let [form @(rf/subscribe [::form])
         all-owners @(rf/subscribe [::available-owners])
         selected-owners (set (map :userid (get-in form [:organization/owners])))
-        roles @(rf/subscribe [:roles])]
+        roles @(rf/subscribe [:roles])
+        owner? (contains? roles :owner)
+        organization-owner? (-> selected-owners
+                                (contains? (:userid @(rf/subscribe [:user]))))]
     [:div.form-group
      [:label.administration-field-label
       {:for owners-dropdown-id}
@@ -192,8 +193,7 @@
        :item-label :display
        :item-selected? #(contains? selected-owners (% :userid))
        :multi? true
-       :disabled? (and (some #{:organization-owner} roles)
-                       (not (some #{:owner} roles)))
+       :disabled? (not (or organization-owner? owner?))
        :on-change #(rf/dispatch [::set-owners %])}]]))
 
 (defn- remove-review-email-button [field-index]

--- a/src/cljs/rems/administration/create_organization.cljs
+++ b/src/cljs/rems/administration/create_organization.cljs
@@ -185,7 +185,7 @@
     [:div.form-group
      [:label.administration-field-label
       {:for owners-dropdown-id}
-      (text :t.administration/owners) " " (text :t.administration/optional)]
+      (str (text :t.administration/owners) " " (text :t.administration/optional))]
      [dropdown/dropdown
       {:id owners-dropdown-id
        :items all-owners
@@ -233,7 +233,7 @@
     [:div.form-group
      [:label.administration-field-label
       {:for :review-emails}
-      (text :t.administration/review-emails) " " (text :t.administration/optional)]
+      (str (text :t.administration/review-emails) " " (text :t.administration/optional))]
      (for [[field-index _review-email] (indexed (:organization/review-emails form))]
        ^{:key field-index} [organization-review-email-field field-index])
      [:div.dashed-group.text-center

--- a/src/cljs/rems/administration/create_organization.cljs
+++ b/src/cljs/rems/administration/create_organization.cljs
@@ -118,7 +118,8 @@
      (put! "/api/organizations/edit"
            {:params request
             :handler (flash-message/default-success-handler
-                      :top description #(navigate! (str "/administration/organizations/" (:organization/id request))))
+                      :top description #(do (config/fetch-organizations!)
+                                            (navigate! (str "/administration/organizations/" (:organization/id %)))))
             :error-handler (flash-message/default-error-handler :top description)}))
    {}))
 

--- a/test/clj/rems/api/test_organizations.clj
+++ b/test/clj/rems/api/test_organizations.clj
@@ -6,9 +6,10 @@
             [rems.db.test-data-helpers :as test-helpers]
             [ring.mock.request :refer :all]))
 
-
-
 (use-fixtures :each api-fixture)
+
+(def organization-id "organizations-api-test-org")
+(def organization-id-2 "organizations-api-test-org-2")
 
 (deftest organizations-api-test
   (let [api-key "42"
@@ -37,7 +38,7 @@
 
     (testing "create organization"
       (let [data (api-call :post "/api/organizations/create"
-                           {:organization/id "organizations-api-test-org"
+                           {:organization/id organization-id
                             :organization/name {:fi "Organisaatiot API Test ORG"
                                                 :en "Organizations API Test ORG"}
                             :organization/short-name {:fi "ORG" :en "ORG"}
@@ -46,14 +47,14 @@
                                                           :name {:fi "Organisaatiot API Test ORG Katselmoijat"
                                                                  :en "Organizations API Test ORG Reviewers"}}]}
                            api-key owner)]
-        (is (= "organizations-api-test-org" (:organization/id data))))
+        (is (= organization-id (:organization/id data))))
 
       (testing "owners can see it"
         (let [data (api-call :get (str "/api/organizations")
                              nil
                              api-key org-owner1)]
-          (is (contains? (set (map :organization/id data)) "organizations-api-test-org"))
-          (is (= {:organization/id "organizations-api-test-org"
+          (is (contains? (set (map :organization/id data)) organization-id))
+          (is (= {:organization/id organization-id
                   :organization/name {:fi "Organisaatiot API Test ORG"
                                       :en "Organizations API Test ORG"}
                   :organization/short-name {:fi "ORG" :en "ORG"}
@@ -63,29 +64,29 @@
                                                        :en "Organizations API Test ORG Reviewers"}}]
                   :enabled true
                   :archived false}
-                 (find-first (comp #{"organizations-api-test-org"} :organization/id) (get-orgs owner))
-                 (get-org owner "organizations-api-test-org")
-                 (find-first (comp #{"organizations-api-test-org"} :organization/id) (get-orgs org-owner1))
-                 (get-org org-owner1 "organizations-api-test-org")))))
+                 (find-first (comp #{organization-id} :organization/id) (get-orgs owner))
+                 (get-org owner organization-id)
+                 (find-first (comp #{organization-id} :organization/id) (get-orgs org-owner1))
+                 (get-org org-owner1 organization-id)))))
 
       (testing "a normal user can see it"
-        (is (= {:organization/id "organizations-api-test-org"
+        (is (= {:organization/id organization-id
                 :organization/name {:fi "Organisaatiot API Test ORG"
                                     :en "Organizations API Test ORG"}
                 :organization/short-name {:fi "ORG" :en "ORG"}}
-               (find-first (comp #{"organizations-api-test-org"} :organization/id) (get-orgs user))
-               (get-org user "organizations-api-test-org"))))
+               (find-first (comp #{organization-id} :organization/id) (get-orgs user))
+               (get-org user organization-id))))
 
       (testing "organization owner owns it"
         (let [data (api-call :get (str "/api/organizations?owner=" org-owner1)
                              nil
                              api-key org-owner1)]
-          (is (contains? (set (map :organization/id data)) "organizations-api-test-org")))))
+          (is (contains? (set (map :organization/id data)) organization-id)))))
 
     (testing "edit organization"
       (testing "as owner"
         (let [data (api-call :put "/api/organizations/edit"
-                             {:organization/id "organizations-api-test-org"
+                             {:organization/id organization-id
                               :organization/name {:fi "Organisaatiot API Test ORG 2"
                                                   :en "Organizations API Test ORG 2"}
                               :organization/short-name {:fi "ORG2" :en "ORG2"}
@@ -94,8 +95,8 @@
                                                             :name {:fi "Organisaatiot 2 API Test ORG Katselmoijat"
                                                                    :en "Organizations 2 API Test ORG Reviewers"}}]}
                              api-key owner)]
-          (is (= "organizations-api-test-org" (:organization/id data)))
-          (is (= {:organization/id "organizations-api-test-org"
+          (is (= organization-id (:organization/id data)))
+          (is (= {:organization/id organization-id
                   :organization/name {:fi "Organisaatiot API Test ORG 2"
                                       :en "Organizations API Test ORG 2"}
                   :organization/short-name {:fi "ORG2" :en "ORG2"}
@@ -107,11 +108,11 @@
                                                        :en "Organizations 2 API Test ORG Reviewers"}}]
                   :enabled true
                   :archived false}
-                 (find-first (comp #{"organizations-api-test-org"} :organization/id) (get-orgs owner))
-                 (get-org owner "organizations-api-test-org"))))
+                 (find-first (comp #{organization-id} :organization/id) (get-orgs owner))
+                 (get-org owner organization-id))))
         (testing "that is also an organization owner can edit"
           (api-call :put "/api/organizations/edit"
-                    {:organization/id "organizations-api-test-org"
+                    {:organization/id organization-id
                      :organization/name {:fi "Organisaatiot API Test ORG 2"
                                          :en "Organizations API Test ORG 2"}
                      :organization/short-name {:fi "ORG2" :en "ORG2"}
@@ -120,7 +121,7 @@
                                                    :name {:fi "Organisaatiot 2 API Test ORG Katselmoijat"
                                                           :en "Organizations 2 API Test ORG Reviewers"}}]}
                     api-key owner)
-          (is (= {:organization/id "organizations-api-test-org"
+          (is (= {:organization/id organization-id
                   :organization/name {:fi "Organisaatiot API Test ORG 2"
                                       :en "Organizations API Test ORG 2"}
                   :organization/short-name {:fi "ORG2" :en "ORG2"}
@@ -131,12 +132,12 @@
                                                        :en "Organizations 2 API Test ORG Reviewers"}}]
                   :enabled true
                   :archived false}
-                 (find-first (comp #{"organizations-api-test-org"} :organization/id) (get-orgs owner))
-                 (get-org owner "organizations-api-test-org")))))
+                 (find-first (comp #{organization-id} :organization/id) (get-orgs owner))
+                 (get-org owner organization-id)))))
 
       (testing "as organization-owner"
         (let [data (api-call :put "/api/organizations/edit"
-                             {:organization/id "organizations-api-test-org"
+                             {:organization/id organization-id
                               :organization/name {:fi "Organisaatiot API Test ORG 3"
                                                   :en "Organizations API Test ORG 3"}
                               :organization/short-name {:fi "ORG3" :en "ORG3"}
@@ -145,26 +146,60 @@
                                                             :name {:fi "Organisaatiot 3 API Test ORG Katselmoijat"
                                                                    :en "Organizations 3 API Test ORG Reviewers"}}]}
                              api-key org-owner1)]
-          (is (= "organizations-api-test-org" (:organization/id data)))
-          (is (= {:organization/id "organizations-api-test-org"
+          (is (= organization-id (:organization/id data)))
+          (is (= {:organization/id organization-id
                   :organization/name {:fi "Organisaatiot API Test ORG 3"
                                       :en "Organizations API Test ORG 3"}
                   :organization/short-name {:fi "ORG3" :en "ORG3"}
-                  :organization/owners [{:userid org-owner1 :email "organization-owner1@example.com" :name "Organization Owner 1"}
-                                        {:userid org-owner2 :email "organization-owner2@example.com" :name "Organization Owner 2"}] ; owners is not changed
+                  :organization/owners [{:userid org-owner2 :email "organization-owner2@example.com" :name "Organization Owner 2"}]
                   :organization/review-emails [{:email "test@organization3.test.org"
                                                 :name {:fi "Organisaatiot 3 API Test ORG Katselmoijat"
                                                        :en "Organizations 3 API Test ORG Reviewers"}}]
                   :enabled true
                   :archived false}
-                 (find-first (comp #{"organizations-api-test-org"} :organization/id) (get-orgs owner))
-                 (get-org owner "organizations-api-test-org"))))))))
+                 (find-first (comp #{organization-id} :organization/id) (get-orgs owner))
+                 (get-org owner organization-id))))
+        (testing "unable to edit organization owners when no longer organization owner"
+          ;; XXX: org owner loses the role #{:organization-owner} if user is not
+          ;; organization owner in any org. hence we create a second org which
+          ;; maintains this role.
+          (api-call :post "/api/organizations/create"
+                    {:organization/id organization-id-2
+                     :organization/name {:fi "Organisaatiot API Test ORG"
+                                         :en "Organizations API Test ORG"}
+                     :organization/short-name {:fi "ORG" :en "ORG"}
+                     :organization/owners [{:userid org-owner1}]
+                     :organization/review-emails []}
+                    api-key owner)
+          (let [data (api-call :put "/api/organizations/edit"
+                               {:organization/id organization-id
+                                :organization/name {:fi "Organisaatiot API Test ORG 3"
+                                                    :en "Organizations API Test ORG 3"}
+                                :organization/short-name {:fi "ORG3" :en "ORG3"}
+                                :organization/owners [{:userid org-owner1}]
+                                :organization/review-emails [{:email "test@organization3.test.org"
+                                                              :name {:fi "Organisaatiot 3 API Test ORG Katselmoijat"
+                                                                     :en "Organizations 3 API Test ORG Reviewers"}}]}
+                               api-key org-owner1)]
+            (is (= organization-id (:organization/id data)))
+            (is (= {:organization/id organization-id
+                    :organization/name {:fi "Organisaatiot API Test ORG 3"
+                                        :en "Organizations API Test ORG 3"}
+                    :organization/short-name {:fi "ORG3" :en "ORG3"}
+                    :organization/owners [{:userid org-owner2 :email "organization-owner2@example.com" :name "Organization Owner 2"}]
+                    :organization/review-emails [{:email "test@organization3.test.org"
+                                                  :name {:fi "Organisaatiot 3 API Test ORG Katselmoijat"
+                                                         :en "Organizations 3 API Test ORG Reviewers"}}]
+                    :enabled true
+                    :archived false}
+                   (find-first (comp #{organization-id} :organization/id) (get-orgs owner))
+                   (get-org owner organization-id)))))))))
 
 (deftest organization-api-status-test
   (api-key/add-api-key! "42")
   (test-helpers/create-user! {:userid "owner" :name "Owner" :email "owner@example.com"} :owner)
   (api-call :post "/api/organizations/create"
-            {:organization/id "organizations-api-test-org"
+            {:organization/id organization-id
              :organization/name {:fi "Organisaatiot API Test ORG"
                                  :en "Organizations API Test ORG"}
              :organization/short-name {:fi "ORG" :en "ORG"}
@@ -177,22 +212,22 @@
                               (select-keys [:enabled :archived])))]
     (is (= {:enabled true :archived false} (get-status)) "initially enabled, not archived")
     (api-call :put "/api/organizations/enabled"
-              {:organization/id "organizations-api-test-org"
+              {:organization/id organization-id
                :enabled false}
               "42" "owner")
     (is (= {:enabled false :archived false} (get-status)))
     (api-call :put "/api/organizations/archived"
-              {:organization/id "organizations-api-test-org"
+              {:organization/id organization-id
                :archived true}
               "42" "owner")
     (is (= {:enabled false :archived true} (get-status)))
     (api-call :put "/api/organizations/enabled"
-              {:organization/id "organizations-api-test-org"
+              {:organization/id organization-id
                :enabled true}
               "42" "owner")
     (is (= {:enabled true :archived true} (get-status)))
     (api-call :put "/api/organizations/archived"
-              {:organization/id "organizations-api-test-org"
+              {:organization/id organization-id
                :archived false}
               "42" "owner")
     (is (= {:enabled true :archived false} (get-status)))))

--- a/test/clj/rems/test_browser.clj
+++ b/test/clj/rems/test_browser.clj
@@ -2490,6 +2490,13 @@
                               :name "Organization Owner 2"
                               :email "organization-owner2@example.com"
                               :organizations [{:organization/id "Default"}]})
+  (test-helpers/create-organization! {:actor "owner"
+                                      :organization/id "organization-owner2-dummy-organization"
+                                      :organization/short-name {:en "dummy-en" :fi "dummy-fi" :sv "dummy-sv"}
+                                      :organization/name {:en (str "dummy-organization-" " en")
+                                                          :fi (str "dummy-organization-" " fi")
+                                                          :sv (str "dummy-organization-" " sv")}
+                                      :organization/owners [{:userid "organization-owner2"}]})
 
   (btu/with-postmortem
     (login-as "owner")
@@ -2593,7 +2600,7 @@
                 "Active" true}
                (slurp-fields :organization))))
 
-      (testing "edit as organization owner 1"
+      (testing "edit as organization owner 2"
         (btu/scroll-and-click :edit-organization)
         (btu/wait-page-loaded)
         (is (btu/eventually-visible? :short-name-en))
@@ -2622,40 +2629,39 @@
                   "Name (EN)" "Review mail EN"
                   "Email" "review.email@example.com"
                   "Active" true}
-                 (slurp-fields :organization)))))
-
-      (testing "edit as organization owner 1, remove self as organization owner"
-        (btu/scroll-and-click :edit-organization)
-        (btu/wait-page-loaded)
-        (is (btu/eventually-visible? :short-name-en))
-
-        (remove-option "Owners (optional)" "Organization Owner 1")
-        (btu/scroll-and-click :save)
-        (is (btu/eventually-visible? {:css ".alert-success"}))
-        (is (str/includes? (btu/get-element-text {:css ".alert-success"}) "Success"))
-
-        (testing "view after editing, organization owner 1 is no longer in organization owners"
-          (is (btu/eventually-visible? :organization))
-          (is (= {"Id" (btu/context-getx :organization-id)
-                  "Short name (FI)" "SNFI"
-                  "Short name (EN)" "SNEN"
-                  "Short name (SV)" "SNSV"
-                  "Title (EN)" (str (btu/context-getx :organization-name) " EN")
-                  "Title (FI)" (str (btu/context-getx :organization-name) " FI")
-                  "Title (SV)" (str (btu/context-getx :organization-name) " SV")
-                  "Owners" "Organization Owner 2 (organization-owner2@example.com)"
-                  "Name (FI)" "Review mail FI"
-                  "Name (SV)" "Review mail SV"
-                  "Name (EN)" "Review mail EN"
-                  "Email" "review.email@example.com"
-                  "Active" true}
                  (slurp-fields :organization))))
-
-        (testing "edit organization again, owners field should be disabled"
+        (testing "edit again, remove self as organization owner"
           (btu/scroll-and-click :edit-organization)
           (btu/wait-page-loaded)
           (is (btu/eventually-visible? :short-name-en))
-          (is (btu/disabled? {:id (get-dropdown-id "Owners (optional)")})))))))
+
+          (remove-option "Owners (optional)" "Organization Owner 2")
+          (btu/scroll-and-click :save)
+          (is (btu/eventually-visible? {:css ".alert-success"}))
+          (is (str/includes? (btu/get-element-text {:css ".alert-success"}) "Success"))
+
+          (testing "view after editing, organization owner 2 is no longer in organization owners"
+            (is (btu/eventually-visible? :organization))
+            (is (= {"Id" (btu/context-getx :organization-id)
+                    "Short name (FI)" "SNFI"
+                    "Short name (EN)" "SNEN"
+                    "Short name (SV)" "SNSV"
+                    "Title (EN)" (str (btu/context-getx :organization-name) " EN")
+                    "Title (FI)" (str (btu/context-getx :organization-name) " FI")
+                    "Title (SV)" (str (btu/context-getx :organization-name) " SV")
+                    "Owners" "Organization Owner 1 (organization-owner1@example.com)"
+                    "Name (FI)" "Review mail FI"
+                    "Name (SV)" "Review mail SV"
+                    "Name (EN)" "Review mail EN"
+                    "Email" "review.email@example.com"
+                    "Active" true}
+                   (slurp-fields :organization))))
+
+          (testing "edit organization again, owners field should be disabled"
+            (btu/scroll-and-click :edit-organization)
+            (btu/wait-page-loaded)
+            (is (btu/eventually-visible? :short-name-en))
+            (is (btu/disabled? {:id (get-dropdown-id "Owners (optional)")}))))))))
 
 (deftest test-small-navbar
   (testing "create a test application with the API to have another page to navigate to"


### PR DESCRIPTION
relates #2828

Allow organization owner to edit own organizations owners the same as regular owner. Testing needed additional setup, since user loses organization owner role if they dont belong to any organizations owners. Hence organization-id-2 in test-organizations.

# Checklist for author

Remove items that aren't applicable, check items that are done.

## Reviewability
- [x] Link to issue

## Documentation
- [x] Update changelog if necessary

## Testing
- [x] Valuable features are integration / browser / acceptance tested automatically

## Follow-up
- [ ] New tasks are created for pending or remaining tasks
