### PR TITLE
Rename rems.standalone namespace to rems.main

### DIFF
--- a/env/dev/clj/rems.clj
+++ b/env/dev/clj/rems.clj
@@ -2,7 +2,7 @@
   (:require [clojure.pprint :refer [pprint]]
             [clojure.tools.namespace.repl :as repl]
             [kaocha.repl]
-            [rems.standalone]
+            [rems.main]
             [rems.repl-utils]))
 
 (defn repl-help []
@@ -17,18 +17,18 @@
   (println "                 (kaocha 'rems.api.test-catalogue-items/change-form-test)"))
 
 (defn start-app []
-  (rems.standalone/start-app))
+  (rems.main/start-app))
 
 (defn stop-app []
-  (rems.standalone/stop-app))
+  (rems.main/stop-app))
 
 (defn reload []
-  (rems.standalone/stop-app)
-  (repl/refresh-all :after 'rems.standalone/start-app))
+  (rems.main/stop-app)
+  (repl/refresh-all :after 'rems.main/start-app))
 
 (defn refresh []
-  (rems.standalone/stop-app)
-  (repl/refresh :after 'rems.standalone/start-app))
+  (rems.main/stop-app)
+  (repl/refresh :after 'rems.main/start-app))
 
 (defn pptransit []
   (rems.repl-utils/pptransit))

--- a/project.clj
+++ b/project.clj
@@ -70,7 +70,7 @@
   :test-paths ["src/clj" "src/cljc" "test/clj" "test/cljc"] ; also run tests from src files
   :resource-paths ["resources" "target/shadow"]
   :target-path "target/%s/"
-  :main rems.standalone
+  :main rems.main
   :migratus {:store :database :db ~(get (System/getenv) "DATABASE_URL" "postgresql://localhost/rems?user=rems")}
 
   :plugins [[lein-cljfmt "0.6.7"]

--- a/src/clj/rems/main.clj
+++ b/src/clj/rems/main.clj
@@ -1,4 +1,4 @@
-(ns rems.standalone
+(ns rems.main
   "Run the REMS app in an embedded http server."
   (:require [clojure.string :as str]
             [clojure.tools.cli :refer [parse-opts]]

--- a/src/clj/rems/main.clj
+++ b/src/clj/rems/main.clj
@@ -1,5 +1,6 @@
 (ns rems.main
-  "Run the REMS app in an embedded http server."
+  "Run REMS CLI functions including the embedded HTTP server. Available CLI functions
+   are described in more detail by rems.main/-main docstring."
   (:require [clojure.string :as str]
             [clojure.tools.cli :refer [parse-opts]]
             [clojure.tools.logging :as log]

--- a/test/clj/rems/api/testing.clj
+++ b/test/clj/rems/api/testing.clj
@@ -9,7 +9,7 @@
             [rems.handler :refer :all]
             [rems.locales]
             [rems.middleware]
-            [rems.standalone]
+            [rems.main]
             [ring.mock.request :refer :all]
             [rems.json :as json]))
 

--- a/test/clj/rems/browser_test_util.clj
+++ b/test/clj/rems/browser_test_util.clj
@@ -17,7 +17,7 @@
             [rems.db.test-data-users :as test-users]
             [rems.db.test-data :as test-data]
             [rems.json :as json]
-            [rems.standalone]
+            [rems.main]
             [rems.util :refer [ensure-empty-directory!]]
             [slingshot.slingshot :refer [try+]])
   (:import [java.net SocketException]))

--- a/test/clj/rems/test_browser.clj
+++ b/test/clj/rems/test_browser.clj
@@ -27,7 +27,7 @@
             [rems.db.test-data-helpers :as test-helpers]
             [rems.db.users :as users]
             [rems.db.user-settings :as user-settings]
-            [rems.standalone]
+            [rems.main]
             [rems.testing-util :refer [with-user with-fake-login-users]]
             [rems.text :as text]))
 


### PR DESCRIPTION
relates #3017 

- rename `rems.standalone` to `rems.main`
- update `rems.main` docstring to mention CLI commands

# Checklist for author

Remove items that aren't applicable, check items that are done.

## Reviewability
- [x] Link to issue