### PR TITLE
Hide organization actions from org owner in organizations table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ Changes since v2.29
 - Application warning and error links were not functioning correctly for attachment fields. This is now fixed. (#2955)
 - DUO fields are no longer editable in the UI when application is not in editable state. (#2997)
 - Organization edit now requires user to be either owner or organization owner of the organization. (#2828)
+- Organization owner is no longer allowed to toggle enable/disable and archive organization actions. These are available only to owner user. (#2828)
 - Test/demo data creation now uses configured languages. Mismatch between configured languages and data localizations may cause issues in certain UI components. (#2334)
 - Multiselect field is now correctly rendered in application pdf again. More than one selected value resulted in empty field value. (#3059)
 

--- a/src/cljs/rems/administration/organizations.cljs
+++ b/src/cljs/rems/administration/organizations.cljs
@@ -79,14 +79,10 @@
  ::organizations-table-rows
  (fn [_ _]
    [(rf/subscribe [::organizations])
-    (rf/subscribe [:language])
-    (rf/subscribe [:owned-organizations])])
- (fn [[organizations language owned-organizations] _]
-   (for [organization organizations
-         :let [id (:organization/id organization)
-               org-owner? (->> owned-organizations
-                               (some (comp #{id} :organization/id)))]]
-     {:key id
+    (rf/subscribe [:language])])
+ (fn [[organizations language] _]
+   (for [organization organizations]
+     {:key (:organization/id organization)
       :short-name {:value (get-in organization [:organization/short-name language])}
       :name {:value (get-in organization [:organization/name language])}
       :active (let [checked? (status-flags/active? organization)]
@@ -94,11 +90,10 @@
                       [readonly-checkbox {:value checked?}]]
                  :sort-value (if checked? 1 2)})
       :commands {:td [:td.commands
-                      [to-view-organization id]
-                      (when org-owner?
-                        [:<>
-                         [status-flags/enabled-toggle organization #(rf/dispatch [::set-organization-enabled %1 %2 [::fetch-organizations]])]
-                         [status-flags/archived-toggle organization #(rf/dispatch [::set-organization-archived %1 %2 [::fetch-organizations]])]])]}})))
+                      [to-view-organization (:organization/id organization)]
+                      [roles/show-when #{:owner} ; XXX: organization owner cannot use these actions currently
+                       [status-flags/enabled-toggle organization #(rf/dispatch [::set-organization-enabled %1 %2 [::fetch-organizations]])]
+                       [status-flags/archived-toggle organization #(rf/dispatch [::set-organization-archived %1 %2 [::fetch-organizations]])]]]}})))
 
 (defn- organizations-list []
   (let [organizations-table {:id ::organizations

--- a/test/clj/rems/test_browser.clj
+++ b/test/clj/rems/test_browser.clj
@@ -2577,8 +2577,9 @@
           (is (some #{{"short-name" "SNEN2"
                        "name" (str (btu/context-getx :organization-name) " EN")
                        "active" true
-                       "commands" "ViewDisableArchive"}}
-                    orgs))))
+                       "commands" "View"}}
+                    orgs)
+              "Organization owner cannot disable or archive organization")))
 
       (testing "view from list"
         (click-row-action [:organizations]


### PR DESCRIPTION
closes #2828 

Hide organization actions disable/archive from organizations table if user is not `#{:owner}`. Currently organization owner should be allowed to only edit organization.

# Checklist for author

Remove items that aren't applicable, check items that are done.

## Reviewability
- [x] Link to issue

## Documentation
- [x] Update changelog if necessary

## Testing
- [x] Valuable features are integration / browser / acceptance tested automatically

## Follow-up
- [ ] New tasks are created for pending or remaining tasks
