### PR TITLE
Format info-field values, e.g. for user attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ have notable changes.
 Changes since v2.31
 
 - User attributes can now be retrieved from ID token and user_info endpoint. (#3028)
+- User attributes are now formatted better (a boolean becomes a checkbox, etc.) (#3103)
 
 ## v2.31 "Harmajankatu" 2022-11-29
 

--- a/src/cljs/rems/administration/organization.cljs
+++ b/src/cljs/rems/administration/organization.cljs
@@ -77,10 +77,12 @@
                        [inline-info-field (str (text :t.administration/title)
                                                " (" (str/upper-case (name langcode)) ")")
                         localization]))
-              [inline-info-field (text :t.administration/owners) (->> (:organization/owners organization)
-                                                                      (map enrich-user)
-                                                                      (map :display)
-                                                                      (interpose [:br]))]
+              [inline-info-field
+               (text :t.administration/owners)
+               (->> (:organization/owners organization)
+                    (map enrich-user)
+                    (map :display))
+               {:multiline? true}]
               [review-emails-field (:organization/review-emails organization)]
               [inline-info-field (text :t.administration/active) [readonly-checkbox {:value (status-flags/active? organization)}]]]}]
    (let [id (:organization/id organization)

--- a/src/cljs/rems/atoms.cljs
+++ b/src/cljs/rems/atoms.cljs
@@ -224,6 +224,7 @@
        (component-info failure-symbol)
        (example "failure symbol"
                 [failure-symbol])
+
        (component-info flash-message)
        (example "flash-message with info"
                 [flash-message {:status :info
@@ -232,6 +233,7 @@
        (example "flash-message with error"
                 [flash-message {:status :danger
                                 :content "You fail"}])
+
        (component-info readonly-checkbox)
        (example "readonly-checkbox unchecked"
                 [readonly-checkbox {:value false}])
@@ -241,13 +243,23 @@
                 [checkbox {:value @state :on-change on-change}])
        (example "checkbox with id and class"
                 [checkbox {:id :special :class :text-danger :value @state :on-change on-change}])
+
        (component-info info-field)
-       (example "info-field with data"
-                [info-field "Name" "Bob Tester"])
+       (example "info-field with text"
+                [info-field "Users" "Bob Tester"])
+       (example "info-field with array"
+                [info-field "Users" ["Bob Tester" "Jane Coder"]])
+       (example "info-field with boolean"
+                [info-field "Users" false])
+       (example "info-field with map"
+                [info-field "Users" {"Bob Tester" false "Jane Coder" true}])
+       (example "info-field with nested data is unsupported but shows somehow"
+                [info-field "Users" [{"Bob Tester" false "Jane Coder" {:type :coder :missing nil}}]])
        (example "info-field without box around value"
-                [info-field "Name" "Bob Tester" {:box? false}])
+                [info-field "Users" "Bob Tester" {:box? false}])
        (example "info-field inline"
-                [info-field "Name" "Bob Tester" {:inline? true}])
+                [info-field "Users" ["Bob Tester" "Jane Coder"] {:inline? true}])
+
        (component-info attachment-link)
        (example "attachment-link"
                 [attachment-link {:attachment/id 1
@@ -255,6 +267,7 @@
        (example "attachment-link, long filename"
                 [attachment-link {:attachment/id 123
                                   :attachment/filename "this_is_the_very_very_very_long_filename_of_a_test_file_the_file_itself_is_quite_short_though_abcdefghijklmnopqrstuvwxyz0123456789_overflow_overflow_overflow.txt"}])
+
        (component-info expander)
        (example "expander"
                 [expander {:id "guide-expander-id"

--- a/src/cljs/rems/atoms.cljs
+++ b/src/cljs/rems/atoms.cljs
@@ -103,7 +103,7 @@
   "Formats field `value` for display.
 
   A simple and crude version until something better is needed."
-  [value]
+  [value multiline?]
   (cond (string? value)
         value
 
@@ -115,8 +115,8 @@
 
         (map? value)
         (->> value
-             (mapv (fn [[k v]] [(format-field-values k) ": " (format-field-values v)])) ; first level
-             (interpose ", ")
+             (mapv (fn [[k v]] [(format-field-values k multiline?) ": " (format-field-values v multiline?)])) ; first level
+             (interpose (if multiline? "\n" ", "))
              (mapcat identity) ; flatten only first level, preserve any values as is
              (into [:<>]))
 
@@ -127,8 +127,8 @@
 
         (sequential? value)
         (->> value
-             (mapv format-field-values)
-             (interpose ", ")
+             (mapv #(format-field-values % multiline?))
+             (interpose (if multiline? "\n" ", "))
              (into [:<>]))
 
         :else (str value)))
@@ -145,8 +145,8 @@
   Additional options:
   `:inline?` - puts the label and value on the same row
   `:box?`    - wrap the value into a field value box (default true)"
-  [title value & [{:keys [inline? box?] :or {box? true} :as _opts}]]
-  (let [formatted-value (format-field-values value)
+  [title value & [{:keys [inline? box? multiline?] :or {box? true} :as _opts}]]
+  (let [formatted-value (format-field-values value multiline?)
         style (cond box? {:class "form-control"}
                     :else {:style {:padding-left 0}})]
     (if inline?
@@ -285,6 +285,8 @@
                 [info-field "Users" "Bob Tester"])
        (example "info-field with array"
                 [info-field "Users" ["Bob Tester" "Jane Coder"]])
+       (example "info-field with array, multline"
+                [info-field "Users" ["Bob Tester" "Jane Coder"] {:multiline? true}])
        (example "info-field with boolean"
                 [info-field "Users" false])
        (example "info-field with map"

--- a/src/cljs/rems/atoms.cljs
+++ b/src/cljs/rems/atoms.cljs
@@ -120,6 +120,11 @@
              (mapcat identity) ; flatten only first level, preserve any values as is
              (into [:<>]))
 
+        (and (vector? value)
+             (or (keyword? (first value))
+                 (fn? (first value))))
+        value ; hiccup
+
         (sequential? value)
         (->> value
              (mapv format-field-values)

--- a/src/cljs/rems/atoms.cljs
+++ b/src/cljs/rems/atoms.cljs
@@ -111,7 +111,7 @@
         (name value)
 
         (boolean? value)
-        [readonly-checkbox {:checked value}]
+        [readonly-checkbox {:value value}]
 
         (map? value)
         (->> value

--- a/src/cljs/rems/atoms.cljs
+++ b/src/cljs/rems/atoms.cljs
@@ -109,6 +109,7 @@
   `:box?`    - wrap the value into a field value box (default true)"
   [title value & [{:keys [inline? box?] :or {box? true} :as _opts}]]
   (let [values (if (list? value) value (list value))
+        formatted-values (mapv str values)
         style (cond box? {:class "form-control"}
                     :else {:style {:padding-left 0}})]
     (if inline?
@@ -116,10 +117,10 @@
        [:div.form-group.row
         [:label.col-sm-3.col-form-label title]
         (into [:div.col-sm-9 style]
-              values)]]
+              formatted-values)]]
       [:div.form-group
        [:label title]
-       (into [:div style] values)])))
+       (into [:div style] formatted-values)])))
 
 (defn download-button [{:keys [disabled? title url]}]
   [:a (cond-> {:class [:attachment-link :btn :btn-outline-secondary :mr-2 :text-truncate]

--- a/src/cljs/rems/user.cljs
+++ b/src/cljs/rems/user.cljs
@@ -28,6 +28,7 @@
         other-attributes (dissoc attributes :name :userid :email :organizations :notification-email :researcher-status-by)
         extra-attributes (index-by [:attribute] (:oidc-extra-attributes @(rf/subscribe [:rems.config/config])))]
     (into [:div.user-attributes
+           ;; basic, important attributes
            (when-let [user-id (:userid attributes)]
              [info-field (text :t.applicant-info/username) user-id {:inline? true}])
            (when-let [mail (:notification-email attributes)]
@@ -40,10 +41,12 @@
              [info-field (text :t.applicant-info/organization) (str/join ", " (map organization-name-if-known organizations)) {:inline? true}])
            (when (#{"so" "system"} (:researcher-status-by attributes))
              [info-field (text :t.applicant-info/researcher-status) [readonly-checkbox {:value true}] {:inline? true}])]
+
+          ;; other attributes
           (for [[k v] other-attributes]
             (let [title (or (localized (get-in extra-attributes [(name k) :name]))
                             k)]
-              [info-field title (str v) {:inline? true}])))))
+              [info-field title v {:inline? true}])))))
 
 (defn guide []
   [:div


### PR DESCRIPTION
Close #3103 

![format_info_field](https://user-images.githubusercontent.com/823661/212261493-071da595-20b9-4b4d-b840-05513d04ac52.png)

Something similar may need to be done for PDF?

# Checklist for author

Remove items that aren't applicable, check items that are done.

## Reviewability
- [x] Link to issue
- [x] Consider adding screenshots for ease of review

## Backwards compatibility
- [ ] Feature appears correctly in PDF print

## Documentation
- [x] Update changelog if necessary
- [x] Components are added to guide page

## Testing
- [ ] Complex logic is unit tested
- [ ] Valuable features are integration / browser / acceptance tested automatically
