### PR TITLE
release v2.30, again

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject rems "2.29"
+(defproject rems "2.30"
   :description "Resource Entitlement Management System is a tool for managing access rights to resources, such as research datasets."
   :url "https://github.com/CSCfi/rems"
 


### PR DESCRIPTION
new run, because release v2.30 went out without proper version number in `project.clj`.