### PR TITLE
Extra page improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ have notable changes.
 
 Changes since v2.30
 
+### Additions
+- Extra pages have been enhanced: (#2983, #2589, #3069)
+  - They can be shown in top menu, footer, both or not at all with `:show-menu` and `:show-footer`
+  - You can decide if you want the standard heading or not with `:heading`.
+  - If localization of the file or link is not required, you can define the attributes at top level.
+  - Who can see which extras can be tuned with `:roles` such as `:logged-in`, `:applicant` or `:handler`.
+  - See `config-defaults.edn` for more details.
+
 ## v2.30 "Kellosaarenranta" 2022-10-13
 
 ### Changes

--- a/dev-config.edn
+++ b/dev-config.edn
@@ -28,10 +28,10 @@
                                :sv {:title "Info"
                                     :filename "about-sv.md"}}}
                {:id "footer"
+                :filename "footer-en.md"
                 :translations {:fi {:title "Footer"
                                     :filename "footer-fi.md"}
-                               :en {:title "Footer"
-                                    :filename "footer-en.md"}
+                               :en {:title "Footer"}
                                :sv {:title "Footer"
                                     :filename "footer-sv.md"}}
                 :show-menu false

--- a/dev-config.edn
+++ b/dev-config.edn
@@ -45,6 +45,16 @@
                                     :filename "link-sv.md"}}
                 :show-menu false
                 :show-footer false}
+               {:id "mixed"
+                :translations {:fi {:title "Mixed"
+                                    :filename "mixed-fi.md"}
+                               :en {:url "https://example.org/en/mixed"}} ; missing sv
+                :show-menu false
+                :show-footer false}
+               {:id "unlocalized"
+                :url "https://example.org/unlocalized"
+                :show-menu false
+                :show-footer false}
                {:id "url"
                 :url "https://example.org/"
                 :translations {:fi {:title "Esimerkki"

--- a/dev-config.edn
+++ b/dev-config.edn
@@ -56,6 +56,7 @@
                 :show-menu false
                 :show-footer false}
                {:id "url"
+                :roles [:logged-in]
                 :url "https://example.org/"
                 :translations {:fi {:title "Esimerkki"
                                     :url "https://example.org/fi"}

--- a/dev-config.edn
+++ b/dev-config.edn
@@ -26,7 +26,25 @@
                                :en {:title "About"
                                     :filename "about-en.md"}
                                :sv {:title "Info"
-                                    :filename "about-sv.md"}}}]
+                                    :filename "about-sv.md"}}}
+               {:id "footer"
+                :translations {:fi {:title "Footer"
+                                    :filename "footer-fi.md"}
+                               :en {:title "Footer"
+                                    :filename "footer-en.md"}
+                               :sv {:title "Footer"
+                                    :filename "footer-sv.md"}}
+                :show-menu false
+                :show-footer true}
+               {:id "link"
+                :translations {:fi {:title "Link"
+                                    :filename "link-fi.md"}
+                               :en {:title "Link"
+                                    :filename "link-en.md"}
+                               :sv {:title "Link"
+                                    :filename "link-sv.md"}}
+                :show-menu false
+                :show-footer false}]
  :extra-pages-path "./test-data/extra-pages"
  :application-deadline-days 4
  :application-id-column :generated-and-assigned-external-id

--- a/dev-config.edn
+++ b/dev-config.edn
@@ -46,6 +46,7 @@
                 :show-menu false
                 :show-footer false}
                {:id "mixed"
+                :heading false
                 :translations {:fi {:title "Mixed"
                                     :filename "mixed-fi.md"}
                                :en {:url "https://example.org/en/mixed"}} ; missing sv

--- a/dev-config.edn
+++ b/dev-config.edn
@@ -44,7 +44,15 @@
                                :sv {:title "Link"
                                     :filename "link-sv.md"}}
                 :show-menu false
-                :show-footer false}]
+                :show-footer false}
+               {:id "url"
+                :url "https://example.org/"
+                :translations {:fi {:title "Esimerkki"
+                                    :url "https://example.org/fi"}
+                               :en {:title "Example"}
+                               :sv {:title "Exempel"}}
+                :show-menu true
+                :show-footer true}]
  :extra-pages-path "./test-data/extra-pages"
  :application-deadline-days 4
  :application-id-column :generated-and-assigned-external-id

--- a/resources/config-defaults.edn
+++ b/resources/config-defaults.edn
@@ -314,8 +314,9 @@
  ;;
  ;; :extra-pages [;; This is a page that's hosted at an external URL
  ;;               {:id "hello"
- ;;                :url "http://example.org/hello.html"
- ;;                :translations {:fi {:title "Hei"}
+ ;;                :url "http://example.org/hello.html" ; fallback URL
+ ;;                :translations {:fi {:title "Hei"
+ ;;                                    :url "http://example.org/fi/hello.html"} ; specific localized URL
  ;;                               :en {:title "Hello"}}}
  ;;
  ;;               ;; This is a page that's a markdown file, localized into two languages.

--- a/resources/config-defaults.edn
+++ b/resources/config-defaults.edn
@@ -314,7 +314,7 @@
  ;;
  ;; :extra-pages [;; This is a page that's hosted at an external URL, only for logged-in users
  ;;               {:id "hello"
- ;;                :roles [:logged-in] ; other roles are possible too such as :applicant :member :handler etc.
+ ;;                :roles [:logged-in] ; only for this role
  ;;                :heading false ; don't show the heading, write any Markdown heading you like, defaults to true
  ;;                :url "http://example.org/hello.html" ; fallback URL
  ;;                :translations {:fi {:title "Hei"
@@ -333,6 +333,9 @@
  ;; Additional options (for any type):
  ;;   :show-menu true    ; show in top menu, defaults to true
  ;;   :show-footer false ; show in footer, defaults to false
+ ;;   :roles ; Can be used to configure which users see and can access the extra page.
+ ;;          ; The :logged-in, or more specific roles are possible.
+ ;;          ; The default is to show the page to everyone.
  ;;
  ;; NB: Pages not accessible through menus will be served in the corresponding
  ;; url `/extra-pages/<id>` and can be accessed through a link for example.

--- a/resources/config-defaults.edn
+++ b/resources/config-defaults.edn
@@ -419,6 +419,6 @@
  :enable-cart true ; show shopping cart and allow bundling multiple resources into one application
  :enable-save-compaction false ; whether to merge consecutive saves into one event (EXPERIMENTAL)
  :enable-autosave false ; whether to automatically save the application as the applicant types (EXPERIMENTAL)
- ; which columns in applications list(s) should be hidden in UI
- ; allowed values: [:description :resource :applicant :handlers :state :todo :created :submitted :last-activity :view]
+ ;; which columns in applications list(s) should be hidden in UI
+ ;; allowed values: [:description :resource :applicant :handlers :state :todo :created :submitted :last-activity :view]
  :application-list-hidden-columns []}

--- a/resources/config-defaults.edn
+++ b/resources/config-defaults.edn
@@ -336,6 +336,13 @@
  ;;
  ;; NB: Pages not accessible through menus will be served in the corresponding
  ;; url `/extra-pages/<id>` and can be accessed through a link for example.
+ ;;
+ ;; Assets such as images can also be hosted by REMS if included the theme directory.
+ ;; See `:theme-path`.
+ ;;
+ ;; For example with this Markdown you can include an image:
+ ;;   ![REMS Logo](/img/rems_logo_en.png)
+ ;;
 
  :extra-pages []
 

--- a/resources/config-defaults.edn
+++ b/resources/config-defaults.edn
@@ -317,6 +317,7 @@
  ;;                :url "http://example.org/hello.html"
  ;;                :translations {:fi {:title "Hei"}
  ;;                               :en {:title "Hello"}}}
+ ;;
  ;;               ;; This is a page that's a markdown file, localized into two languages.
  ;;               ;; The files are searched under :extra-pages-path (see below).
  ;;               {:id "about"
@@ -324,6 +325,14 @@
  ;;                                    :filename "about-fi.md"}
  ;;                               :en {:title "About"
  ;;                                    :filename "about-en.md"}}}]
+ ;;
+ ;; Additional options (for any type):
+ ;;   :show-menu true    ; show in top menu, defaults to true
+ ;;   :show-footer false ; show in footer, defaults to false
+ ;;
+ ;; NB: Pages not accessible through menus will be served in the corresponding
+ ;; url `/extra-pages/<id>` and can be accessed through a link for example.
+
  :extra-pages []
 
  ;; Path to the markdown files for the extra pages.

--- a/resources/config-defaults.edn
+++ b/resources/config-defaults.edn
@@ -322,8 +322,9 @@
  ;;               ;; This is a page that's a markdown file, localized into two languages.
  ;;               ;; The files are searched under :extra-pages-path (see below).
  ;;               {:id "about"
+ ;;                :filename "about.md" ; fallback file
  ;;                :translations {:fi {:title "Info"
- ;;                                    :filename "about-fi.md"}
+ ;;                                    :filename "about-fi.md"} ; specific localized file
  ;;                               :en {:title "About"
  ;;                                    :filename "about-en.md"}}}]
  ;;

--- a/resources/config-defaults.edn
+++ b/resources/config-defaults.edn
@@ -315,6 +315,7 @@
  ;; :extra-pages [;; This is a page that's hosted at an external URL, only for logged-in users
  ;;               {:id "hello"
  ;;                :roles [:logged-in] ; other roles are possible too such as :applicant :member :handler etc.
+ ;;                :heading false ; don't show the heading, write any Markdown heading you like, defaults to true
  ;;                :url "http://example.org/hello.html" ; fallback URL
  ;;                :translations {:fi {:title "Hei"
  ;;                                    :url "http://example.org/fi/hello.html"} ; specific localized URL

--- a/resources/config-defaults.edn
+++ b/resources/config-defaults.edn
@@ -312,8 +312,9 @@
  ;;
  ;; Example: define two pages
  ;;
- ;; :extra-pages [;; This is a page that's hosted at an external URL
+ ;; :extra-pages [;; This is a page that's hosted at an external URL, only for logged-in users
  ;;               {:id "hello"
+ ;;                :roles [:logged-in] ; other roles are possible too such as :applicant :member :handler etc.
  ;;                :url "http://example.org/hello.html" ; fallback URL
  ;;                :translations {:fi {:title "Hei"
  ;;                                    :url "http://example.org/fi/hello.html"} ; specific localized URL

--- a/resources/sql/queries.sql
+++ b/resources/sql/queries.sql
@@ -52,7 +52,7 @@ WHERE 1=1
 /*~ (when-not (nil? (:enabled params)) */
   AND ci.enabled = :enabled
 /*~ ) ~*/
-;
+ORDER BY ci.id;
 
 -- :name set-catalogue-item-enabled! :!
 UPDATE catalogue_item

--- a/src/clj/rems/api/extra_pages.clj
+++ b/src/clj/rems/api/extra_pages.clj
@@ -17,12 +17,12 @@
       (let [roles (:roles page)]
         (when (or (nil? roles) ; default is unlimited
                   (apply roles/has-roles? roles))
-          (let [translations (:translations page)
-                extra-pages-path (:extra-pages-path env)]
+          (let [extra-pages-path (:extra-pages-path env)]
             (assert extra-pages-path ":extra-pages-path undefined in config")
             (into {}
-                  (for [[lang {:keys [filename]}] translations
-                        :let [filename (or filename (:filename page))]]
+                  (for [lang (:languages env)
+                        :let [filename (or (get-in page [:translations lang :filename])
+                                           (:filename page))]]
                     [lang (when filename
                             (let [file (io/file extra-pages-path filename)]
                               (when (.isFile file) (slurp file))))]))))))))

--- a/src/clj/rems/api/public.clj
+++ b/src/clj/rems/api/public.clj
@@ -17,9 +17,9 @@
    (s/optional-key :url) s/Str
    (s/optional-key :show-menu) s/Bool
    (s/optional-key :show-footer) s/Bool
-   :translations {s/Keyword {:title s/Str
-                             (s/optional-key :filename) s/Str
-                             (s/optional-key :url) s/Str}}})
+   (s/optional-key :translations) {s/Keyword {(s/optional-key :title) s/Str
+                                              (s/optional-key :filename) s/Str
+                                              (s/optional-key :url) s/Str}}})
 
 (s/defschema GetConfigResponse
   {:authentication s/Keyword

--- a/src/clj/rems/api/public.clj
+++ b/src/clj/rems/api/public.clj
@@ -15,6 +15,7 @@
   {:id s/Str
    (s/optional-key :filename) s/Str
    (s/optional-key :url) s/Str
+   (s/optional-key :roles) #{s/Keyword}
    (s/optional-key :show-menu) s/Bool
    (s/optional-key :show-footer) s/Bool
    (s/optional-key :translations) {s/Keyword {(s/optional-key :title) s/Str

--- a/src/clj/rems/api/public.clj
+++ b/src/clj/rems/api/public.clj
@@ -18,6 +18,7 @@
    (s/optional-key :roles) #{s/Keyword}
    (s/optional-key :show-menu) s/Bool
    (s/optional-key :show-footer) s/Bool
+   (s/optional-key :heading) s/Bool
    (s/optional-key :translations) {s/Keyword {(s/optional-key :title) s/Str
                                               (s/optional-key :filename) s/Str
                                               (s/optional-key :url) s/Str}}})

--- a/src/clj/rems/api/public.clj
+++ b/src/clj/rems/api/public.clj
@@ -17,7 +17,8 @@
    (s/optional-key :show-menu) s/Bool
    (s/optional-key :show-footer) s/Bool
    :translations {s/Keyword {:title s/Str
-                             (s/optional-key :filename) s/Str}}})
+                             (s/optional-key :filename) s/Str
+                             (s/optional-key :url) s/Str}}})
 
 (s/defschema GetConfigResponse
   {:authentication s/Keyword

--- a/src/clj/rems/api/public.clj
+++ b/src/clj/rems/api/public.clj
@@ -14,6 +14,8 @@
 (s/defschema ExtraPage
   {:id s/Str
    (s/optional-key :url) s/Str
+   (s/optional-key :show-menu) s/Bool
+   (s/optional-key :show-footer) s/Bool
    :translations {s/Keyword {:title s/Str
                              (s/optional-key :filename) s/Str}}})
 

--- a/src/clj/rems/api/public.clj
+++ b/src/clj/rems/api/public.clj
@@ -13,6 +13,7 @@
 
 (s/defschema ExtraPage
   {:id s/Str
+   (s/optional-key :filename) s/Str
    (s/optional-key :url) s/Str
    (s/optional-key :show-menu) s/Bool
    (s/optional-key :show-footer) s/Bool

--- a/src/clj/rems/api/services/public.clj
+++ b/src/clj/rems/api/services/public.clj
@@ -1,6 +1,7 @@
 (ns rems.api.services.public
   (:require [rems.config :refer [env]]
-            [rems.locales :as locales]))
+            [rems.locales :as locales]
+            [rems.common.roles :as roles]))
 
 (defn get-translations []
   locales/translations)
@@ -8,8 +9,16 @@
 (defn get-theme []
   (:theme env))
 
+(defn- filter-extra-pages [pages]
+  (filter (fn [page]
+            (let [roles (:roles page)]
+              (or (nil? roles) ; default is unlimited
+                  (apply roles/has-roles? roles))))
+          pages))
+
 (defn get-config []
-  (select-keys env [:alternative-login-url
+  (-> env
+      (select-keys [:alternative-login-url
                     :application-id-column
                     :authentication
                     :catalogue-is-public
@@ -29,7 +38,8 @@
                     :catalogue-tree-show-matching-parents
                     :enable-cart
                     :application-list-hidden-columns
-                    :enable-autosave]))
+                    :enable-autosave])
+      (update :extra-pages filter-extra-pages)))
 
 (defn get-config-full []
   (assoc env

--- a/src/clj/rems/config.clj
+++ b/src/clj/rems/config.clj
@@ -41,7 +41,7 @@
 (defn- parse-config [config]
   (-> config
       (update :email-retry-period #(Period/parse %))
-      (update :extra-pages (partial mapv #(update-existing % :roles set)))
+      (update-existing :extra-pages (partial mapv #(update-existing % :roles set)))
       (update :disable-commands (partial mapv keyword))))
 
 (deftest test-parse-config

--- a/src/clj/rems/config.clj
+++ b/src/clj/rems/config.clj
@@ -6,6 +6,7 @@
             [cprop.core :refer [load-config]]
             [cprop.source :as source]
             [cprop.tools :refer [merge-maps]]
+            [medley.core :refer [update-existing]]
             [mount.core :refer [defstate]]
             [rems.application.commands :as commands]
             [rems.application.events :as events]
@@ -40,6 +41,7 @@
 (defn- parse-config [config]
   (-> config
       (update :email-retry-period #(Period/parse %))
+      (update :extra-pages (partial mapv #(update-existing % :roles set)))
       (update :disable-commands (partial mapv keyword))))
 
 (deftest test-parse-config

--- a/src/clj/rems/css/styles.clj
+++ b/src/clj/rems/css/styles.clj
@@ -577,8 +577,8 @@
                :padding-bottom "1rem"
                :background-color (theme-getx :footer-bgcolor :table-heading-bgcolor :color3)
                :margin-top (u/em 1)}
-      [:a :a:hover {:color footer-text-color
-                    :font-weight (button-navbar-font-weight)}]
+      [:a :a:hover :.nav-link {:color footer-text-color
+                               :font-weight (button-navbar-font-weight)}]
       [:.dev-reload-button {:position :fixed
                             :right (u/rem 1.5)}]])
 

--- a/src/clj/rems/css/styles.clj
+++ b/src/clj/rems/css/styles.clj
@@ -576,10 +576,12 @@
                :padding-top "1rem"
                :padding-bottom "1rem"
                :background-color (theme-getx :footer-bgcolor :table-heading-bgcolor :color3)
-               :margin-top (u/em 1)}
+               :margin-top (u/em 1)
+               :position :relative}
       [:a :a:hover :.nav-link {:color footer-text-color
                                :font-weight (button-navbar-font-weight)}]
-      [:.dev-reload-button {:position :fixed
+      [:.dev-reload-button {:position :absolute
+                            :bottom (u/rem 1.5)
                             :right (u/rem 1.5)}]])
 
    [:.jumbotron

--- a/src/clj/rems/css/styles.clj
+++ b/src/clj/rems/css/styles.clj
@@ -580,8 +580,7 @@
       [:a :a:hover {:color footer-text-color
                     :font-weight (button-navbar-font-weight)}]
       [:.dev-reload-button {:position :fixed
-                            :bottom 0
-                            :right (u/px 140)}]])
+                            :right (u/rem 1.5)}]])
 
    [:.jumbotron
     {:background-color "#fff"

--- a/src/cljs/rems/atoms.cljs
+++ b/src/cljs/rems/atoms.cljs
@@ -160,7 +160,7 @@
                " - ")
              (text :t.header/title))))
 
-(defn document-title [_title]
+(defn document-title [_title & [{:keys [heading?] :or {heading? true}}]]
   (let [on-update (fn [this]
                     (let [[_ title] (reagent/argv this)]
                       (set-document-title! title)))]
@@ -169,7 +169,8 @@
       :component-did-update on-update
       :display-name "document-title"
       :reagent-render (fn [title]
-                        [:h1 title])})))
+                        (when heading?
+                          [:h1 title]))})))
 
 (defn logo []
   [:div {:class "logo"}
@@ -181,7 +182,7 @@
 
 (defn expander
   "Displays an expandable block of content with animated chevron.
-   
+
    Pass a map of options with the following keys:
    * `id` unique id for expanded content
    * `content` content which is displayed in expanded state

--- a/src/cljs/rems/auth/auth.cljs
+++ b/src/cljs/rems/auth/auth.cljs
@@ -23,7 +23,7 @@
      (when-let [alternative-endpoint (:alternative-login-url config)]
        [:div.text-center.w-100.mt-4
         [atoms/link nil
-         (nav/url-dest alternative-endpoint)
+         alternative-endpoint
          (text :t.login/alternative)]])]))
 
 (defn guide []

--- a/src/cljs/rems/auth/fake.cljs
+++ b/src/cljs/rems/auth/fake.cljs
@@ -9,5 +9,5 @@
    (text :t.login/fake-text)
    [:div.text-center
     [atoms/link {:class "btn btn-primary btn-lg login-btn"}
-     (nav/url-dest "/fake-login")
+     "/fake-login"
      (text :t.login/login)]]])

--- a/src/cljs/rems/auth/oidc.cljs
+++ b/src/cljs/rems/auth/oidc.cljs
@@ -9,5 +9,5 @@
    (text :t.login/oidc-text)
    [:div.text-center
     [atoms/link {:class "btn btn-primary btn-lg login-btn"}
-     (nav/url-dest "/oidc-login")
+     "/oidc-login"
      (text :t.login/login)]]])

--- a/src/cljs/rems/extra_pages.cljs
+++ b/src/cljs/rems/extra_pages.cljs
@@ -78,5 +78,5 @@
 
            ;; if no file content for this page exists, we can try URL
            (if-let [url (get-in config-extra-page [:translations language :url] (:url config-extra-page))]
-             [atoms/link nil url url]
+             [:div.m-3 [atoms/link nil url url]]
              (rf/dispatch [:set-active-page :not-found])))))]))

--- a/src/cljs/rems/extra_pages.cljs
+++ b/src/cljs/rems/extra_pages.cljs
@@ -62,7 +62,7 @@
         config-extra-page (find-first (comp #{page-id} :id) extra-pages)
         language @(rf/subscribe [:language])]
     [:div
-     [document-title title]
+     [document-title title {:heading? (get config-extra-page :heading true)}]
      [flash-message/component :top]
      (if loading?
        [spinner/big]

--- a/src/cljs/rems/extra_pages.cljs
+++ b/src/cljs/rems/extra_pages.cljs
@@ -2,11 +2,11 @@
   (:require [markdown.core :as md]
             [medley.core :refer [find-first]]
             [re-frame.core :as rf]
-            [rems.atoms :refer [document-title]]
+            [rems.atoms :refer [document-title] :as atoms]
             [rems.flash-message :as flash-message]
             [rems.spinner :as spinner]
             [rems.text :refer [text]]
-            [rems.util :refer [fetch set-location!]]))
+            [rems.util :refer [fetch]]))
 
 ;;;; State
 
@@ -69,6 +69,7 @@
 
        (if (= extra-page :not-found)
          (rf/dispatch [:set-active-page :not-found])
+
          (if-let [content (get extra-page language)]
            [:div.document
             (if content
@@ -77,6 +78,5 @@
 
            ;; if no file content for this page exists, we can try URL
            (if-let [url (get-in config-extra-page [:translations language :url] (:url config-extra-page))]
-             (do (set-location! url)
-                 [spinner/big])
+             [atoms/link nil url url]
              (rf/dispatch [:set-active-page :not-found])))))]))

--- a/src/cljs/rems/navbar.cljs
+++ b/src/cljs/rems/navbar.cljs
@@ -52,7 +52,20 @@
         extra-pages (when config (config :extra-pages))
         language @(rf/subscribe [:language])]
     (when extra-pages
-      (for [page extra-pages]
+      (for [page extra-pages
+            :when (:show-menu page true)]
+        (let [url (or (page :url)
+                      (str "/extra-pages/" (page :id)))
+              text (get-in page [:translations language :title] (text :t/missing))]
+          [nav-link url text])))))
+
+(defn footer-extra-pages []
+  (let [config @(rf/subscribe [:rems.config/config])
+        extra-pages (when config (config :extra-pages))
+        language @(rf/subscribe [:language])]
+    (when extra-pages
+      (for [page extra-pages
+            :when (:show-footer page false)]
         (let [url (or (page :url)
                       (str "/extra-pages/" (page :id)))
               text (get-in page [:translations language :title] (text :t/missing))]

--- a/src/cljs/rems/navbar.cljs
+++ b/src/cljs/rems/navbar.cljs
@@ -46,7 +46,8 @@
        [:span.icon-description (text :t.navigation/logout)]]]]))
 
 (defn- extra-page-link [page language]
-  (let [url (or (page :url)
+  (let [url (or (get-in page [:translations language :url])
+                (page :url)
                 (str "/extra-pages/" (page :id)))
         text (get-in page [:translations language :title] (text :t/missing))]
     [nav-link url text]))

--- a/src/cljs/rems/navbar.cljs
+++ b/src/cljs/rems/navbar.cljs
@@ -57,24 +57,26 @@
         extra-pages (when config (config :extra-pages))
         language @(rf/subscribe [:language])]
     (when extra-pages
-      (for [page extra-pages
-            :when (:show-menu page true)]
-        (let [url (or (page :url)
-                      (str "/extra-pages/" (page :id)))
-              text (get-in page [:translations language :title] (text :t/missing))]
-          [nav-link url text])))))
+      (doall (for [page extra-pages
+                   :when (:show-menu page true)]
+               (let [url (or (page :url)
+                             (str "/extra-pages/" (page :id)))
+                     text (get-in page [:translations language :title] (text :t/missing))]
+                 ^{:key (str "navbar-extra-page-" (page :id))}
+                 [nav-link url text]))))))
 
 (defn footer-extra-pages []
   (let [config @(rf/subscribe [:rems.config/config])
         extra-pages (when config (config :extra-pages))
         language @(rf/subscribe [:language])]
     (when extra-pages
-      (for [page extra-pages
-            :when (:show-footer page false)]
-        (let [url (or (page :url)
-                      (str "/extra-pages/" (page :id)))
-              text (get-in page [:translations language :title] (text :t/missing))]
-          [nav-link url text])))))
+      (doall (for [page extra-pages
+                   :when (:show-footer page false)]
+               (let [url (or (page :url)
+                             (str "/extra-pages/" (page :id)))
+                     text (get-in page [:translations language :title] (text :t/missing))]
+                 ^{:key (str "footer-extra-page-" (page :id))}
+                 [nav-link url text]))))))
 
 (defn navbar-items [e attrs identity]
   ;;TODO: get navigation options from subscription

--- a/src/cljs/rems/navbar.cljs
+++ b/src/cljs/rems/navbar.cljs
@@ -8,22 +8,14 @@
             [rems.language-switcher :refer [language-switcher]]
             [rems.text :refer [text]]))
 
-;; TODO fetch as a subscription?
-(def context {:root-path ""})
-
-(defn url-dest
-  [dest]
-  (str (:root-path context) dest))
-
 (defn- nav-link-impl [path title & [active?]]
-  (let [url (url-dest path)]
-    [atoms/link
-     (merge {:class (str "nav-link" (if active? " active" ""))}
-            (when (rems.ajax/local-uri? {:uri url})
-              {:data-toggle "collapse"
-               :data-target ".navbar-collapse.show"}))
-     url
-     title]))
+  [atoms/link
+   (merge {:class (str "nav-link" (if active? " active" ""))}
+          (when (rems.ajax/local-uri? {:uri path})
+            {:data-toggle "collapse"
+             :data-target ".navbar-collapse.show"}))
+   path
+   title])
 
 (defn nav-link
   "A link to path that is shown as active when the current browser location matches the path.
@@ -47,7 +39,7 @@
       [:span {:aria-label (text :t.navigation/profile)}
        [:i.fa.fa-user.mr-1]
        [:span.icon-description (:name user)]]]
-     [atoms/link {:id "logout" :class "nav-link"} (url-dest "/logout")
+     [atoms/link {:id "logout" :class "nav-link"} "/logout"
       [:span {:aria-label (text :t.navigation/logout)}
        [:i.fa.fa-sign-out-alt.mr-1]
        [:span.icon-description (text :t.navigation/logout)]]]]))

--- a/src/cljs/rems/navbar.cljs
+++ b/src/cljs/rems/navbar.cljs
@@ -3,6 +3,7 @@
             [re-frame.core :as rf]
             [rems.ajax]
             [rems.atoms :as atoms]
+            [rems.common.util :refer [getx]]
             [rems.common.roles :as roles]
             [rems.guide-util :refer [component-info example]]
             [rems.language-switcher :refer [language-switcher]]
@@ -44,6 +45,12 @@
        [:i.fa.fa-sign-out-alt.mr-1]
        [:span.icon-description (text :t.navigation/logout)]]]]))
 
+(defn- extra-page-link [page language]
+  (let [url (or (page :url)
+                (str "/extra-pages/" (page :id)))
+        text (get-in page [:translations language :title] (text :t/missing))]
+    [nav-link url text]))
+
 (defn navbar-extra-pages []
   (let [config @(rf/subscribe [:rems.config/config])
         extra-pages (when config (config :extra-pages))
@@ -51,11 +58,8 @@
     (when extra-pages
       (doall (for [page extra-pages
                    :when (:show-menu page true)]
-               (let [url (or (page :url)
-                             (str "/extra-pages/" (page :id)))
-                     text (get-in page [:translations language :title] (text :t/missing))]
-                 ^{:key (str "navbar-extra-page-" (page :id))}
-                 [nav-link url text]))))))
+               ^{:key (str "navbar-extra-page-" (getx page :id))}
+               [extra-page-link page language])))))
 
 (defn footer-extra-pages []
   (let [config @(rf/subscribe [:rems.config/config])
@@ -64,11 +68,8 @@
     (when extra-pages
       (doall (for [page extra-pages
                    :when (:show-footer page false)]
-               (let [url (or (page :url)
-                             (str "/extra-pages/" (page :id)))
-                     text (get-in page [:translations language :title] (text :t/missing))]
-                 ^{:key (str "footer-extra-page-" (page :id))}
-                 [nav-link url text]))))))
+               ^{:key (str "footer-extra-page-" (getx page :id))}
+               [extra-page-link page language])))))
 
 (defn navbar-items [e attrs identity]
   ;;TODO: get navigation options from subscription

--- a/src/cljs/rems/navbar.cljs
+++ b/src/cljs/rems/navbar.cljs
@@ -1,6 +1,7 @@
 (ns rems.navbar
   (:require [clojure.string :as str]
             [re-frame.core :as rf]
+            [rems.ajax]
             [rems.atoms :as atoms]
             [rems.common.roles :as roles]
             [rems.guide-util :refer [component-info example]]
@@ -15,10 +16,14 @@
   (str (:root-path context) dest))
 
 (defn- nav-link-impl [path title & [active?]]
-  [atoms/link {:class (str "nav-link" (if active? " active" ""))
-               :data-toggle "collapse"
-               :data-target ".navbar-collapse.show"}
-   (url-dest path) title])
+  (let [url (url-dest path)]
+    [atoms/link
+     (merge {:class (str "nav-link" (if active? " active" ""))}
+            (when (rems.ajax/local-uri? {:uri url})
+              {:data-toggle "collapse"
+               :data-target ".navbar-collapse.show"}))
+     url
+     title]))
 
 (defn nav-link
   "A link to path that is shown as active when the current browser location matches the path.

--- a/src/cljs/rems/spa.cljs
+++ b/src/cljs/rems/spa.cljs
@@ -328,7 +328,7 @@
 (defn footer []
   [:footer.footer
    [:div.container.d-flex.flex-row.justify-content-between.align-items-center
-    (nav/footer-extra-pages)
+    [nav/footer-extra-pages]
     [:div.footer-text (text :t/footer)]
     (when (config/dev-environment?)
       [dev-reload-button])]])

--- a/src/cljs/rems/spa.cljs
+++ b/src/cljs/rems/spa.cljs
@@ -328,7 +328,7 @@
 (defn footer []
   [:footer.footer
    [:div.container.d-flex.flex-row.justify-content-between.align-items-center
-    [nav/footer-extra-pages]
+    [:div.d-flex.flex-row [nav/footer-extra-pages]]
     [:div.footer-text (text :t/footer)]
     (when (config/dev-environment?)
       [dev-reload-button])]])

--- a/src/cljs/rems/spa.cljs
+++ b/src/cljs/rems/spa.cljs
@@ -327,10 +327,11 @@
 
 (defn footer []
   [:footer.footer
-   [:div.container
+   [:div.container.d-flex.flex-row.justify-content-between.align-items-center
+    (nav/footer-extra-pages)
+    [:div.footer-text (text :t/footer)]
     (when (config/dev-environment?)
-      [dev-reload-button])
-    [:div.footer-text (text :t/footer)]]])
+      [dev-reload-button])]])
 
 (defn main-content [_page-id _grab-focus?]
   (let [on-update (fn [this]

--- a/test-config.edn
+++ b/test-config.edn
@@ -49,6 +49,7 @@
                 :show-menu false
                 :show-footer false}
                {:id "url"
+                :roles [:logged-in]
                 :url "https://example.org/"
                 :translations {:fi {:title "Esimerkki"
                                     :url "https://example.org/fi"}

--- a/test-config.edn
+++ b/test-config.edn
@@ -37,7 +37,15 @@
                                :sv {:title "Link"
                                     :filename "link-sv.md"}}
                 :show-menu false
-                :show-footer false}]
+                :show-footer false}
+               {:id "url"
+                :url "https://example.org/"
+                :translations {:fi {:title "Esimerkki"
+                                    :url "https://example.org/fi"}
+                               :en {:title "Example"}
+                               :sv {:title "Exempel"}}
+                :show-menu true
+                :show-footer true}]
  :extra-pages-path "./test-data/extra-pages"
  :attachment-max-size 10000
  :enable-pdf-api true

--- a/test-config.edn
+++ b/test-config.edn
@@ -38,6 +38,16 @@
                                     :filename "link-sv.md"}}
                 :show-menu false
                 :show-footer false}
+               {:id "mixed"
+                :translations {:fi {:title "Mixed"
+                                    :filename "mixed-fi.md"}
+                               :en {:url "https://example.org/en/mixed"}} ; missing sv
+                :show-menu false
+                :show-footer false}
+               {:id "unlocalized"
+                :url "https://example.org/unlocalized"
+                :show-menu false
+                :show-footer false}
                {:id "url"
                 :url "https://example.org/"
                 :translations {:fi {:title "Esimerkki"

--- a/test-config.edn
+++ b/test-config.edn
@@ -21,10 +21,10 @@
                                :sv {:title "Info"
                                     :filename "about-sv.md"}}}
                {:id "footer"
+                :filename "footer-en.md"
                 :translations {:fi {:title "Footer"
                                     :filename "footer-fi.md"}
-                               :en {:title "Footer"
-                                    :filename "footer-en.md"}
+                               :en {:title "Footer"}
                                :sv {:title "Footer"
                                     :filename "footer-sv.md"}}
                 :show-menu false

--- a/test-config.edn
+++ b/test-config.edn
@@ -39,6 +39,7 @@
                 :show-menu false
                 :show-footer false}
                {:id "mixed"
+                :heading false
                 :translations {:fi {:title "Mixed"
                                     :filename "mixed-fi.md"}
                                :en {:url "https://example.org/en/mixed"}} ; missing sv

--- a/test-config.edn
+++ b/test-config.edn
@@ -13,6 +13,32 @@
                          {:attribute "picture"}
                          {:attribute "organizations"}]
  :languages [:en :fi :sv]
+ :extra-pages [{:id "about"
+                :translations {:fi {:title "Info"
+                                    :filename "about-fi.md"}
+                               :en {:title "About"
+                                    :filename "about-en.md"}
+                               :sv {:title "Info"
+                                    :filename "about-sv.md"}}}
+               {:id "footer"
+                :translations {:fi {:title "Footer"
+                                    :filename "footer-fi.md"}
+                               :en {:title "Footer"
+                                    :filename "footer-en.md"}
+                               :sv {:title "Footer"
+                                    :filename "footer-sv.md"}}
+                :show-menu false
+                :show-footer true}
+               {:id "link"
+                :translations {:fi {:title "Link"
+                                    :filename "link-fi.md"}
+                               :en {:title "Link"
+                                    :filename "link-en.md"}
+                               :sv {:title "Link"
+                                    :filename "link-sv.md"}}
+                :show-menu false
+                :show-footer false}]
+ :extra-pages-path "./test-data/extra-pages"
  :attachment-max-size 10000
  :enable-pdf-api true
  :enable-permissions-api true

--- a/test-data/extra-pages/about-en.md
+++ b/test-data/extra-pages/about-en.md
@@ -1,1 +1,3 @@
 This is a dummy About page for REMS.
+
+![REMS Logo](/img/rems_logo_en.png)

--- a/test-data/extra-pages/about-fi.md
+++ b/test-data/extra-pages/about-fi.md
@@ -1,1 +1,5 @@
 Tämä on REMSin info-sivun tynkä.
+
+![REMS Logo](/img/rems_logo_fi.png)
+
+

--- a/test-data/extra-pages/about-sv.md
+++ b/test-data/extra-pages/about-sv.md
@@ -1,1 +1,3 @@
 Den här är en infosida på svenska.
+
+![REMS Logo](/img/rems_logo_sv.png)

--- a/test-data/extra-pages/footer-en.md
+++ b/test-data/extra-pages/footer-en.md
@@ -1,0 +1,1 @@
+This is a dummy footer page for REMS.

--- a/test-data/extra-pages/footer-fi.md
+++ b/test-data/extra-pages/footer-fi.md
@@ -1,0 +1,1 @@
+Tämä on REMSin footer sivun tynkä.

--- a/test-data/extra-pages/footer-sv.md
+++ b/test-data/extra-pages/footer-sv.md
@@ -1,0 +1,1 @@
+Den här är en REMS footer sida på svenska.

--- a/test-data/extra-pages/link-en.md
+++ b/test-data/extra-pages/link-en.md
@@ -1,0 +1,1 @@
+This is a dummy extra page for REMS that can only be shown with a direct link.

--- a/test-data/extra-pages/link-fi.md
+++ b/test-data/extra-pages/link-fi.md
@@ -1,0 +1,1 @@
+Tämä on REMSin extrasivun tynkä, jonka näkee vain suoralla linkillä.

--- a/test-data/extra-pages/link-sv.md
+++ b/test-data/extra-pages/link-sv.md
@@ -1,0 +1,1 @@
+Den här är en REMS ekstrasida på svenska, som kan visas bara med en direkt länk.

--- a/test-data/extra-pages/mixed-fi.md
+++ b/test-data/extra-pages/mixed-fi.md
@@ -1,1 +1,3 @@
+# Tämä otsikko on Markdown-tiedostosta
+
 Tämä on REMSin info-sivun tynkä, jossa muilla kielillä käytetään linkkiä.

--- a/test-data/extra-pages/mixed-fi.md
+++ b/test-data/extra-pages/mixed-fi.md
@@ -1,0 +1,1 @@
+Tämä on REMSin info-sivun tynkä, jossa muilla kielillä käytetään linkkiä.

--- a/test/clj/rems/api/test_extra_pages.clj
+++ b/test/clj/rems/api/test_extra_pages.clj
@@ -5,62 +5,57 @@
             [rems.handler :refer [handler]]
             [ring.mock.request :refer :all]))
 
-(use-fixtures
-  :once
-  api-fixture)
+(use-fixtures :once api-fixture)
 
 (deftest extra-pages-api-test
-  (let [api-key "42"
-        user-id "owner"]
-    (test-data/create-test-users-and-roles!)
-    (with-redefs [rems.config/env (assoc rems.config/env
-                                         :extra-pages [{:id "test"
-                                                        :filename "test-en.md"
-                                                        :translations {:fi {:title "Testi"
-                                                                            :filename "test-fi.md"}
-                                                                       :en {:title "Test"}
-                                                                       :de {:url "https://example.org/de"}}}
+  (test-data/create-test-users-and-roles!)
+  (with-redefs [rems.config/env (assoc rems.config/env
+                                       :extra-pages [{:id "test"
+                                                      :filename "test-en.md"
+                                                      :translations {:fi {:title "Testi"
+                                                                          :filename "test-fi.md"}
+                                                                     :en {:title "Test"}
+                                                                     :de {:url "https://example.org/de"}}}
 
-                                                       {:id "test2"
-                                                        :url "https://example.org/"
-                                                        :translations {:fi {:title "Testi"
-                                                                            :filename "test-fi.md"}
-                                                                       :en {:title "Test"
-                                                                            :filename "test-en.md"}
-                                                                       :de {:url "https://example.org/de"}}}
+                                                     {:id "test2"
+                                                      :url "https://example.org/"
+                                                      :translations {:fi {:title "Testi"
+                                                                          :filename "test-fi.md"}
+                                                                     :en {:title "Test"
+                                                                          :filename "test-en.md"}
+                                                                     :de {:url "https://example.org/de"}}}
 
-                                                       {:id "test-roles"
-                                                        :roles [:handler]
-                                                        :filename "test-en.md"}]
-                                         :extra-pages-path "./test-data/extra-pages/")]
-      (testing "fetch existing extra-page"
-        (let [response (api-call :get "/api/extra-pages/test" {} api-key user-id)]
-          (is (= (set (keys response)) #{:en :fi :de}))
-          (testing "fallback"
-            (is (= "This is a test.\n" (:en response)) "should have fallback")
-            (is (= "Tämä on testi.\n" (:fi response)) "should have custom localization")
-            (is (= "This is a test.\n" (:de response)) "should have fallback though url is intended for front-end")))
+                                                     {:id "test-roles"
+                                                      :roles [:handler]
+                                                      :filename "test-en.md"}]
+                                       :extra-pages-path "./test-data/extra-pages/")]
+    (testing "fetch existing extra-page"
+      (let [response (api-call :get "/api/extra-pages/test" {} "42" "alice")]
+        (is (= (set (keys response)) #{:en :fi :de}) "should return content in defined languages")
+        (is (= "This is a test.\n" (:en response)) "should have fallback")
+        (is (= "Tämä on testi.\n" (:fi response)) "should have custom localization")
+        (is (= "This is a test.\n" (:de response)) "should have fallback though url is intended for front-end"))
 
-        (let [response (api-call :get "/api/extra-pages/test2" {} api-key user-id)]
-          (is (= (set (keys response)) #{:en :fi :de}))
-          (testing "without fallback"
-            (is (= nil (:de response)) "should have no content as url is intended for front-end"))))
+      (let [response (api-call :get "/api/extra-pages/test2" {} "42" "alice")]
+        (is (= (set (keys response)) #{:en :fi :de}))
+        (testing "without fallback"
+          (is (nil? (:de response)) "should have no content as url is intended for front-end"))))
 
-      (testing "roles"
-        (testing "not with the role"
-          (let [response (-> (request :get "/api/extra-pages/test-roles")
-                             (authenticate api-key user-id)
-                             handler)]
-            (is (response-is-not-found? response))))
-
-        (testing "with the role"
-          (let [response (-> (request :get "/api/extra-pages/test-roles")
-                             (authenticate api-key "handler")
-                             handler)]
-            (is (response-is-not-found? response)))))
-
-      (testing "try to fetch non-existing extra-page"
-        (let [response (-> (request :get "/api/extra-pages/test-does-not-exist")
-                           (authenticate api-key user-id)
+    (testing "roles"
+      (testing "without the role"
+        (let [response (-> (request :get "/api/extra-pages/test-roles")
+                           (authenticate "42" "alice")
                            handler)]
-          (is (response-is-not-found? response)))))))
+          (is (response-is-not-found? response))))
+
+      (testing "with the role"
+        (let [response (-> (request :get "/api/extra-pages/test-roles")
+                           (authenticate "42" "handler")
+                           handler)]
+          (is (response-is-not-found? response)))))
+
+    (testing "try to fetch non-existing extra-page"
+      (let [response (-> (request :get "/api/extra-pages/test-does-not-exist")
+                         (authenticate "42" "alice")
+                         handler)]
+        (is (response-is-not-found? response))))))

--- a/test/clj/rems/api/test_extra_pages.clj
+++ b/test/clj/rems/api/test_extra_pages.clj
@@ -16,7 +16,7 @@
                                                       :translations {:fi {:title "Testi"
                                                                           :filename "test-fi.md"}
                                                                      :en {:title "Test"}
-                                                                     :de {:url "https://example.org/de"}}}
+                                                                     :sv {:url "https://example.org/sv"}}}
 
                                                      {:id "test2"
                                                       :url "https://example.org/"
@@ -24,7 +24,7 @@
                                                                           :filename "test-fi.md"}
                                                                      :en {:title "Test"
                                                                           :filename "test-en.md"}
-                                                                     :de {:url "https://example.org/de"}}}
+                                                                     :sv {:url "https://example.org/sv"}}}
 
                                                      {:id "test-roles"
                                                       :roles [:handler]
@@ -32,15 +32,15 @@
                                        :extra-pages-path "./test-data/extra-pages/")]
     (testing "fetch existing extra-page"
       (let [response (api-call :get "/api/extra-pages/test" {} "42" "alice")]
-        (is (= (set (keys response)) #{:en :fi :de}) "should return content in defined languages")
+        (is (= (set (keys response)) #{:en :fi :sv}) "should return content in defined languages")
         (is (= "This is a test.\n" (:en response)) "should have fallback")
         (is (= "Tämä on testi.\n" (:fi response)) "should have custom localization")
-        (is (= "This is a test.\n" (:de response)) "should have fallback though url is intended for front-end"))
+        (is (= "This is a test.\n" (:sv response)) "should have fallback though url is intended for front-end"))
 
       (let [response (api-call :get "/api/extra-pages/test2" {} "42" "alice")]
-        (is (= (set (keys response)) #{:en :fi :de}))
+        (is (= (set (keys response)) #{:en :fi :sv}))
         (testing "without fallback"
-          (is (nil? (:de response)) "should have no content as url is intended for front-end"))))
+          (is (nil? (:sv response)) "should have no content as url is intended for front-end"))))
 
     (testing "roles"
       (testing "without the role"
@@ -52,8 +52,9 @@
       (testing "with the role"
         (let [response (-> (request :get "/api/extra-pages/test-roles")
                            (authenticate "42" "handler")
-                           handler)]
-          (is (response-is-not-found? response)))))
+                           handler
+                           read-ok-body)]
+          (is (= "This is a test.\n" (:en response))))))
 
     (testing "try to fetch non-existing extra-page"
       (let [response (-> (request :get "/api/extra-pages/test-does-not-exist")

--- a/test/clj/rems/api/test_extra_pages.clj
+++ b/test/clj/rems/api/test_extra_pages.clj
@@ -27,7 +27,7 @@
                                                                      :sv {:url "https://example.org/sv"}}}
 
                                                      {:id "test-roles"
-                                                      :roles [:handler]
+                                                      :roles [:owner]
                                                       :filename "test-en.md"}]
                                        :extra-pages-path "./test-data/extra-pages/")]
     (testing "fetch existing extra-page"
@@ -51,7 +51,7 @@
 
       (testing "with the role"
         (let [response (-> (request :get "/api/extra-pages/test-roles")
-                           (authenticate "42" "handler")
+                           (authenticate "42" "owner")
                            handler
                            read-ok-body)]
           (is (= "This is a test.\n" (:en response))))))

--- a/test/clj/rems/api/test_extra_pages.clj
+++ b/test/clj/rems/api/test_extra_pages.clj
@@ -1,5 +1,6 @@
 (ns ^:integration rems.api.test-extra-pages
   (:require [clojure.test :refer :all]
+            [rems.db.test-data :as test-data]
             [rems.api.testing :refer :all]
             [rems.handler :refer [handler]]
             [ring.mock.request :refer :all]))
@@ -11,19 +12,55 @@
 (deftest extra-pages-api-test
   (let [api-key "42"
         user-id "owner"]
+    (test-data/create-test-users-and-roles!)
     (with-redefs [rems.config/env (assoc rems.config/env
                                          :extra-pages [{:id "test"
+                                                        :filename "test-en.md"
+                                                        :translations {:fi {:title "Testi"
+                                                                            :filename "test-fi.md"}
+                                                                       :en {:title "Test"}
+                                                                       :de {:url "https://example.org/de"}}}
+
+                                                       {:id "test2"
+                                                        :url "https://example.org/"
                                                         :translations {:fi {:title "Testi"
                                                                             :filename "test-fi.md"}
                                                                        :en {:title "Test"
-                                                                            :filename "test-en.md"}}}]
+                                                                            :filename "test-en.md"}
+                                                                       :de {:url "https://example.org/de"}}}
+
+                                                       {:id "test-roles"
+                                                        :roles [:handler]
+                                                        :filename "test-en.md"}]
                                          :extra-pages-path "./test-data/extra-pages/")]
       (testing "fetch existing extra-page"
         (let [response (api-call :get "/api/extra-pages/test" {} api-key user-id)]
-          (is (= (set (keys response)) #{:en :fi}))
-          (is (= (:en response) "This is a test.\n"))))
+          (is (= (set (keys response)) #{:en :fi :de}))
+          (testing "fallback"
+            (is (= "This is a test.\n" (:en response)) "should have fallback")
+            (is (= "Tämä on testi.\n" (:fi response)) "should have custom localization")
+            (is (= "This is a test.\n" (:de response)) "should have fallback though url is intended for front-end")))
+
+        (let [response (api-call :get "/api/extra-pages/test2" {} api-key user-id)]
+          (is (= (set (keys response)) #{:en :fi :de}))
+          (testing "without fallback"
+            (is (= nil (:de response)) "should have no content as url is intended for front-end"))))
+
+      (testing "roles"
+        (testing "not with the role"
+          (let [response (-> (request :get "/api/extra-pages/test-roles")
+                             (authenticate api-key user-id)
+                             handler)]
+            (is (response-is-not-found? response))))
+
+        (testing "with the role"
+          (let [response (-> (request :get "/api/extra-pages/test-roles")
+                             (authenticate api-key "handler")
+                             handler)]
+            (is (response-is-not-found? response)))))
+
       (testing "try to fetch non-existing extra-page"
-        (let [response (-> (request :get "/api/extra-pages/test2")
+        (let [response (-> (request :get "/api/extra-pages/test-does-not-exist")
                            (authenticate api-key user-id)
                            handler)]
           (is (response-is-not-found? response)))))))

--- a/test/clj/rems/api/test_extra_pages.clj
+++ b/test/clj/rems/api/test_extra_pages.clj
@@ -8,6 +8,7 @@
 (use-fixtures :once api-fixture)
 
 (deftest extra-pages-api-test
+  (test-data/create-test-api-key!)
   (test-data/create-test-users-and-roles!)
   (with-redefs [rems.config/env (assoc rems.config/env
                                        :extra-pages [{:id "test"

--- a/test/clj/rems/test_browser.clj
+++ b/test/clj/rems/test_browser.clj
@@ -3017,7 +3017,7 @@
 
         (testing "mixed markdown content"
           (btu/go (str (btu/get-server-url) "extra-pages/mixed"))
-          (is (btu/eventually-visible? {:css "h1" :fn/has-text "Mixed"}))
+          (is (btu/eventually-visible? {:css "h1" :fn/has-text "Tämä otsikko on Markdown-tiedostosta"}))
           (is (btu/eventually-visible? {:css ".document" :fn/has-text "Tämä on REMSin info-sivun tynkä, jossa muilla kielillä käytetään linkkiä."}))))
 
       (testing "fallback"

--- a/test/clj/rems/test_browser.clj
+++ b/test/clj/rems/test_browser.clj
@@ -3007,8 +3007,13 @@
           (is (btu/eventually-visible? {:css ".document" :fn/has-text "Tämä on REMSin footer sivun tynkä."})))
 
         (testing "link content"
-          (is (btu/eventually-visible? [:big-navbar {:tag :a :fn/has-text "Esimerkki"}]))
-          (is (= "https://example.org/fi" (btu/get-element-attr [:big-navbar {:tag :a :fn/has-text "Esimerkki"}] :href))))
+          (testing "roles"
+            (is (not (btu/visible? [:big-navbar {:tag :a :fn/has-text "Esimerkki"}])))
+            (login-as "alice")
+            (is (btu/eventually-visible? [:big-navbar {:tag :a :fn/has-text "Esimerkki"}]))
+            (is (= "https://example.org/fi" (btu/get-element-attr [:big-navbar {:tag :a :fn/has-text "Esimerkki"}] :href)))
+            (logout)
+            (is (btu/eventually-invisible? [:big-navbar {:tag :a :fn/has-text "Esimerkki"}]))))
 
         (testing "mixed markdown content"
           (btu/go (str (btu/get-server-url) "extra-pages/mixed"))
@@ -3028,8 +3033,13 @@
             (is (btu/eventually-visible? {:css ".document" :fn/has-text "This is a dummy footer page for REMS."})))
 
           (testing "link content"
-            (is (btu/eventually-visible? [:big-navbar {:tag :a :fn/has-text "Example"}]))
-            (is (= "https://example.org/" (btu/get-element-attr [:big-navbar {:tag :a :fn/has-text "Example"}] :href))))
+            (testing "roles"
+              (is (not (btu/visible? [:big-navbar {:tag :a :fn/has-text "Example"}])))
+              (login-as "elsa")
+              (is (btu/eventually-visible? [:big-navbar {:tag :a :fn/has-text "Example"}]))
+              (is (= "https://example.org/" (btu/get-element-attr [:big-navbar {:tag :a :fn/has-text "Example"}] :href)))
+              (logout)
+              (is (btu/eventually-invisible? [:big-navbar {:tag :a :fn/has-text "Example"}]))))
 
           (testing "mixed link content"
             (btu/go (str (btu/get-server-url) "extra-pages/mixed"))

--- a/test/clj/rems/test_browser.clj
+++ b/test/clj/rems/test_browser.clj
@@ -3043,7 +3043,7 @@
 
           (testing "mixed link content"
             (btu/go (str (btu/get-server-url) "extra-pages/mixed"))
-            (is (btu/eventually-visible? {:css "h1" :fn/has-text "Example Domain"}))))
+            (is (btu/eventually-visible? {:tag :a :fn/has-text "https://example.org/en/mixed"}))))
 
         (btu/go (btu/get-server-url))
 

--- a/test/clj/rems/test_browser.clj
+++ b/test/clj/rems/test_browser.clj
@@ -3053,4 +3053,6 @@
           (testing "mixed missing content"
             (btu/go (str (btu/get-server-url) "extra-pages/mixed"))
             (is (btu/eventually-visible? {:css "h1" :fn/has-text "Sidan hittades inte"}))
-            (is (btu/eventually-visible? {:tag :p :fn/has-text "Denna sida hittades inte."}))))))))
+            (is (btu/eventually-visible? {:tag :p :fn/has-text "Denna sida hittades inte."})))))
+
+      (change-language :en))))

--- a/test/clj/rems/test_browser.clj
+++ b/test/clj/rems/test_browser.clj
@@ -2969,3 +2969,26 @@
                   "Bilaga (SV)" "E2E license with attachments (SV)"
                   "Aktiv" true}
                  (slurp-fields :license))))))))
+
+(deftest test-extra-pages
+  (btu/with-postmortem
+    (testing "without login"
+      (btu/go (btu/get-server-url))
+      (testing "extra page in menu"
+        (is (btu/eventually-visible? [:big-navbar {:tag :a :fn/has-text "About"}]))
+        (btu/scroll-and-click [:big-navbar {:tag :a :fn/has-text "About"}])
+        (is (btu/eventually-visible? {:css "h1" :fn/has-text "About"}))
+        (is (btu/eventually-visible? {:css ".document" :fn/has-text "This is a dummy About page for REMS."})))
+
+      (testing "extra page in footer"
+        (is (btu/eventually-visible? [{:css ".footer"} {:tag :a :fn/has-text "Footer"}]))
+        (btu/scroll-and-click [{:css ".footer"} {:tag :a :fn/has-text "Footer"}])
+        (is (btu/eventually-visible? {:css "h1" :fn/has-text "Footer"}))
+        (is (btu/eventually-visible? {:css ".document" :fn/has-text "This is a dummy footer page for REMS."})))
+
+      (testing "extra page in link"
+        (is (not (btu/visible? [:big-navbar {:tag :a :fn/has-text "Link"}])))
+        (is (not (btu/visible? [{:css ".footer"} {:tag :a :fn/has-text "Link"}])))
+        (btu/go (str (btu/get-server-url) "extra-pages/link"))
+        (is (btu/eventually-visible? {:css "h1" :fn/has-text "Link"}))
+        (is (btu/eventually-visible? {:css ".document" :fn/has-text "This is a dummy extra page for REMS that can only be shown with a direct link."}))))))

--- a/test/clj/rems/test_browser.clj
+++ b/test/clj/rems/test_browser.clj
@@ -2991,4 +2991,14 @@
         (is (not (btu/visible? [{:css ".footer"} {:tag :a :fn/has-text "Link"}])))
         (btu/go (str (btu/get-server-url) "extra-pages/link"))
         (is (btu/eventually-visible? {:css "h1" :fn/has-text "Link"}))
-        (is (btu/eventually-visible? {:css ".document" :fn/has-text "This is a dummy extra page for REMS that can only be shown with a direct link."}))))))
+        (is (btu/eventually-visible? {:css ".document" :fn/has-text "This is a dummy extra page for REMS that can only be shown with a direct link."}))))
+
+    (testing "localizations"
+      ;; NB: testing only one other language as the mechanism is the same for all types
+      (btu/go (btu/get-server-url))
+      (change-language :fi)
+      (testing "fi"
+        (is (btu/eventually-visible? [:big-navbar {:tag :a :fn/has-text "Info"}]))
+        (btu/scroll-and-click [:big-navbar {:tag :a :fn/has-text "Info"}])
+        (is (btu/eventually-visible? {:css "h1" :fn/has-text "Info"}))
+        (is (btu/eventually-visible? {:css ".document" :fn/has-text "Tämä on REMSin info-sivun tynkä."}))))))

--- a/test/clj/rems/test_browser.clj
+++ b/test/clj/rems/test_browser.clj
@@ -3055,4 +3055,6 @@
             (is (btu/eventually-visible? {:css "h1" :fn/has-text "Sidan hittades inte"}))
             (is (btu/eventually-visible? {:tag :p :fn/has-text "Denna sida hittades inte."})))))
 
-      (change-language :en))))
+      (change-language :en)
+      (user-settings/delete-user-settings! "alice")
+      (user-settings/delete-user-settings! "elsa")))) ; clear language settings


### PR DESCRIPTION
Closes #2983, #2589, #3069

  - Extra pages can be shown in top menu, footer, both or not at all with `:show-menu` and `:show-footer`
  - You can decide if you want the standard heading or not with `:heading`.
  - If localization of the file or link is not required, you can define the attributes at top level.
  - Who can see which extras can be tuned with `:roles` such as `:logged-in`, `:applicant` or `:handler`.
  - Details are in `config-defaults.edn`.

![extra-pages](https://user-images.githubusercontent.com/823661/196388513-e27d312b-04cb-485c-8226-78100afd1543.png)

# Checklist for author

Remove items that aren't applicable, check items that are done.

## Reviewability
- [x] Link to issue
- [x] Consider adding screenshots for ease of review

## Backwards compatibility
- [x] API is backwards compatible or completely new (slightly changed as some things are now optional and more optionals added)
- [x] Config is backwards compatible

## Documentation
- [x] Update changelog if necessary
- [x] New config options in config-defaults.edn

## Testing
- [x] Valuable features are integration / browser / acceptance tested automatically
