### PR TITLE
Disable email

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,9 @@ Changes since v2.31
 ### Additions
 - User attributes can now be retrieved from ID token and user_info endpoint. (#3028)
 - User attributes are now formatted better (a boolean becomes a checkbox, etc.) (#3103)
-- All handler, reviewer, decider emails can be disabled with `:enable-handler-emails false`. This does not include the invitation emails, which will always be sent. (#3116)
+- Most handler, reviewer, decider emails can be disabled with `:enable-handler-emails false`. (#3116)
+  This does not include the invitation emails, which will always be sent, to be able to invite users.
+  This also does not include any reminder emails that you can separately enable if you wish.
 - Any individual email can be disabled by setting its translation to empty string `""` (#3117).
 
 ### Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ Changes since v2.31
 ### Additions
 - User attributes can now be retrieved from ID token and user_info endpoint. (#3028)
 - User attributes are now formatted better (a boolean becomes a checkbox, etc.) (#3103)
+- All handler, reviewer, decider emails can be disabled with `:enable-handler-emails false`. This does not include the invitation emails, which will always be sent. (#3116)
+- Any individual email can be disabled by setting its translation to empty string `""` (#3117).
 
 ### Fixes
 - Autosaving does not cause the focus to jump anymore (#3112)

--- a/resources/config-defaults.edn
+++ b/resources/config-defaults.edn
@@ -425,4 +425,5 @@
 
  :show-resources-section true ; should resources section be shown in the application UI
  :show-attachment-zip-action true ; should the attachment download be shown in the application actions UI
- :show-pdf-action true} ; should PDF button be shown in the application actions UI
+ :show-pdf-action true ; should PDF button be shown in the application actions UI
+ :enable-handler-emails true} ; should notification emails be sent to the handlers, reviewers, deciders for application actions (invitation emails will be sent regardless)

--- a/resources/config-defaults.edn
+++ b/resources/config-defaults.edn
@@ -426,4 +426,4 @@
  :show-resources-section true ; should resources section be shown in the application UI
  :show-attachment-zip-action true ; should the attachment download be shown in the application actions UI
  :show-pdf-action true ; should PDF button be shown in the application actions UI
- :enable-handler-emails true} ; should notification emails be sent to the handlers, reviewers, deciders for application actions (invitation emails will be sent regardless)
+ :enable-handler-emails true} ; should notification emails be sent to the handlers, reviewers, deciders for application actions (invitation emails will be sent regardless, reminders are also sent if configured)

--- a/src/clj/rems/email/core.clj
+++ b/src/clj/rems/email/core.clj
@@ -108,7 +108,7 @@
                      ;; postal turns extra keys into headers
                      "Auto-Submitted" "auto-generated")
         to-error (validate-address (:to email))]
-    (when (:to email)
+    (when (and (:body email) (:to email))
       (log/info "sending email:" (pr-str email))
       (cond
         to-error

--- a/src/clj/rems/email/template.clj
+++ b/src/clj/rems/email/template.clj
@@ -35,7 +35,8 @@
        (str/join ", ")))
 
 (defn- handlers [application]
-  (get-in application [:application/workflow :workflow.dynamic/handlers]))
+  (when (:enable-handler-emails env)
+    (get-in application [:application/workflow :workflow.dynamic/handlers])))
 
 (defn- other-handlers [event application]
   (filter #(not= (:userid %) (:event/actor event)) (handlers application)))

--- a/src/clj/rems/email/template.clj
+++ b/src/clj/rems/email/template.clj
@@ -5,7 +5,7 @@
             [rems.config :refer [env]]
             [rems.context :as context]
             [rems.db.user-settings :as user-settings]
-            [rems.text :refer [localize-utc-date text text-format with-language]]
+            [rems.text :refer [localize-utc-date text text-no-fallback text-format with-language]]
             [rems.util :as util]))
 
 ;;; Mapping events to emails
@@ -48,27 +48,30 @@
 
 (defn- emails-to-recipients [recipients event application subject-text body-text]
   (vec
-   (for [recipient recipients]
-     (with-language (:language (user-settings/get-user-settings (:userid recipient)))
-       (fn []
-         {:to-user (:userid recipient)
-          :subject (text-format subject-text
-                                (application-util/get-member-name recipient)
-                                (application-util/get-member-name (:event/actor-attributes event))
-                                (format-application-for-email application)
-                                (application-util/get-applicant-name application)
-                                (resources-for-email application)
-                                (link-to-application (:application/id event)))
-          :body (str
-                 (text-format body-text
-                              (application-util/get-member-name recipient)
-                              (application-util/get-member-name (:event/actor-attributes event))
-                              (format-application-for-email application)
-                              (application-util/get-applicant-name application)
-                              (resources-for-email application)
-                              (link-to-application (:application/id event)))
-                 (text :t.email/regards)
-                 (text :t.email/footer))})))))
+   (for [recipient recipients
+         :let [email (with-language (:language (user-settings/get-user-settings (:userid recipient)))
+                       (fn []
+                         (when (and body-text (not (str/blank? (text-no-fallback body-text))))
+                           {:to-user (:userid recipient)
+                            :subject (text-format subject-text
+                                                  (application-util/get-member-name recipient)
+                                                  (application-util/get-member-name (:event/actor-attributes event))
+                                                  (format-application-for-email application)
+                                                  (application-util/get-applicant-name application)
+                                                  (resources-for-email application)
+                                                  (link-to-application (:application/id event)))
+                            :body (str
+                                   (text-format body-text
+                                                (application-util/get-member-name recipient)
+                                                (application-util/get-member-name (:event/actor-attributes event))
+                                                (format-application-for-email application)
+                                                (application-util/get-applicant-name application)
+                                                (resources-for-email application)
+                                                (link-to-application (:application/id event)))
+                                   (text :t.email/regards)
+                                   (text :t.email/footer))})))]
+         :when email]
+     email)))
 
 (defmethod event-to-emails :application.event/approved [event application]
   (concat (emails-to-recipients (application-util/applicant-and-members application)

--- a/src/cljc/rems/text.cljc
+++ b/src/cljc/rems/text.cljc
@@ -36,21 +36,27 @@
                  [k :t/missing (failsafe-fallback k args)]
                  (vec args)))))
 
-(defn text
+(defn text-no-fallback
   "Return the tempura translation for a given key. Additional fallback
-  keys can be given."
+  keys can be given but there is no default fallback text."
   [& ks]
-  #?(:clj (context/*tempura* (conj (vec ks) (text-format :t/missing (vec ks))))
+  #?(:clj (context/*tempura* (vec ks))
      :cljs (let [translations (rf/subscribe [:translations])
                  language (rf/subscribe [:language])]
              (try
                (tr {:dict @translations}
                    [@language]
-                   (conj (vec ks) (text-format :t/missing (vec ks))))
+                   (vec ks))
                (catch js/Object e
                  ;; fail gracefully if the re-frame state is incomplete
                  (.error js/console e)
                  (str (vec ks)))))))
+
+(defn text
+  "Return the tempura translation for a given key. Additional fallback
+  keys can be given."
+  [& ks]
+  (apply text-no-fallback (conj (vec ks) (text-format :t/missing (vec ks)))))
 
 (defn localized [m]
   (let [lang #?(:clj context/*lang*

--- a/src/cljc/rems/text.cljc
+++ b/src/cljc/rems/text.cljc
@@ -56,7 +56,19 @@
   "Return the tempura translation for a given key. Additional fallback
   keys can be given."
   [& ks]
-  (apply text-no-fallback (conj (vec ks) (text-format :t/missing (vec ks)))))
+  #?(:clj (apply text-no-fallback (conj (vec ks) (text-format :t/missing (vec ks))))
+     ;; NB: we can't call the text-no-fallback here as in CLJS
+     ;; we can both call this as function or use as a React component
+     :cljs (let [translations (rf/subscribe [:translations])
+                 language (rf/subscribe [:language])]
+             (try
+               (tr {:dict @translations}
+                   [@language]
+                   (conj (vec ks) (text-format :t/missing (vec ks))))
+               (catch js/Object e
+                 ;; fail gracefully if the re-frame state is incomplete
+                 (.error js/console e)
+                 (str (vec ks)))))))
 
 (defn localized [m]
   (let [lang #?(:clj context/*lang*

--- a/test/clj/rems/email/test_core.clj
+++ b/test/clj/rems/email/test_core.clj
@@ -23,6 +23,11 @@
                   rems.db.users/get-user (constantly {:email "user@example.com"})
                   rems.db.user-settings/get-user-settings (constantly {})]
 
+      (testing "don't send if there is no body (mail toggled off)"
+        (is (nil? (send-email! {:to "foo@example.com" :subject "ding" :body nil})))
+        (is (= nil @message-atom))
+        (reset! message-atom nil))
+
       (testing "mail to email address"
         (is (nil? (send-email! {:to "foo@example.com" :subject "ding" :body "boing"})))
         (is (= {:to "foo@example.com"

--- a/test/clj/rems/email/test_template.clj
+++ b/test/clj/rems/email/test_template.clj
@@ -514,4 +514,14 @@
       (is (= {:to-user "applicant"
               :subject "Your application 2001/3, \"Application title\" has been submitted"
               :body "Dear Alice Applicant,\n\nYour application 2001/3, \"Application title\" has been submitted. You will be notified by email when the application has been handled.\n\nYou can view the application at http://example.com/application/7"}
+             (email-to "applicant" mails)))))
+
+  (with-redefs [rems.config/env (assoc rems.config/env :enable-handler-emails false)]
+    (let [mails (emails created-events submit-event)]
+      (is (= #{"applicant"} (email-recipients mails))
+          "applicant gets the email but handler messages are not sent")
+      (is (= {:to-user "applicant"
+              :subject "Your application 2001/3, \"Application title\" has been submitted"
+              :body "Dear Alice Applicant,\n\nYour application 2001/3, \"Application title\" has been submitted. You will be notified by email when the application has been handled.\n\nYou can view the application at http://example.com/application/7"}
              (email-to "applicant" mails))))))
+

--- a/test/clj/rems/email/test_template.clj
+++ b/test/clj/rems/email/test_template.clj
@@ -4,10 +4,8 @@
             [rems.application.model :as model]
             [rems.config]
             [rems.db.user-settings :as user-settings]
-            [rems.db.workflow :as workflow]
             [rems.email.template :as template]
-            [rems.locales])
-  (:import (org.joda.time DateTime)))
+            [rems.locales]))
 
 (defn empty-footer [f]
   (with-redefs [rems.locales/translations (assoc-in rems.locales/translations [:en :t :email :footer] "")]
@@ -507,3 +505,13 @@
              :invitation/token "secret"
              :invitation/workflow {:workflow/id 5}}
             {:title "Template Workflow"})))))
+
+(deftest test-disabled-email
+  (with-redefs [rems.locales/translations (assoc-in rems.locales/translations [:en :t :email :application-submitted :message-to-handler] "")]
+    (let [mails (emails created-events submit-event)]
+      (is (= #{"applicant"} (email-recipients mails))
+          "applicant gets the email but handler messages are not sent")
+      (is (= {:to-user "applicant"
+              :subject "Your application 2001/3, \"Application title\" has been submitted"
+              :body "Dear Alice Applicant,\n\nYour application 2001/3, \"Application title\" has been submitted. You will be notified by email when the application has been handled.\n\nYou can view the application at http://example.com/application/7"}
+             (email-to "applicant" mails))))))


### PR DESCRIPTION
Close #3117 
Close #3116 

Adds two ways of disabling emails. One for handlers completely, one per email type.

# Checklist for author

Remove items that aren't applicable, check items that are done.

## Reviewability
- [x] Link to issue

## Backwards compatibility
- [x] Config is backwards compatible

## Documentation
- [x] Update changelog if necessary

## Testing
- [x] Complex logic is unit tested
- [x] Valuable features are integration / browser / acceptance tested automatically
