### PR TITLE
Delete orphan attachments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ have notable changes.
 
 Changes since v2.30
 
+### Additions
+- Orphan attachments could sometimes be saved, though not in use. They are now removed when an application is submitted. (#3041)
+
 ## v2.30 "Kellosaarenranta" 2022-10-13
 
 ### Changes

--- a/resources/sql/queries.sql
+++ b/resources/sql/queries.sql
@@ -329,6 +329,10 @@ WHERE appid = :application-id;
 DELETE FROM attachment
 WHERE appid = :application;
 
+-- :name delete-attachment! :!
+DELETE FROM attachment
+WHERE id = :id;
+
 -- :name create-license! :insert
 INSERT INTO license
 (organization, type)

--- a/src/clj/rems/api/services/attachment.clj
+++ b/src/clj/rems/api/services/attachment.clj
@@ -46,6 +46,11 @@
       (throw-forbidden))
     (attachments/save-attachment! file user-id application-id)))
 
+(defn get-attachments-in-use
+  "Returns the attachment ids actually in use (field answer or event)."
+  [application]
+  (keys (model/classify-attachments application)))
+
 (defn zip-attachments [application all?]
   (let [classes (model/classify-attachments application)
         out (ByteArrayOutputStream.)]

--- a/src/clj/rems/api/services/command.clj
+++ b/src/clj/rems/api/services/command.clj
@@ -1,14 +1,11 @@
 (ns rems.api.services.command
   (:require [clojure.java.jdbc :as jdbc]
-            [clojure.set :refer [difference]]
             [clojure.tools.logging :as log]
-            [rems.api.services.attachment :as attachment]
-            [rems.api.services.blacklist :as blacklist]
             [rems.application.approver-bot :as approver-bot]
             [rems.application.bona-fide-bot :as bona-fide-bot]
             [rems.application.commands :as commands]
+            [rems.application.process-managers :as process-managers]
             [rems.application.rejecter-bot :as rejecter-bot]
-            [rems.common.application-util :as application-util]
             [rems.db.applications :as applications]
             [rems.db.attachments :as attachments]
             [rems.db.core :as db]
@@ -21,52 +18,19 @@
             [rems.util :refer [secure-token]])
   (:import rems.TryAgainException))
 
-;; TODO should this process manager be in its own ns?
-(defn- revokes-to-blacklist [new-events]
-  (doseq [event new-events
-          :when (= :application.event/revoked (:event/type event))
-          :let [application (applications/get-application-internal (:application/id event))]
-          user (application-util/applicant-and-members application)
-          resource (:application/resources application)]
-    (blacklist/add-user-to-blacklist! (:event/actor event)
-                                      {:blacklist/user {:userid (:userid user)}
-                                       :blacklist/resource {:resource/ext-id (:resource/ext-id resource)}
-                                       :comment (:application/comment event)})))
-
-;; TODO should this process manager be in its own ns?
-(defn- delete-applications [new-events]
-  (doseq [event new-events]
-    (when (= :application.event/deleted (:event/type event))
-      (applications/delete-application-and-reload-cache! (:application/id event))))
-  [])
-
-(defn- delete-orphan-attachments [application-id]
-  (let [application (applications/get-application-internal application-id)
-        attachments-in-use (rems.api.services.attachment/get-attachments-in-use application)
-        all-attachments (set (map :attachment/id (:application/attachments application)))]
-    (doseq [attachment-id (difference all-attachments attachments-in-use)]
-      (attachments/delete-attachment! attachment-id))))
-
-;; TODO should this process manager be in its own ns?
-(defn- delete-orphan-attachments-on-submit [new-events]
-  (doseq [event new-events]
-    (when (= :application.event/submitted (:event/type event))
-      (delete-orphan-attachments (:application/id event))))
-  [])
-
 ;; Process managers react to events with side effects & new commands.
 ;; See docs/architecture/002-event-side-effects.md
 (defn run-process-managers [new-events]
   (concat
-   (revokes-to-blacklist new-events)
+   (process-managers/revokes-to-blacklist new-events)
    (email/generate-event-emails! new-events)
    (entitlements/update-entitlements-for-events new-events)
    (rejecter-bot/run-rejecter-bot new-events)
    (approver-bot/run-approver-bot new-events)
    (bona-fide-bot/run-bona-fide-bot new-events)
    (event-notification/queue-notifications! new-events)
-   (delete-applications new-events)
-   (delete-orphan-attachments-on-submit new-events)))
+   (process-managers/delete-applications new-events)
+   (process-managers/delete-orphan-attachments-on-submit new-events)))
 
 (def ^:private command-injections
   (merge applications/fetcher-injections

--- a/src/clj/rems/application/process_managers.clj
+++ b/src/clj/rems/application/process_managers.clj
@@ -1,0 +1,44 @@
+(ns rems.application.process-managers
+  "Miscellaneous process managers."
+  (:require [clojure.set :refer [difference]]
+            [rems.api.services.attachment :as attachment]
+            [rems.api.services.blacklist :as blacklist]
+            [rems.common.application-util :as application-util]
+            [rems.db.applications :as applications]
+            [rems.db.attachments :as attachments]))
+
+(defn revokes-to-blacklist
+  "Revokation causes the users to be blacklisted."
+  [new-events]
+  (doseq [event new-events
+          :when (= :application.event/revoked (:event/type event))
+          :let [application (applications/get-application-internal (:application/id event))]
+          user (application-util/applicant-and-members application)
+          resource (:application/resources application)]
+    (blacklist/add-user-to-blacklist! (:event/actor event)
+                                      {:blacklist/user {:userid (:userid user)}
+                                       :blacklist/resource {:resource/ext-id (:resource/ext-id resource)}
+                                       :comment (:application/comment event)})))
+
+(defn delete-applications
+  "The deleted event causes a side-effect that completely deletes the application."
+  [new-events]
+  (doseq [event new-events]
+    (when (= :application.event/deleted (:event/type event))
+      (applications/delete-application-and-reload-cache! (:application/id event))))
+  [])
+
+(defn delete-orphan-attachments [application-id]
+  (let [application (applications/get-application-internal application-id)
+        attachments-in-use (rems.api.services.attachment/get-attachments-in-use application)
+        all-attachments (set (map :attachment/id (:application/attachments application)))]
+    (doseq [attachment-id (difference all-attachments attachments-in-use)]
+      (attachments/delete-attachment! attachment-id))))
+
+(defn delete-orphan-attachments-on-submit
+  "When an application is submitted, we delete its unused attachments, if any."
+  [new-events]
+  (doseq [event new-events]
+    (when (= :application.event/submitted (:event/type event))
+      (delete-orphan-attachments (:application/id event))))
+  [])

--- a/src/clj/rems/application/process_managers.clj
+++ b/src/clj/rems/application/process_managers.clj
@@ -1,5 +1,7 @@
 (ns rems.application.process-managers
-  "Miscellaneous process managers."
+  "Miscellaneous process managers.
+
+  NB: An event manager should return an empty sequence (or `nil`) if it doesn't create new events itself."
   (:require [clojure.set :refer [difference]]
             [rems.api.services.attachment :as attachment]
             [rems.api.services.blacklist :as blacklist]
@@ -25,8 +27,7 @@
   [new-events]
   (doseq [event new-events]
     (when (= :application.event/deleted (:event/type event))
-      (applications/delete-application-and-reload-cache! (:application/id event))))
-  [])
+      (applications/delete-application-and-reload-cache! (:application/id event)))))
 
 (defn delete-orphan-attachments [application-id]
   (let [application (applications/get-application-internal application-id)
@@ -40,5 +41,4 @@
   [new-events]
   (doseq [event new-events]
     (when (= :application.event/submitted (:event/type event))
-      (delete-orphan-attachments (:application/id event))))
-  [])
+      (delete-orphan-attachments (:application/id event)))))

--- a/src/clj/rems/application/process_managers.clj
+++ b/src/clj/rems/application/process_managers.clj
@@ -31,7 +31,7 @@
 
 (defn delete-orphan-attachments [application-id]
   (let [application (applications/get-application-internal application-id)
-        attachments-in-use (rems.api.services.attachment/get-attachments-in-use application)
+        attachments-in-use (attachment/get-attachments-in-use application)
         all-attachments (set (map :attachment/id (:application/attachments application)))]
     (doseq [attachment-id (difference all-attachments attachments-in-use)]
       (attachments/delete-attachment! attachment-id))))

--- a/src/clj/rems/db/attachments.clj
+++ b/src/clj/rems/db/attachments.clj
@@ -117,3 +117,6 @@
                                :filename (:filename attachment)
                                :type (:type attachment)
                                :data (:data attachment)}))))
+
+(defn delete-attachment! [attachment-id]
+  (db/delete-attachment! {:id attachment-id}))

--- a/src/cljs/rems/fields.cljs
+++ b/src/cljs/rems/fields.cljs
@@ -93,22 +93,22 @@
 (defn field-wrapper
   "Common parts of a form field.
 
-  :field/id - number (required), field id
-  :form/id - number (required), form id
-  :field/title - string (required), field title to show to the user
-  :field/max-length - maximum number of characters (optional)
-  :field/optional - boolean, true if the field is not required
-  :field/value - string, the current value of the field
+  :field/id             - number (required), field id
+  :form/id              - number (required), form id
+  :field/title          - string (required), field title to show to the user
+  :field/max-length     - maximum number of characters (optional)
+  :field/optional       - boolean, true if the field is not required
+  :field/value          - string, the current value of the field
   :field/previous-value - string, the previously submitted value of the field
-  :field/info-text - text for collapsable info field
-  :readonly - boolean, true if the field should not be editable
-  :readonly-component - HTML, custom component for a readonly field
-  :diff - boolean, true if should show the diff between :value and :previous-value
-  :diff-component - HTML, custom component for rendering a diff
-  :validation - validation errors
-  :fieldset - boolean, true if the field should be wrapped in a fieldset
+  :field/info-text      - text for collapsable info field
+  :readonly             - boolean, true if the field should not be editable
+  :readonly-component   - HTML, custom component for a readonly field
+  :diff                 - boolean, true if should show the diff between :value and :previous-value
+  :diff-component       - HTML, custom component for rendering a diff
+  :validation           - validation errors
+  :fieldset             - boolean, true if the field should be wrapped in a fieldset
 
-  editor-component - HTML, form component for editing the field"
+  editor-component      - HTML, form component for editing the field"
   [{:keys [readonly readonly-component diff diff-component validation on-toggle-diff fieldset] :as opts} editor-component]
   (let [raw-title (localized (:field/title opts))
         title (linkify raw-title)

--- a/test/clj/rems/application/test_process_managers.clj
+++ b/test/clj/rems/application/test_process_managers.clj
@@ -159,7 +159,7 @@
                                     {:attachment/id attachment-id4 :attachment/filename "attachment4.txt" :attachment/type "text/plain"}]
                                    (:application/attachments (applications/get-application-internal app-id))
                                    (attachments/get-attachments-for-application app-id))
-                                "attachment1, attachment2 and attachment4 are saved")
+                                "attachment1, attachment2, attachment4 and handler attachment are saved")
 
                             (is (= [{:attachment/id unrelated-attachment-id :attachment/filename "attachment1.txt" :attachment/type "text/plain"}]
                                    (:application/attachments (applications/get-application-internal unrelated-app-id))

--- a/test/clj/rems/application/test_process_managers.clj
+++ b/test/clj/rems/application/test_process_managers.clj
@@ -161,7 +161,30 @@
                                    (attachments/get-attachments-for-application app-id))
                                 "attachment1, attachment2, attachment4 and handler attachment are saved")
 
-                            (is (= [{:attachment/id unrelated-attachment-id :attachment/filename "attachment1.txt" :attachment/type "text/plain"}]
-                                   (:application/attachments (applications/get-application-internal unrelated-app-id))
-                                   (attachments/get-attachments-for-application unrelated-app-id))
-                                "unrelated attachment is still there")))))))))))))))
+                            (testing "upload attachment5"
+                              (let [_attachment-id5 (upload-request app-id "alice" "attachment5.txt")]
+
+                                (testing "send application again"
+                                  ;; NB: don't save again, so attachment5 shouldn't be in use
+
+                                  (is (= {:success true}
+                                         (-> (request :post "/api/applications/submit")
+                                             (authenticate "42" "alice")
+                                             (json-body {:application-id app-id})
+                                             handler
+                                             read-ok-body)))
+
+                                  ;; NB: attachment 5 should have been cleaned
+
+                                  (is (= [{:attachment/id attachment-id1 :attachment/filename "attachment1.txt" :attachment/type "text/plain"} ; still here because it's the old value
+                                          {:attachment/id attachment-id2 :attachment/filename "attachment2.txt" :attachment/type "text/plain"}
+                                          {:attachment/id handler-attachment-id :attachment/filename "handler.txt" :attachment/type "text/plain"}
+                                          {:attachment/id attachment-id4 :attachment/filename "attachment4.txt" :attachment/type "text/plain"}]
+                                         (:application/attachments (applications/get-application-internal app-id))
+                                         (attachments/get-attachments-for-application app-id))
+                                      "attachment1, attachment2, attachment4 and handler attachment are saved")
+
+                                  (is (= [{:attachment/id unrelated-attachment-id :attachment/filename "attachment1.txt" :attachment/type "text/plain"}]
+                                         (:application/attachments (applications/get-application-internal unrelated-app-id))
+                                         (attachments/get-attachments-for-application unrelated-app-id))
+                                      "unrelated attachment is still there"))))))))))))))))))

--- a/test/clj/rems/application/test_process_managers.clj
+++ b/test/clj/rems/application/test_process_managers.clj
@@ -1,0 +1,193 @@
+(ns ^:integration rems.application.test-process-managers
+  (:require [clojure.java.io :as io]
+            [clojure.test :refer :all]
+            [rems.api.services.command :as command]
+            [rems.api.testing :refer :all]
+            [rems.db.attachments :as attachments]
+            [rems.db.applications :as applications]
+            [rems.db.test-data :as test-data]
+            [rems.db.test-data-helpers :as test-helpers]
+            [rems.handler :refer [handler]]
+            [ring.mock.request :refer :all]))
+
+(use-fixtures :each api-fixture)
+
+(def testfile (io/file "./test-data/test.txt"))
+
+(def filecontent
+  {:tempfile testfile
+   :content-type "text/plain"
+   :filename "test.txt"
+   :size (.length testfile)})
+
+(defn upload-request [app-id file]
+  (-> (request :post (str "/api/applications/add-attachment?application-id=" app-id))
+      (assoc :multipart-params {"file" file})))
+
+(deftest test-run-delete-orphan-attachments
+  (binding [command/*fail-on-process-manager-errors* true]
+    (test-data/create-test-api-key!)
+    (test-helpers/create-user! {:userid "alice"})
+    (test-helpers/create-user! {:userid "handler"})
+    (let [res-id (test-helpers/create-resource! {:resource-ext-id "resource"})
+          wf-id (test-helpers/create-workflow! {:type :workflow/default
+                                                :handlers ["handler"]})
+          form-id (test-helpers/create-form! {:form/fields [{:field/id "attachment1"
+                                                             :field/title {:en "first attachment"
+                                                                           :fi "first attachment"
+                                                                           :sv "first attachment"}
+                                                             :field/optional false
+                                                             :field/type :attachment}
+                                                            {:field/id "attachment2"
+                                                             :field/title {:en "second attachment"
+                                                                           :fi "second attachment"
+                                                                           :sv "second attachment"}
+                                                             :field/optional false
+                                                             :field/type :attachment}]})
+          cat-id (test-helpers/create-catalogue-item! {:title {:en "catalogue-item"}
+                                                       :form-id form-id
+                                                       :workflow-id wf-id
+                                                       :resource-id res-id})
+          app-id (test-helpers/create-application! {:actor "alice" :catalogue-item-ids [cat-id]})]
+
+      (testing "create unrelated application"
+        (let [unrelated-app-id (test-helpers/create-application! {:actor "alice" :catalogue-item-ids [cat-id]})
+              unrelated-attachment-id (-> (upload-request unrelated-app-id (assoc filecontent :filename "attachment1.txt"))
+                                          (authenticate "42" "alice")
+                                          handler
+                                          read-ok-body
+                                          :id)]
+          (is (number? unrelated-attachment-id))
+
+          (is (= [{:attachment/id unrelated-attachment-id :attachment/filename "attachment1.txt" :attachment/type "text/plain"}]
+                 (:application/attachments (applications/get-application-internal unrelated-app-id))
+                 (attachments/get-attachments-for-application unrelated-app-id))
+              "unrelated attachment was saved")
+
+          (testing "in main application"
+            (testing "upload attachment1"
+              (let [attachment-id1 (-> (upload-request app-id (assoc filecontent :filename "attachment1.txt"))
+                                       (authenticate "42" "alice")
+                                       handler
+                                       read-ok-body
+                                       :id)]
+                (is (number? attachment-id1))
+
+                (testing "use attachment1 in a field"
+                  (is (= {:success true
+                          :warnings [{:type "t.form.validation/required"
+                                      :form-id form-id
+                                      :field-id "attachment2"}]}
+                         (-> (request :post (str "/api/applications/save-draft" ))
+                             (authenticate "42" "alice")
+                             (json-body {:application-id app-id
+                                         :field-values [{:form form-id :field "attachment1" :value (str attachment-id1)}]})
+                             handler
+                             read-ok-body)))
+
+                  (is (= [{:attachment/id attachment-id1 :attachment/filename "attachment1.txt" :attachment/type "text/plain"}]
+                         (:application/attachments (applications/get-application-internal app-id))
+                         (attachments/get-attachments-for-application app-id))
+                      "attachment1 was saved"))
+
+                (testing "upload attachment2"
+                  (let [attachment-id2 (-> (upload-request app-id (assoc filecontent :filename "attachment2.txt"))
+                                           (authenticate "42" "alice")
+                                           handler
+                                           read-ok-body
+                                           :id)]
+                    (is (number? attachment-id2))
+
+                    (testing "use attachment2 in a field"
+                      (is (= {:success true}
+                             (-> (request :post (str "/api/applications/save-draft" ))
+                                 (authenticate "42" "alice")
+                                 (json-body {:application-id app-id
+                                             :field-values [{:form form-id :field "attachment1" :value (str attachment-id1)}
+                                                            {:form form-id :field "attachment2" :value (str attachment-id2)}]})
+                                 handler
+                                 read-ok-body)))
+
+                      (is (= [{:attachment/id attachment-id1 :attachment/filename "attachment1.txt" :attachment/type "text/plain"}
+                              {:attachment/id attachment-id2 :attachment/filename "attachment2.txt" :attachment/type "text/plain"}]
+                             (:application/attachments (applications/get-application-internal app-id))
+                             (attachments/get-attachments-for-application app-id))
+                          "attachment1 and attachment2 are saved"))
+
+                    (testing "upload attachment3"
+                      (let [attachment-id3 (-> (upload-request app-id (assoc filecontent :filename "attachment3.txt"))
+                                               (authenticate "42" "alice")
+                                               handler
+                                               read-ok-body
+                                               :id)]
+                        (is (number? attachment-id3))
+
+                        (testing "send application"
+                          ;; NB: don't save again, so attachment3 shouldn't be in use
+
+                          (is (= {:success true}
+                                 (-> (request :post "/api/applications/submit")
+                                     (authenticate "42" "alice")
+                                     (json-body {:application-id app-id})
+                                     handler
+                                     read-ok-body)))
+
+                          ;; NB: attachment 3 should have been cleaned
+
+                          (is (= [{:attachment/id attachment-id1 :attachment/filename "attachment1.txt" :attachment/type "text/plain"}
+                                  {:attachment/id attachment-id2 :attachment/filename "attachment2.txt" :attachment/type "text/plain"}]
+                                 (:application/attachments (applications/get-application-internal app-id))
+                                 (attachments/get-attachments-for-application app-id))
+                              "attachment1 and attachment2 are saved, but not attachment3"))))
+
+                    (testing "return application with handler attachment comment"
+                      (let [handler-attachment-id  (-> (upload-request app-id (assoc filecontent :filename "handler.txt"))
+                                                       (authenticate "42" "handler")
+                                                       handler
+                                                       read-ok-body
+                                                       :id)]
+                        (is (number? handler-attachment-id))
+                        (is (= {:success true}
+                               (-> (request :post "/api/applications/return")
+                                   (authenticate "42" "handler")
+                                   (json-body {:application-id app-id
+                                               :attachments [{:attachment/id handler-attachment-id}]})
+                                   handler
+                                   read-ok-body)))
+
+                        (is (= [{:attachment/id attachment-id1 :attachment/filename "attachment1.txt" :attachment/type "text/plain"}
+                                {:attachment/id attachment-id2 :attachment/filename "attachment2.txt" :attachment/type "text/plain"}
+                                {:attachment/id handler-attachment-id :attachment/filename "handler.txt" :attachment/type "text/plain"}]
+                               (:application/attachments (applications/get-application-internal app-id))
+                               (attachments/get-attachments-for-application app-id))
+                            "attachment1, attachment2 and handler attachment are saved")
+
+                        (testing "replace attachment1 in a field"
+                          (let [attachment-id4 (-> (upload-request app-id (assoc filecontent :filename "attachment4.txt"))
+                                                   (authenticate "42" "alice")
+                                                   handler
+                                                   read-ok-body
+                                                   :id)]
+                            (is (number? attachment-id4))
+
+                            (is (= {:success true}
+                                   (-> (request :post (str "/api/applications/save-draft" ))
+                                       (authenticate "42" "alice")
+                                       (json-body {:application-id app-id
+                                                   :field-values [{:form form-id :field "attachment1" :value (str attachment-id4)}
+                                                                  {:form form-id :field "attachment2" :value (str attachment-id2)}]})
+                                       handler
+                                       read-ok-body)))
+
+                            (is (= [{:attachment/id attachment-id1 :attachment/filename "attachment1.txt" :attachment/type "text/plain"} ; still here because it's the old value
+                                    {:attachment/id attachment-id2 :attachment/filename "attachment2.txt" :attachment/type "text/plain"}
+                                    {:attachment/id handler-attachment-id :attachment/filename "handler.txt" :attachment/type "text/plain"}
+                                    {:attachment/id attachment-id4 :attachment/filename "attachment4.txt" :attachment/type "text/plain"}]
+                                   (:application/attachments (applications/get-application-internal app-id))
+                                   (attachments/get-attachments-for-application app-id))
+                                "attachment1, attachment2 and attachment4 are saved")
+
+                            (is (= [{:attachment/id unrelated-attachment-id :attachment/filename "attachment1.txt" :attachment/type "text/plain"}]
+                                   (:application/attachments (applications/get-application-internal unrelated-app-id))
+                                   (attachments/get-attachments-for-application unrelated-app-id))
+                                "unrelated attachment is still there")))))))))))))))

--- a/test/clj/rems/application/test_process_managers.clj
+++ b/test/clj/rems/application/test_process_managers.clj
@@ -71,7 +71,7 @@
                           :warnings [{:type "t.form.validation/required"
                                       :form-id form-id
                                       :field-id "attachment2"}]}
-                         (-> (request :post (str "/api/applications/save-draft" ))
+                         (-> (request :post (str "/api/applications/save-draft"))
                              (authenticate "42" "alice")
                              (json-body {:application-id app-id
                                          :field-values [{:form form-id :field "attachment1" :value (str attachment-id1)}]})
@@ -88,7 +88,7 @@
 
                     (testing "use attachment2 in a field"
                       (is (= {:success true}
-                             (-> (request :post (str "/api/applications/save-draft" ))
+                             (-> (request :post (str "/api/applications/save-draft"))
                                  (authenticate "42" "alice")
                                  (json-body {:application-id app-id
                                              :field-values [{:form form-id :field "attachment1" :value (str attachment-id1)}
@@ -145,7 +145,7 @@
                           (let [attachment-id4 (upload-request app-id "alice" "attachment4.txt")]
 
                             (is (= {:success true}
-                                   (-> (request :post (str "/api/applications/save-draft" ))
+                                   (-> (request :post (str "/api/applications/save-draft"))
                                        (authenticate "42" "alice")
                                        (json-body {:application-id app-id
                                                    :field-values [{:form form-id :field "attachment1" :value (str attachment-id4)}


### PR DESCRIPTION
Closes #3041

Creates a new process manager that cleans an application on submission of unused attachments. An unused attachment is something that is not used in a field value (new or old) or an event (attachment). This can happen if an attachment is uploaded but the application is not saved before submission (or something is uploaded in its place before saving).

# Checklist for author

Remove items that aren't applicable, check items that are done.

## Reviewability
- [x] Link to issue

## Documentation
- [x] Update changelog if necessary

## Testing
- [x] Valuable features are integration / browser / acceptance tested automatically
