### PR TITLE
Hide organization actions in organizations table for non organization owner

### DIFF
--- a/test/clj/rems/test_browser.clj
+++ b/test/clj/rems/test_browser.clj
@@ -2494,14 +2494,14 @@
 
     (btu/context-assoc! :organization-id (str "test-organizations org id " (btu/get-seed))
                         :organization-name (str "test-organizations org name " (btu/get-seed)))
-   
-   (testing "view all organizations"
-     (go-to-admin "Organizations")
-     (is (every? #{"ViewDisableArchive"}
-                 (->> (slurp-table :organizations)
-                      (filter not-empty)
-                      (map #(get % "commands"))))
-         "owner can see all actions for all organizations"))
+
+    (testing "view all organizations"
+      (go-to-admin "Organizations")
+      (is (every? #{"ViewDisableArchive"}
+                  (->> (slurp-table :organizations)
+                       (filter not-empty)
+                       (map #(get % "commands"))))
+          "owner can see all actions for all organizations"))
 
     (testing "view after creation"
       (create-organization)
@@ -2661,7 +2661,7 @@
                     "Active" true}
                    (slurp-fields :organization)))
             (is (not (btu/visible? :edit-organization)))
-            
+
             (go-to-admin "Organizations")
             (is (= "View"
                    (->> (slurp-table :organizations)

--- a/test/clj/rems/test_browser.clj
+++ b/test/clj/rems/test_browser.clj
@@ -2494,9 +2494,17 @@
 
     (btu/context-assoc! :organization-id (str "test-organizations org id " (btu/get-seed))
                         :organization-name (str "test-organizations org name " (btu/get-seed)))
-    (create-organization)
+   
+   (testing "view all organizations"
+     (go-to-admin "Organizations")
+     (is (every? #{"ViewDisableArchive"}
+                 (->> (slurp-table :organizations)
+                      (filter not-empty)
+                      (map #(get % "commands"))))
+         "owner can see all actions for all organizations"))
 
     (testing "view after creation"
+      (create-organization)
       (is (btu/eventually-visible? :organization))
       (is (= {"Id" (btu/context-getx :organization-id)
               "Short name (FI)" "SNFI"
@@ -2652,7 +2660,14 @@
                     "Email" "review.email@example.com"
                     "Active" true}
                    (slurp-fields :organization)))
-            (is (not (btu/visible? :edit-organization)))))))))
+            (is (not (btu/visible? :edit-organization)))
+            
+            (go-to-admin "Organizations")
+            (is (= "View"
+                   (->> (slurp-table :organizations)
+                        (some #(when (= "SNEN" (get % "short-name"))
+                                 (get % "commands")))))
+                "organization actions should not be visible for non organization owner")))))))
 
 (deftest test-small-navbar
   (testing "create a test application with the API to have another page to navigate to"


### PR DESCRIPTION
closes #2828 

# Checklist for author

Remove items that aren't applicable, check items that are done.

## Reviewability
- [x] Link to issue
- [x] Consider adding screenshots for ease of review

## Documentation
- [ ] Update changelog if necessary (might be redundant, changelog row already exists for disallowing org owners editing not-their-organization)

## Testing
- [x] Valuable features are integration / browser / acceptance tested automatically

## Follow-up
- [ ] New tasks are created for pending or remaining tasks

---
## Screenshots

<img width="1198" alt="Screenshot 2022-10-12 at 15 25 57" src="https://user-images.githubusercontent.com/794087/195342134-162ff813-92cc-4748-ac0a-920dfa96627c.png">