### PR TITLE
Fix bug where DUO MOR-code restriction could crash application fetching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ Changes since v2.30
 - The application Actions block is now successfully hidden, if there are no actions available (#2836)
 - The component guide page had accumulated some small errors that are now fixed. (#2836)
 - The component guide links to component source code works again. (#3080)
+- Saving application no longer crashes when a resource requires DUO:0000024 (MOR) code. This could occur when applicant had not entered a value for the date restriction field. (#3086)
 
 ## v2.30 "Kellosaarenranta" 2022-10-13
 

--- a/src/clj/rems/ext/duo.clj
+++ b/src/clj/rems/ext/duo.clj
@@ -223,9 +223,11 @@
        ;;  results of studies until a specific date."
       "DUO:0000024" (let [required-dt (map-restrictions dataset-code :date)
                           dt (map-restrictions query-code :date)]
-                      (if (or (time/equal? dt required-dt)
-                              (not (time/before? dt required-dt)))
-                        :duo/compatible :duo/not-compatible))
+                      (if (nil? dt)
+                        :duo/not-compatible ; when autosaving, nil is initially expected
+                        (if (or (time/equal? dt required-dt)
+                                (not (time/before? dt required-dt)))
+                          :duo/compatible :duo/not-compatible)))
 
       (if (seq (:restrictions dataset-code))
         :duo/needs-manual-validation

--- a/test/clj/rems/api/test_applications.clj
+++ b/test/clj/rems/api/test_applications.clj
@@ -2158,7 +2158,8 @@
       ;; - MONDO:0005105 - melanoma
       ;;   - MONDO:0006486 - uveal melanoma
       (let [res1 (test-helpers/create-resource! {:resource-ext-id ext1
-                                                 :resource/duo {:duo/codes [{:id "DUO:0000024" :restrictions [{:type :date :values [{:value "2022-02-16"}]}]}]}})
+                                                 :resource/duo {:duo/codes [{:id "DUO:0000016"}
+                                                                            {:id "DUO:0000024" :restrictions [{:type :date :values [{:value "2022-02-16"}]}]}]}})
             res2 (test-helpers/create-resource! {:resource-ext-id ext2
                                                  :resource/duo {:duo/codes [{:id "DUO:0000027" :restrictions [{:type :project :values [{:value "csc rems"}]}]}
                                                                             {:id "DUO:0000007" :restrictions [{:type :mondo :values [{:id "MONDO:0005105"}]}]}]}})
@@ -2171,10 +2172,16 @@
                                {:type :application.command/save-draft
                                 :application-id app-id
                                 :field-values []
-                                :duo-codes [{:id "DUO:0000027" :restrictions [{:type :project :values [{:value "project id"}]}]}
+                                :duo-codes [{:id "DUO:0000024" :restrictions []}
+                                            {:id "DUO:0000027" :restrictions [{:type :project :values [{:value "project id"}]}]}
                                             {:id "DUO:0000007" :restrictions [{:type :mondo :values [{:id "MONDO:0045024"
                                                                                                       :label "cancer or benign tumor"}]}]}]})))
-          (is (= {:duo/codes [{:id "DUO:0000027"
+          (is (= {:duo/codes [{:id "DUO:0000024"
+                               :restrictions []
+                               :description {:en "This data use modifier indicates that requestor agrees not to publish results of studies until a specific date."}
+                               :label {:en "publication moratorium"}
+                               :shorthand "MOR"}
+                              {:id "DUO:0000027"
                                :restrictions [{:type "project" :values [{:value "project id"}]}]
                                :description {:en "This data use modifier indicates that use is limited to use within an approved project."}
                                :label {:en "project specific restriction"}
@@ -2186,10 +2193,15 @@
                                :label {:en "disease specific research"}
                                :shorthand "DS"}]
                   :duo/matches [{:resource/id res1
+                                 :duo/id "DUO:0000016"
+                                 :duo/label {:en "genetic studies only"}
+                                 :duo/shorthand "GSO"
+                                 :duo/validation {:errors [] :validity "duo/not-found"}}
+                                {:resource/id res1
                                  :duo/id "DUO:0000024"
                                  :duo/label {:en "publication moratorium"}
                                  :duo/shorthand "MOR"
-                                 :duo/validation {:errors [] :validity "duo/not-found"}}
+                                 :duo/validation {:errors [] :validity "duo/not-compatible"}}
                                 {:resource/id res2
                                  :duo/id "DUO:0000027"
                                  :duo/label {:en "project specific restriction"}
@@ -2216,10 +2228,16 @@
                                {:type :application.command/save-draft
                                 :application-id app-id
                                 :field-values []
-                                :duo-codes [{:id "DUO:0000024" :restrictions [{:type :date :values [{:value "2022-02-16"}]}]}
+                                :duo-codes [{:id "DUO:0000016" :restrictions []}
+                                            {:id "DUO:0000024" :restrictions [{:type :date :values [{:value "2022-02-16"}]}]}
                                             {:id "DUO:0000027" :restrictions [{:type :project :values [{:value "project id"}]}]}
                                             {:id "DUO:0000007" :restrictions [{:type :mondo :values [{:id "MONDO:0006486"}]}]}]})))
-          (is (= {:duo/codes [{:id "DUO:0000024"
+          (is (= {:duo/codes [{:id "DUO:0000016"
+                               :restrictions []
+                               :description {:en "This data use modifier indicates that use is limited to genetic studies only (i.e., studies that include genotype research alone or both genotype and phenotype research, but not phenotype research exclusively)"}
+                               :label {:en "genetic studies only"}
+                               :shorthand "GSO"}
+                              {:id "DUO:0000024"
                                :restrictions [{:type "date" :values [{:value "2022-02-16"}]}]
                                :description {:en "This data use modifier indicates that requestor agrees not to publish results of studies until a specific date."}
                                :label {:en "publication moratorium"}
@@ -2236,6 +2254,11 @@
                                :label {:en "disease specific research"}
                                :shorthand "DS"}]
                   :duo/matches [{:resource/id res1
+                                 :duo/id "DUO:0000016"
+                                 :duo/label {:en "genetic studies only"}
+                                 :duo/shorthand "GSO"
+                                 :duo/validation {:errors [] :validity "duo/compatible"}}
+                                {:resource/id res1
                                  :duo/id "DUO:0000024"
                                  :duo/label {:en "publication moratorium"}
                                  :duo/shorthand "MOR"


### PR DESCRIPTION
fixes #3086

- DUO validation had bug where `clj-time.core` comparison functions would fail because `:date` restriction in query-code (applicant duo code) was missing data, leading to providing `nil` to the date comparison. Autosave could trigger this bug immediately, leading to the application page crashing upon selecting `MOR` DUO-code from the list. This is now fixed.

# Checklist for author

Remove items that aren't applicable, check items that are done.

## Reviewability
- [x] Link to issue

## Documentation
- [x] Update changelog if necessary

## Testing
- [x] Valuable features are integration / browser / acceptance tested automatically
