### PR TITLE
Autosave improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ Changes since v2.29
   - User has a `PUT /edit` endpoint, `/create` remains "create or update".
   - The changes should be backwards-compatible as the old endpoints remain.
   - The non-standard endpoints have been been deprecated and will be removed later.
+- The text for saving has been changed "Alice saved a draft." -> "Alice updated the application.". This will be clearer in the future when autosave is enabled (#3045)
+- When continuing an old application, the applicant will be shown a warning about problematic fields. (#3045)
 
 ### Additions
 - Application list in UI can now be configured to hide certain columns using config option `:application-list-hidden-columns`. (#2861)

--- a/resources/translations/en.edn
+++ b/resources/translations/en.edn
@@ -174,6 +174,7 @@
                  :applicant "Applicant"
                  :application "Application"
                  :applications "Applications"
+                 :continue-existing-application "Continue application"
                  :copied-from "copied from"
                  :copied-to "copied to"
                  :created "Created"

--- a/resources/translations/en.edn
+++ b/resources/translations/en.edn
@@ -199,7 +199,7 @@
                           ;; %2 - name of decider
                           :decision-requested "%1 requested a decision from %2."
                           :deleted "%1 deleted the draft."
-                          :draft-saved "%1 saved a draft."
+                          :draft-saved "%1 updated the application."
                           ;; %2 - external id
                           :external-id-assigned "%1 assigned an external id %2."
                           :expiration-notifications-sent "%1 sent expiration notification email."

--- a/resources/translations/en.edn
+++ b/resources/translations/en.edn
@@ -475,6 +475,7 @@
          :invalid-attachment "Attachment file type not allowed."
          :too-large-attachment "The attachment is too large."
          :attachment-max-size "Allowed maximum size of an attachment: %1."
+         :last-save "Last save %1."
          :licenses "Terms of use"
          ;; %1 - number
          :maxlength "(max %1 characters)"

--- a/resources/translations/fi.edn
+++ b/resources/translations/fi.edn
@@ -188,7 +188,7 @@
                           :decider-joined "%1 hyväksyi kutsun päättämään."
                           :decision-requested "%1 pyysi päätöstä käyttäjältä %2."
                           :deleted "%1 poisti luonnoksen."
-                          :draft-saved "%1 tallensi luonnoksen."
+                          :draft-saved "%1 päivitti hakemusta."
                           :external-id-assigned "%1 lisäsi tunnisteen %2."
                           :expiration-notifications-sent "%1 lähetti sähköpostimuistutuksen vanhentuvasta hakemuksesta."
                           :licenses-accepted "%1 hyväksyi käyttöehdot."

--- a/resources/translations/fi.edn
+++ b/resources/translations/fi.edn
@@ -170,6 +170,7 @@
                  :applicant "Hakija"
                  :application "Hakemus"
                  :applications "Hakemukset"
+                 :continue-existing-application "Jatka hakemusta"
                  :copied-from "kopioitu hakemuksesta"
                  :copied-to "kopioitu hakemukseksi"
                  :created "Luotu"

--- a/resources/translations/fi.edn
+++ b/resources/translations/fi.edn
@@ -432,6 +432,7 @@
          :failed "Epäonnistui"
          :has-accepted-licenses "Käyttöehdot hyväksytty."
          :invalid-attachment "Liitteen tiedostomuoto ei ole sallittu."
+         :last-save "Viimeisin talletus %1."
          :too-large-attachment "Liite on liian suuri."
          :attachment-max-size "Liitetiedoston suurin sallittu koko: %1."
          :licenses "Käyttöehdot"

--- a/resources/translations/sv.edn
+++ b/resources/translations/sv.edn
@@ -432,6 +432,7 @@
          :failed "Misslyckades"
          :has-accepted-licenses "Har accepterat licenserna."
          :invalid-attachment "Filtyp inte tillåten."
+         :last-save "Senaste sparning %1."
          :too-large-attachment "Bilagan är för stort."
          :attachment-max-size "Maximal storlek på bilaga: %1."
          :licenses "Licenser"

--- a/resources/translations/sv.edn
+++ b/resources/translations/sv.edn
@@ -188,7 +188,7 @@
                           :decider-joined "%1 blev beslutare." ; TODO check
                           :decision-requested "%1 begärde beslut från användare %2."
                           :deleted "%1 raderade utkastet."
-                          :draft-saved "%1 sparade ett utkast."
+                          :draft-saved "%1 förändrade ansökan."
                           :external-id-assigned "%1 lade till externt id %2."
                           :expiration-notifications-sent "%1 skickade e-post p.g.a. inaktiv ansökan."
                           :licenses-accepted "%1 accepterade licenserna."

--- a/resources/translations/sv.edn
+++ b/resources/translations/sv.edn
@@ -170,6 +170,7 @@
                  :applicant "Sökande"
                  :application "Ansökan"
                  :applications "Ansökningar"
+                 :continue-existing-application "Återuppta ansökan"
                  :copied-from "Kopierat från ansökan"
                  :copied-to "Kopierat till ansökan"
                  :created "Skapad"

--- a/src/clj/rems/application/commands.clj
+++ b/src/clj/rems/application/commands.clj
@@ -369,6 +369,14 @@
           (ok-with-data {:application-id (:application/id event)}
                         [event]))))))
 
+(defn validate-application [application field-values]
+  (let [forms (for [form (:application/forms application)]
+                (-> form
+                    (form/enrich-form-answers field-values nil)
+                    (form/enrich-form-field-visible)))]
+    (merge (form-validation-errors forms)
+           (form-validation-warnings forms))))
+
 (defmethod command-handler :application.command/save-draft
   [cmd application _injections]
   (let [answers (:field-values cmd)

--- a/src/clj/rems/css/styles.clj
+++ b/src/clj/rems/css/styles.clj
@@ -678,7 +678,8 @@
    ;; and overrides that for example when there is a sibling .form-control.is-invalid,
    ;; but that doesn't work with checkbox groups, dropdowns, etc., and we anyways
    ;; don't need the feature of hiding this div with CSS when it has no content.
-   [:div.invalid-feedback {:display :block}]
+   [:div.invalid-feedback {:display :block
+                           :font-size :inherit}]
 
    ;; custom checkbox
    [:.readonly-checkbox {:background-color "#ccc"}]

--- a/src/cljc/rems/text.cljc
+++ b/src/cljc/rems/text.cljc
@@ -92,6 +92,9 @@
 (defn- time-format []
   (time-format/formatter "yyyy-MM-dd HH:mm" (time/default-time-zone)))
 
+(defn- time-format-with-seconds []
+  (time-format/formatter "yyyy-MM-dd HH:mm:ss" (time/default-time-zone)))
+
 (defn localize-time [time]
   #?(:clj (when time
             (let [time (if (string? time) (time-format/parse time) time)]
@@ -99,6 +102,16 @@
      :cljs (let [time (if (string? time) (time-format/parse time) time)]
              (when time
                (time-format/unparse-local (time-format) (time/to-default-time-zone time))))))
+
+(defn localize-time-with-seconds
+  "Localized datetime with second precision."
+  [time]
+  #?(:clj (when time
+            (let [time (if (string? time) (time-format/parse time) time)]
+              (time-format/unparse (time-format-with-seconds) time)))
+     :cljs (let [time (if (string? time) (time-format/parse time) time)]
+             (when time
+               (time-format/unparse-local (time-format-with-seconds) (time/to-default-time-zone time))))))
 
 (defn localize-utc-date
   "For a given time instant, return the ISO date (yyyy-MM-dd) that it corresponds to in UTC."

--- a/src/cljs/rems/application.cljs
+++ b/src/cljs/rems/application.cljs
@@ -183,23 +183,31 @@
         :when (form/field-visible? field (get field-values form-id))]
     {:form form-id :field field-id :value (get-in field-values [form-id field-id])}))
 
-(defn- handle-validations! [{:keys [errors warnings success] :as _response} description application & [{:keys [on-success default-success? focus?] :or {default-success? true focus? true}}]]
-  (flash-message/clear-message! :top-validation)
-  (rf/dispatch [::set-validations errors warnings])
-  (if-not success
-    (flash-message/show-default-error! :top-validation
-                                       description
-                                       [validations {:application application
-                                                     :errors errors}])
-    (do
-      (if (seq warnings)
-        (flash-message/show-default-warning! :top-validation
-                                             description
-                                             {:focus? focus?
-                                              :content [[validations {:application application
-                                                                      :warnings warnings}]]})
-        (when default-success? (flash-message/show-default-success! :top-validation description)))
-      (when on-success (on-success)))))
+(defn- handle-validations!
+  [{:keys [errors warnings success] :as _response}
+   description
+   application
+   & [{:keys [on-success default-success? focus? warn-about-missing?]
+       :or {default-success? true
+            focus? true
+            warn-about-missing? true}}]]
+  (let [warnings (if warn-about-missing? warnings (remove (comp #{:t.form.validation/required} :type) warnings))]
+    (flash-message/clear-message! :top-validation)
+    (rf/dispatch [::set-validations errors warnings])
+    (if-not success
+      (flash-message/show-default-error! :top-validation
+                                         description
+                                         [validations {:application application
+                                                       :errors errors}])
+      (do
+        (if (seq warnings)
+          (flash-message/show-default-warning! :top-validation
+                                               description
+                                               {:focus? focus?
+                                                :content [[validations {:application application
+                                                                        :warnings warnings}]]})
+          (when default-success? (flash-message/show-default-success! :top-validation description)))
+        (when on-success (on-success))))))
 
 (defn- duo-codes-to-api [duo-codes]
   (for [duo duo-codes]
@@ -258,7 +266,8 @@
                                                                                                                                            " "
                                                                                                                                            (localize-time-with-seconds (time-core/now))]))
                                                                              :default-success? false
-                                                                             :focus? false}))
+                                                                             :focus? false
+                                                                             :warn-about-missing? false}))
                     {:error-handler (fn [err]
                                       (rf/dispatch [::set-autosaving false]))})
        {:db (-> db

--- a/src/cljs/rems/application.cljs
+++ b/src/cljs/rems/application.cljs
@@ -162,7 +162,8 @@
                                         :else (some? value)))
                                 field-values)
         any-duo-answer? (seq duo-codes)]
-    (when (or any-field-answer? any-duo-answer?)
+    (when (and (form-fields-editable? application)
+               (or any-field-answer? any-duo-answer?))
       (rf/dispatch [::validate-application]))
     (assoc db ::edit-application {:duo-codes duo-codes
                                   :field-values field-values-by-form-field

--- a/src/cljs/rems/application.cljs
+++ b/src/cljs/rems/application.cljs
@@ -242,7 +242,9 @@
                       :field-values (field-values-to-api application (:field-values edit-application))
                       :duo-codes (duo-codes-to-api (vals (:duo-codes edit-application)))}
              :handler (fn [response]
-                        (handle-validations! response description application {:default-success? false}))
+                        (handle-validations! (dissoc response :errors) ; only use the warnings in this step
+                                             description application {:default-success? false
+                                                                      :warn-about-missing? false})) ; don't complain about unfilled required fields
              :error-handler (flash-message/default-error-handler :actions description)})
      {})))
 

--- a/src/cljs/rems/application.cljs
+++ b/src/cljs/rems/application.cljs
@@ -287,10 +287,7 @@
                     (fn [response]
                       (rf/dispatch [::fetch-application (:application/id application) false])
                       (handle-validations! response description application {:on-success #(do (rf/dispatch [::set-autosaving false])
-                                                                                              (flash-message/show-quiet-success! :actions [:div
-                                                                                                                                           [text :t.form/autosave-confirmed]
-                                                                                                                                           " "
-                                                                                                                                           (localize-time-with-seconds (time-core/now))]))
+                                                                                              (flash-message/show-quiet-success! :actions [text :t.form/autosave-confirmed] {:content [[text-format :t.form/last-save (localize-time-with-seconds (time-core/now))]]}))
                                                                              :default-success? false
                                                                              :focus? false
                                                                              :warn-about-missing? false}))

--- a/src/cljs/rems/application.cljs
+++ b/src/cljs/rems/application.cljs
@@ -241,7 +241,7 @@
                       :field-values (field-values-to-api application (:field-values edit-application))
                       :duo-codes (duo-codes-to-api (vals (:duo-codes edit-application)))}
              :handler (fn [response]
-                        (handle-validations! response description application))
+                        (handle-validations! response description application {:default-success? false}))
              :error-handler (flash-message/default-error-handler :actions description)})
      {})))
 

--- a/src/cljs/rems/application.cljs
+++ b/src/cljs/rems/application.cljs
@@ -4,6 +4,7 @@
             [goog.string]
             [re-frame.core :as rf]
             [medley.core :refer [find-first update-existing]]
+            [cljs-time.core :as time-core]
             [rems.actions.accept-licenses :refer [accept-licenses-action-button]]
             [rems.actions.components :refer [button-wrapper]]
             [rems.actions.add-licenses :refer [add-licenses-action-button add-licenses-form]]
@@ -42,7 +43,7 @@
             [rems.guide-util :refer [component-info example lipsum lipsum-paragraphs]]
             [rems.phase :refer [phases]]
             [rems.spinner :as spinner]
-            [rems.text :refer [localize-decision localize-event localized localize-state localize-time text text-format]]
+            [rems.text :refer [localize-decision localize-event localized localize-state localize-time localize-time-with-seconds text text-format]]
             [rems.user :as user]
             [rems.util :refer [navigate! fetch post! focus-input-field focus-when-collapse-opened format-file-size]]))
 
@@ -253,7 +254,10 @@
                     (fn [response]
                       (rf/dispatch [::fetch-application (:application/id application) false])
                       (apply (handle-validations! description application {:on-success #(do (rf/dispatch [::set-autosaving false])
-                                                                                            (flash-message/show-quiet-success! :actions [text :t.form/autosave-confirmed]))
+                                                                                            (flash-message/show-quiet-success! :actions [:div
+                                                                                                                                         [text :t.form/autosave-confirmed]
+                                                                                                                                         " "
+                                                                                                                                         (localize-time-with-seconds (time-core/now))]))
                                                                            :default-success? false
                                                                            :focus? false})
                              [response]))

--- a/src/cljs/rems/flash_message.cljs
+++ b/src/cljs/rems/flash_message.cljs
@@ -57,7 +57,7 @@
   (let [message {:status :success
                  :location location
                  :content (into [:<>
-                                 [:div#status-warning.flash-message-title description]]
+                                 [:div#status-success.flash-message-title description]]
                                 (:content opts))}]
     (rf/dispatch [::show-flash-message message opts])))
 

--- a/src/cljs/rems/flash_message.cljs
+++ b/src/cljs/rems/flash_message.cljs
@@ -53,10 +53,13 @@
   (show-success! location
                  [:div#status-success.flash-message-title description ": " [text :t.form/success]]))
 
-(defn show-quiet-success! [location description]
-  (show-success! location
-                 [:div#status-success.flash-message-title description]
-                 {:focus? false}))
+(defn show-quiet-success! [location description & [opts]]
+  (let [message {:status :success
+                 :location location
+                 :content (into [:<>
+                                 [:div#status-warning.flash-message-title description]]
+                                (:content opts))}]
+    (rf/dispatch [::show-flash-message message opts])))
 
 (defn show-error! [location content & [opts]]
   (let [message {:status :danger

--- a/test/clj/rems/test_browser.clj
+++ b/test/clj/rems/test_browser.clj
@@ -546,7 +546,7 @@
         (btu/with-client-config {:enable-autosave true}
           (clear-form-field "Simple text field")
           (fill-form-field "Simple text field" "Private field answer")
-          (is (btu/eventually-visible? [{:id :status-success} {:fn/has-text "Application is saved."}]))
+          (is (btu/eventually-visible? [{:id :status-success :fn/has-text "Application is saved."}]))
           (is (btu/eventually-visible? :status-warning))
           (is (= ["Invalid email address."] ; only invalid values are warned about
                  (get-validation-summary))))

--- a/test/clj/rems/test_browser.clj
+++ b/test/clj/rems/test_browser.clj
@@ -546,10 +546,9 @@
         (btu/with-client-config {:enable-autosave true}
           (clear-form-field "Simple text field")
           (fill-form-field "Simple text field" "Private field answer")
-          (is (btu/eventually-visible? {:id :status-success :fn/text "Application is saved."}))
+          (is (btu/eventually-visible? [{:id :status-success} {:fn/has-text "Application is saved."}]))
           (is (btu/eventually-visible? :status-warning))
-          (is (= ["Field \"Text field\" is required."
-                  "Invalid email address."]
+          (is (= ["Invalid email address."] ; only invalid values are warned about
                  (get-validation-summary))))
 
         (testing "try to submit without accepting licenses or filling in a mandatory field"
@@ -924,6 +923,7 @@
         (btu/scroll-and-click [{:css ".users"} {:tag :a :fn/text "new-decider"}])
         (btu/wait-page-loaded)
         ;; NB: this differs a bit from `login-as` and we should keep them the same
+        (btu/wait-visible :logout)
         (is (btu/eventually-visible? {:tag :h1 :fn/has-text "test-invite-decider"}))))
     (testing "check decider-joined event"
       (is (= {:event/type :application.event/decider-joined


### PR DESCRIPTION
Closes #3045 

Bootstrap doesn't support warning color for field errors, and it seemed to just create a confusing experience and extra code anyway, so I decided not to do that one addition.

- Moved to #3051: should DUO be validated with `/validate`? likely yes

# Checklist for author

Remove items that aren't applicable, check items that are done.

## Reviewability
- [x] Link to issue
- [x] Consider adding screenshots for ease of review

## Backwards compatibility
- [x] API is backwards compatible or completely new

## Documentation
- [x] Update changelog if necessary
- [x] API is documented and shows up in Swagger UI

## Testing
- [ ] Valuable features are integration / browser / acceptance tested automatically (could potentially add "continue application" test)


![autosave-improvements](https://user-images.githubusercontent.com/823661/193232489-84f333a3-562b-44b0-bf86-713a6fa55ed2.png)
![continue-application](https://user-images.githubusercontent.com/823661/193232496-3b6c2686-adc1-4d7e-aa93-498b792829ae.png)
