### PR TITLE
Unify API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ have notable changes.
 
 Changes since v2.29
 
+### Changes
+- Some API methods have been unified with the rest by using the command pattern: (#3036)
+  - Categories have a new `POST /create` and a `PUT /edit` endpoint like the others.
+  - User settings have a new `PUT /edit` endpoint.
+  - User has a `PUT /edit` endpoint, `/create` remains "create or update".
+  - The changes should be backwards-compatible as the old endpoints remain.
+  - The non-standard endpoints have been been deprecated and will be removed later.
+
 ### Additions
 - Application list in UI can now be configured to hide certain columns using config option `:application-list-hidden-columns`. (#2861)
 - Mondo codes have been updated to version v2022-08-01. (#3031)

--- a/resources/sql/queries.sql
+++ b/resources/sql/queries.sql
@@ -500,6 +500,11 @@ VALUES (:user, :userattrs::jsonb)
 ON CONFLICT (userId)
 DO UPDATE SET userAttrs = :userattrs::jsonb;
 
+-- :name edit-user! :!
+UPDATE users
+SET userAttrs = :userattrs::jsonb
+WHERE userId = :user;
+
 -- :name remove-user! :!
 DELETE from users
 WHERE userId = :user;

--- a/src/clj/rems/api/categories.clj
+++ b/src/clj/rems/api/categories.clj
@@ -33,15 +33,31 @@
         (ok category)
         (not-found-json-response)))
 
-    (POST "/" []
+    (POST "/create" []
       :summary "Create category"
       :roles +admin-write-roles+
       :body [command schema/CreateCategoryCommand]
       :return CreateCategoryResponse
       (ok (category/create-category! command)))
 
-    (PUT "/" []
+    (PUT "/edit" []
       :summary "Update category"
+      :roles +admin-write-roles+
+      :body [command schema/UpdateCategoryCommand]
+      :return schema/SuccessResponse
+      (if (category/get-category (:category/id command))
+        (ok (category/update-category! command))
+        (not-found-json-response)))
+
+    (POST "/" []
+      :summary "Create category. DEPRECATED, will disappear, use /create instead"
+      :roles +admin-write-roles+
+      :body [command schema/CreateCategoryCommand]
+      :return CreateCategoryResponse
+      (ok (category/create-category! command)))
+
+    (PUT "/" []
+      :summary "Update category, DEPRECATED, will disappear, use /edit instead"
       :roles +admin-write-roles+
       :body [command schema/UpdateCategoryCommand]
       :return schema/SuccessResponse

--- a/src/clj/rems/api/user_settings.clj
+++ b/src/clj/rems/api/user_settings.clj
@@ -32,8 +32,15 @@
       :return GetUserSettings
       (ok (user-settings/get-user-settings (get-user-id))))
 
-    (PUT "/" []
+    (PUT "/edit" []
       :summary "Update user settings"
+      :roles #{:logged-in}
+      :body [settings UpdateUserSettings]
+      :return schema/SuccessResponse
+      (ok (user-settings/update-user-settings! (getx-user-id) settings)))
+
+    (PUT "/" []
+      :summary "Update user settings, DEPRECATED, will disappear, use /edit instead"
       :roles #{:logged-in}
       :body [settings UpdateUserSettings]
       :return schema/SuccessResponse

--- a/src/clj/rems/api/users.clj
+++ b/src/clj/rems/api/users.clj
@@ -18,6 +18,8 @@
    (s/optional-key :organizations) [schema-base/OrganizationId]
    s/Keyword s/Any})
 
+(def EditUserCommand CreateUserCommand)
+
 (def users-api
   (context "/users" []
     :tags ["users"]
@@ -28,6 +30,14 @@
       :body [command CreateUserCommand]
       :return schema/SuccessResponse
       (users/add-user! command)
+      (ok {:success true}))
+
+    (PUT "/edit" []
+      :summary "Update user"
+      :roles #{:owner :user-owner}
+      :body [command EditUserCommand]
+      :return schema/SuccessResponse
+      (users/edit-user! command)
       (ok {:success true}))
 
     (GET "/active" []

--- a/src/clj/rems/api/users.clj
+++ b/src/clj/rems/api/users.clj
@@ -18,7 +18,7 @@
    (s/optional-key :organizations) [schema-base/OrganizationId]
    s/Keyword s/Any})
 
-(def EditUserCommand CreateUserCommand)
+(s/defschema EditUserCommand CreateUserCommand)
 
 (def users-api
   (context "/users" []

--- a/src/clj/rems/db/users.clj
+++ b/src/clj/rems/db/users.clj
@@ -58,6 +58,11 @@
   [user]
   (add-user-raw! (:userid user) (unformat-user user)))
 
+(defn edit-user!
+  "Update a user given formatted user attributes."
+  [user]
+  (db/edit-user! {:user (:userid user) :userattrs (json/generate-string (unformat-user user))}))
+
 (defn get-raw-user-attributes
   "Takes as user id as an input and fetches user attributes that are stored in a json blob in the users table.
 

--- a/src/cljs/rems/administration/create_category.cljs
+++ b/src/cljs/rems/administration/create_category.cljs
@@ -58,7 +58,7 @@
  ::create-category
  (fn [_ [_ request]]
    (let [description [text :t.administration/save]]
-     (post! "/api/categories"
+     (post! "/api/categories/create"
             {:params request
              :handler (flash-message/default-success-handler
                        :top description #(navigate! (str "/administration/categories/" (:category/id %))))

--- a/src/cljs/rems/administration/edit_category.cljs
+++ b/src/cljs/rems/administration/edit_category.cljs
@@ -75,7 +75,7 @@
  (fn [{:keys [db]} [_ request]]
    (let [description [text :t.administration/save]
          category-id (parse-int (::category-id db))]
-     (put! (str "/api/categories")
+     (put! (str "/api/categories/edit")
            {:params (assoc request :category/id category-id)
             :handler (flash-message/status-update-handler
                       :top description #(navigate! (str "/administration/categories/" category-id)))

--- a/src/cljs/rems/profile.cljs
+++ b/src/cljs/rems/profile.cljs
@@ -39,7 +39,7 @@
  ::save
  (fn [{:keys [db]} _]
    (let [description [text :t.profile/save]]
-     (put! "/api/user-settings"
+     (put! "/api/user-settings/edit"
            {:params (::form db)
             :handler (flash-message/default-success-handler :top description
                                                             #(rf/dispatch [::user-settings]))

--- a/src/cljs/rems/user_settings.cljs
+++ b/src/cljs/rems/user_settings.cljs
@@ -101,7 +101,7 @@
  (fn [{:keys [db]} [_ language]]
    (let [user-id (get-in db [:identity :user :userid])]
      (when user-id
-       (put! "/api/user-settings"
+       (put! "/api/user-settings/edit"
              {:params {:language language}
               :handler #(rf/dispatch [::fetch-user-settings])
               :error-handler (flash-message/default-error-handler :top "Update user settings")}))

--- a/test/clj/rems/api/test_categories.clj
+++ b/test/clj/rems/api/test_categories.clj
@@ -30,7 +30,7 @@
           (is (= {:error "not found"} (read-body response)))))
 
       (testing "create"
-        (let [category (api-call :post "/api/categories"
+        (let [category (api-call :post "/api/categories/create"
                                  create-category-data
                                  +test-api-key+ user-id)]
           (is (:success category))
@@ -45,13 +45,13 @@
               (is (= expected result))))))
 
       (testing "adding category as children"
-        (let [dep-category (api-call :post "/api/categories"
+        (let [dep-category (api-call :post "/api/categories/create"
                                      create-category-data
                                      +test-api-key+ user-id)]
           (is (:success dep-category))
           (is (int? (:category/id dep-category)))
 
-          (let [category (api-call :post "/api/categories"
+          (let [category (api-call :post "/api/categories/create"
                                    (merge create-category-data
                                           {:category/children [{:category/id (:category/id dep-category)}]})
                                    +test-api-key+ user-id)]
@@ -70,7 +70,7 @@
               (is (= expected result))))))
 
       (testing "creating category with non-existing children should fail"
-        (let [result (api-call :post "/api/categories"
+        (let [result (api-call :post "/api/categories/create"
                                (merge create-category-data
                                       {:category/children [{:category/id 9999999}]})
                                +test-api-key+ user-id)]
@@ -94,14 +94,14 @@
                                                :en "integration test 2"}}]
     (doseq [user-id [owner org-owner]]
       (testing "create"
-        (let [category (api-call :post "/api/categories"
+        (let [category (api-call :post "/api/categories/create"
                                  create-category-data
                                  +test-api-key+ user-id)]
           (is (:success category))
           (is (int? (:category/id category)))
 
           (testing "and update"
-            (let [update-result (api-call :put "/api/categories"
+            (let [update-result (api-call :put "/api/categories/edit"
                                           (merge create-category-data
                                                  update-category-data
                                                  {:category/id (:category/id category)})
@@ -116,7 +116,7 @@
                 (is (= expected result)))))
 
           (testing "updating category with self as child should fail"
-            (let [result (api-call :put "/api/categories"
+            (let [result (api-call :put "/api/categories/edit"
                                    (merge create-category-data
                                           update-category-data
                                           {:category/id (:category/id category)
@@ -128,19 +128,19 @@
                      (:errors result)))))
 
           (testing "should error when setting ancestor categories as category children"
-            (let [ancestor-category (api-call :post "/api/categories"
+            (let [ancestor-category (api-call :post "/api/categories/create"
                                               (merge create-category-data
                                                      {:category/children [{:category/id (:category/id category)}]})
                                               +test-api-key+ user-id)
-                  subcategory (api-call :post "/api/categories"
+                  subcategory (api-call :post "/api/categories/create"
                                         create-category-data
                                         +test-api-key+ user-id)
-                  update-parent-result (api-call :put "/api/categories"
+                  update-parent-result (api-call :put "/api/categories/edit"
                                                  (merge create-category-data
                                                         {:category/id (:category/id category)
                                                          :category/children [{:category/id (:category/id subcategory)}]})
                                                  +test-api-key+ user-id)
-                  loop-update-result (api-call :put "/api/categories"
+                  loop-update-result (api-call :put "/api/categories/edit"
                                                (merge create-category-data
                                                       {:category/id (:category/id subcategory)
                                                        :category/children [{:category/id (:category/id ancestor-category)}
@@ -156,7 +156,7 @@
                      (:errors loop-update-result)))))))
 
       (testing "updating non-existing category returns 404"
-        (let [response (api-response :put "/api/categories"
+        (let [response (api-response :put "/api/categories/edit"
                                      (merge create-category-data
                                             update-category-data
                                             {:category/id 9999999})
@@ -177,10 +177,10 @@
 
     (doseq [user-id [owner org-owner]]
       (testing "create"
-        (let [dep-category (api-call :post "/api/categories"
+        (let [dep-category (api-call :post "/api/categories/create"
                                      create-category-data
                                      +test-api-key+ user-id)
-              category (api-call :post "/api/categories"
+              category (api-call :post "/api/categories/create"
                                  (merge create-category-data
                                         {:category/children [{:category/id (:category/id dep-category)}]})
                                  +test-api-key+ user-id)]
@@ -201,13 +201,13 @@
                 (is (= {:error "not found"} (read-body response))))))))
 
       (testing "cannot delete category that is depended on by another category"
-        (let [dep-category (api-call :post "/api/categories"
+        (let [dep-category (api-call :post "/api/categories/create"
                                      create-category-data
                                      +test-api-key+ user-id)]
           (is (:success dep-category))
           (is (int? (:category/id dep-category)))
 
-          (let [category (api-call :post "/api/categories"
+          (let [category (api-call :post "/api/categories/create"
                                    (merge create-category-data
                                           {:category/children [{:category/id (:category/id dep-category)}]})
                                    +test-api-key+ user-id)]
@@ -224,7 +224,7 @@
                      (:errors result)))))))
 
       (testing "cannot delete category that is depended on by a catalogue item"
-        (let [dep-category (api-call :post "/api/categories"
+        (let [dep-category (api-call :post "/api/categories/create"
                                      create-category-data
                                      +test-api-key+ user-id)]
           (is (:success dep-category))

--- a/test/clj/rems/api/test_user_settings.clj
+++ b/test/clj/rems/api/test_user_settings.clj
@@ -39,7 +39,7 @@
                  read-ok-body))))
 
     (testing "update user settings"
-      (-> (request :put "/api/user-settings")
+      (-> (request :put "/api/user-settings/edit")
           (json-body {:language :fi})
           (authenticate "42" user-id)
           handler

--- a/test/clj/rems/api/test_users.clj
+++ b/test/clj/rems/api/test_users.clj
@@ -38,8 +38,8 @@
               :email "d@av.id"
               :name "David Newuser"} (users/get-user userid))))
 
-    (testing "update (or, create is idempotent)"
-      (-> (request :post (str "/api/users/create"))
+    (testing "update with edit"
+      (-> (request :put (str "/api/users/edit"))
           (json-body (assoc new-user
                             :email "new email"
                             :name "new name"))
@@ -48,7 +48,19 @@
           assert-response-is-ok)
       (is (= {:userid "david"
               :email "new email"
-              :name "new name"} (users/get-user userid)))))
+              :name "new name"} (users/get-user userid))))
+
+    (testing "update with create (idempotent)"
+      (-> (request :post (str "/api/users/create"))
+          (json-body (assoc new-user
+                            :email "new email2"
+                            :name "new name2"))
+          (authenticate +test-api-key+ "owner")
+          handler
+          assert-response-is-ok)
+      (is (= {:userid "david"
+              :email "new email2"
+              :name "new name2"} (users/get-user userid)))))
 
   (testing "create user with organization and nickname, without email"
     (let [userid "user-with-org"]


### PR DESCRIPTION
Closes #3036

Some API methods have been unified with the rest by using the command pattern:
- Categories have a new `POST /create` and a `PUT /edit` endpoint like the others.
- User settings have a new `PUT /edit` endpoint.
- User has a `PUT /edit` endpoint, `/create` remains "create or update".
- The changes should be backwards-compatible as the old endpoints remain.
- The non-standard endpoints have been been deprecated and will be removed later.

# Checklist for author

Remove items that aren't applicable, check items that are done.

## Reviewability
- [x] Link to issue

## Backwards compatibility
- [x] API is backwards compatible or completely new

## Documentation
- [x] Update changelog if necessary
- [x] API is documented and shows up in Swagger UI

## Testing
- [x] Complex logic is unit tested
- [x] Valuable features are integration / browser / acceptance tested automatically
