### PR TITLE
Rename rems.db.test-data namespace to rems.service.test-data

### DIFF
--- a/src/clj/rems/main.clj
+++ b/src/clj/rems/main.clj
@@ -18,7 +18,7 @@
             [rems.db.core :as db]
             [rems.db.fix-userid]
             [rems.db.roles :as roles]
-            [rems.db.test-data :as test-data]
+            [rems.service.test-data :as test-data]
             [rems.db.users :as users]
             [rems.handler :as handler]
             [rems.json :as json]

--- a/src/clj/rems/service/test_data.clj
+++ b/src/clj/rems/service/test_data.clj
@@ -1,4 +1,4 @@
-(ns rems.db.test-data
+(ns rems.service.test-data
   "Populating the database with nice test data."
   (:require [clj-time.core :as time]
             [clojure.string :as str]

--- a/src/clj/rems/service/test_data.clj
+++ b/src/clj/rems/service/test_data.clj
@@ -1,5 +1,7 @@
 (ns rems.service.test-data
-  "Populating the database with nice test data."
+  "Generate and populate database with usable test data. Contains multiple high-level
+   test data helper functions. Separate functions are provided to generate complete
+   test and demo data, which create the same data, but with different users."
   (:require [clj-time.core :as time]
             [clojure.string :as str]
             [clojure.test :refer :all]

--- a/test/clj/rems/api/test_applications.clj
+++ b/test/clj/rems/api/test_applications.clj
@@ -11,7 +11,7 @@
             [rems.db.attachments]
             [rems.db.blacklist :as blacklist]
             [rems.db.core :as db]
-            [rems.db.test-data :as test-data]
+            [rems.service.test-data :as test-data]
             [rems.db.test-data-helpers :as test-helpers]
             [rems.handler :refer [handler]]
             [rems.json]

--- a/test/clj/rems/api/test_catalogue.clj
+++ b/test/clj/rems/api/test_catalogue.clj
@@ -3,7 +3,7 @@
             [rems.service.catalogue :as catalogue]
             [rems.api.testing :refer :all]
             [rems.db.category :as category]
-            [rems.db.test-data :as test-data]
+            [rems.service.test-data :as test-data]
             [rems.db.test-data-helpers :as test-helpers]
             [rems.handler :refer [handler]]
             [rems.testing-util :refer [with-user]]

--- a/test/clj/rems/api/test_email.clj
+++ b/test/clj/rems/api/test_email.clj
@@ -4,7 +4,7 @@
             [rems.api.testing :refer :all]
             [rems.db.outbox :as outbox]
             [rems.db.test-data-helpers :as test-helpers]
-            [rems.db.test-data :as test-data]
+            [rems.service.test-data :as test-data]
             [rems.handler :refer [handler]]
             [ring.mock.request :refer :all]))
 

--- a/test/clj/rems/api/test_extra_pages.clj
+++ b/test/clj/rems/api/test_extra_pages.clj
@@ -1,6 +1,6 @@
 (ns ^:integration rems.api.test-extra-pages
   (:require [clojure.test :refer :all]
-            [rems.db.test-data :as test-data]
+            [rems.service.test-data :as test-data]
             [rems.api.testing :refer :all]
             [rems.handler :refer [handler]]
             [ring.mock.request :refer :all]))

--- a/test/clj/rems/api/test_invitations.clj
+++ b/test/clj/rems/api/test_invitations.clj
@@ -3,7 +3,7 @@
             [rems.service.invitation :as invitation]
             [rems.api.testing :refer :all]
             [rems.db.applications]
-            [rems.db.test-data :as test-data]
+            [rems.service.test-data :as test-data]
             [rems.db.test-data-helpers :as test-helpers]
             [rems.json]
             [rems.testing-util :refer [with-user]]

--- a/test/clj/rems/api/test_permissions.clj
+++ b/test/clj/rems/api/test_permissions.clj
@@ -4,7 +4,7 @@
             [buddy.core.keys :as buddy-keys]
             [clojure.test :refer :all]
             [rems.api.testing :refer :all]
-            [rems.db.test-data :as test-data]
+            [rems.service.test-data :as test-data]
             [rems.db.test-data-helpers :as test-helpers]
             [rems.config]
             [rems.ga4gh :as ga4gh]

--- a/test/clj/rems/api/test_user_settings.clj
+++ b/test/clj/rems/api/test_user_settings.clj
@@ -3,7 +3,7 @@
             [clojure.test :refer :all]
             [clj-time.core :as time-core]
             [rems.api.testing :refer :all]
-            [rems.db.test-data :as test-data]
+            [rems.service.test-data :as test-data]
             [rems.db.test-data-helpers :as test-helpers]
             [rems.db.user-secrets :as user-secrets]
             [rems.db.user-settings :as user-settings]

--- a/test/clj/rems/api/test_users.clj
+++ b/test/clj/rems/api/test_users.clj
@@ -3,7 +3,7 @@
             [rems.api.testing :refer :all]
             [rems.testing-util :refer [with-fake-login-users]]
             [rems.db.roles :as roles]
-            [rems.db.test-data :as test-data]
+            [rems.service.test-data :as test-data]
             [rems.db.testing :refer [owners-fixture +test-api-key+]]
             [rems.db.users :as users]
             [rems.db.user-mappings :as user-mappings]

--- a/test/clj/rems/application/test_process_managers.clj
+++ b/test/clj/rems/application/test_process_managers.clj
@@ -5,7 +5,7 @@
             [rems.api.testing :refer :all]
             [rems.db.attachments :as attachments]
             [rems.db.applications :as applications]
-            [rems.db.test-data :as test-data]
+            [rems.service.test-data :as test-data]
             [rems.db.test-data-helpers :as test-helpers]
             [rems.handler :refer [handler]]
             [ring.mock.request :refer :all]))

--- a/test/clj/rems/application/test_search.clj
+++ b/test/clj/rems/application/test_search.clj
@@ -2,7 +2,7 @@
   (:require [clojure.test :refer :all]
             [rems.application.search :as search]
             [rems.db.applications :as applications]
-            [rems.db.test-data :as test-data]
+            [rems.service.test-data :as test-data]
             [rems.db.test-data-helpers :as test-helpers]
             [rems.db.testing :refer [rollback-db-fixture search-index-fixture test-db-fixture]]))
 

--- a/test/clj/rems/browser_test_util.clj
+++ b/test/clj/rems/browser_test_util.clj
@@ -15,7 +15,7 @@
             [rems.db.api-key :as api-key]
             [rems.db.test-data-helpers :as test-helpers]
             [rems.db.test-data-users :as test-users]
-            [rems.db.test-data :as test-data]
+            [rems.service.test-data :as test-data]
             [rems.json :as json]
             [rems.main]
             [rems.util :refer [ensure-empty-directory!]]
@@ -171,7 +171,7 @@
   (test-helpers/create-user! (get test-users/+fake-user-data+ "developer"))
   (test-helpers/create-workflow! nil) ;;master workflow
   ;; Forms, workflows etc.
-  ;; These should match the rems.db.test-data closely enough
+  ;; These should match the rems.service.test-data closely enough
   ;; so that one can use also development mode and dev db
   ;; with the tests
   (let [link (test-helpers/create-license! {:actor "owner"

--- a/test/clj/rems/db/testing.clj
+++ b/test/clj/rems/db/testing.clj
@@ -11,7 +11,7 @@
             [rems.db.catalogue :as catalogue]
             [rems.db.category :as category]
             [rems.db.core :as db]
-            [rems.db.test-data :as test-data]
+            [rems.service.test-data :as test-data]
             [rems.db.user-mappings :as user-mappings]
             [rems.locales])
   (:import [org.joda.time Duration ReadableInstant]))

--- a/test/clj/rems/test_db.clj
+++ b/test/clj/rems/test_db.clj
@@ -8,7 +8,7 @@
             [rems.db.core :as db]
             [rems.db.entitlements :as entitlements]
             [rems.db.roles :as roles]
-            [rems.db.test-data :as test-data]
+            [rems.service.test-data :as test-data]
             [rems.db.test-data-helpers :as test-helpers]
             [rems.db.testing :refer [test-db-fixture rollback-db-fixture]]
             [rems.testing-tempura :refer [fake-tempura-fixture]])

--- a/test/clj/rems/test_event_notification.clj
+++ b/test/clj/rems/test_event_notification.clj
@@ -6,7 +6,7 @@
             [rems.service.command :as command]
             [rems.api.testing :refer [api-fixture api-call]]
             [rems.db.events]
-            [rems.db.test-data :as test-data]
+            [rems.service.test-data :as test-data]
             [rems.db.test-data-helpers :as test-helpers]
             [rems.event-notification :as event-notification]
             [rems.json :as json]

--- a/test/clj/rems/test_layers.clj
+++ b/test/clj/rems/test_layers.clj
@@ -26,6 +26,11 @@
            (str/starts-with? s "rems.service.")
            (str/starts-with? s "rems.api"))))
 
+;; use for future namespace renaming needs
+(defn rename-ns [s]
+  (-> s
+      #_(str/replace "rems.db.test-data" "rems.service.test-data")))
+
 (defn ok-transition? [from to]
   (case [(:layer from) (:layer to)]
     [:api :service] true
@@ -44,6 +49,7 @@
                         :namespace-definitions
                         (mapv (comp str :name))
                         ;;(concat ["rems.cli"]) ; consider implementing `rems.cli` ns
+                        #_(mapv rename-ns)
                         (filter interesting-ns?)
                         (mapv #(merge {:name %}
                                       (cond (str/starts-with? % "rems.ext.") {:layer :ext}
@@ -57,6 +63,7 @@
                               :namespace-usages
                               (map (juxt (comp str :from) (comp str :to)))
                               distinct
+                              #_(map (fn [[from to]] [(rename-ns from) (rename-ns to)]))
                               (filterv (fn [[from to]]
                                          (and (interesting-ns? from)
                                               (interesting-ns? to))))

--- a/test/clj/rems/test_layers.clj
+++ b/test/clj/rems/test_layers.clj
@@ -26,11 +26,6 @@
            (str/starts-with? s "rems.service.")
            (str/starts-with? s "rems.api"))))
 
-(defn rename-ns [s]
-  ;; TODO implement these namespace renames
-  (-> s
-      (str/replace "rems.db.test-data" "rems.service.test-data")))
-
 (defn ok-transition? [from to]
   (case [(:layer from) (:layer to)]
     [:api :service] true
@@ -49,7 +44,6 @@
                         :namespace-definitions
                         (mapv (comp str :name))
                         ;;(concat ["rems.cli"]) ; consider implementing `rems.cli` ns
-                        (mapv rename-ns)
                         (filter interesting-ns?)
                         (mapv #(merge {:name %}
                                       (cond (str/starts-with? % "rems.ext.") {:layer :ext}
@@ -63,7 +57,6 @@
                               :namespace-usages
                               (map (juxt (comp str :from) (comp str :to)))
                               distinct
-                              (map (fn [[from to]] [(rename-ns from) (rename-ns to)]))
                               (filterv (fn [[from to]]
                                          (and (interesting-ns? from)
                                               (interesting-ns? to))))

--- a/test/clj/rems/test_pdf.clj
+++ b/test/clj/rems/test_pdf.clj
@@ -3,7 +3,7 @@
             [clojure.test :refer :all]
             [rems.db.applications :as applications]
             [rems.db.core :as db]
-            [rems.db.test-data :as test-data]
+            [rems.service.test-data :as test-data]
             [rems.db.test-data-helpers :as test-helpers]
             [rems.db.testing :refer [test-db-fixture rollback-db-fixture]]
             [rems.pdf :as pdf]


### PR DESCRIPTION
relates #3017

- rename `rems.db.test-data` ns to `rems.service.test-data` and update references from other namespaces
- update `rems.service.test-data` ns docstring

# Checklist for author

Remove items that aren't applicable, check items that are done.

## Reviewability
- [x] Link to issue
