### PR TITLE
feat: show latest application event even when minimized

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Changes since v2.31
 ### Changes
 - Application editing performance is improved. (#3106)
 - Show form errors column only when some form has errors. (#3107)
+- Latest event is now shown in the minimized application state. (#3119)
 
 ### Additions
 - User attributes can now be retrieved from ID token and user_info endpoint. (#3028)

--- a/resources/translations/en.edn
+++ b/resources/translations/en.edn
@@ -182,6 +182,7 @@
                  ;; TODO: Once the terms have stabilized, convert db and the
                  ;;   code to match the term in UI.
                  :description "Title"
+                 :details "Details"
                  :duos {:validation {:missing-duo-codes "Data Use Ontology codes are specified in resources but missing from application:"}}
                  :empty "No applications."
                  ;; %1 - date

--- a/resources/translations/fi.edn
+++ b/resources/translations/fi.edn
@@ -176,6 +176,7 @@
                  :copied-to "kopioitu hakemukseksi"
                  :created "Luotu"
                  :description "Otsikko"
+                 :details "Tiedot"
                  :duos {:validation {:missing-duo-codes "DUO-koodit ovat määritetty resursseihin, mutta puuttuvat hakemuksesta:"}}
                  :empty "Ei hakemuksia."
                  :entitlement-end "Pääsyoikeudet loppuvat %1."

--- a/resources/translations/sv.edn
+++ b/resources/translations/sv.edn
@@ -176,6 +176,7 @@
                  :copied-to "Kopierat till ansökan"
                  :created "Skapad"
                  :description "Rubrik"
+                 :details "Detaljer"
                  :duos {:validation {:missing-duo-codes "DUO koder anges i resurser, men de saknas från ansökan:"}}
                  :empty "Inga ansökningar."
                  :entitlement-end "Upphörandedatum för rättigheterna: %1."

--- a/src/cljs/rems/application.cljs
+++ b/src/cljs/rems/application.cljs
@@ -813,6 +813,7 @@
 
 (defn- application-state-details [application config events]
   [:<>
+   [:h3.mt-3 (text :t.applications/details)]
    [info-field
     (text :t.applications/application)
     [:<>
@@ -836,7 +837,7 @@
     {:inline? true}]
    (when (seq events)
      (into [:<>
-            [:h3 (text :t.form/events)]]
+            [:h3.mt-3 (text :t.form/events)]]
            (render-events events)))])
 
 (defn- application-state [{:keys [application config highlight-event-ids userid]}]
@@ -855,6 +856,9 @@
                (when (is-handler? application userid)
                  (->> events-show-always
                       (application-state-details application config)))]
+      :collapse-hidden (when (and (not (is-handler? application userid))
+                                  (seq events))
+                         [:div.mt-3.mb-3 (render-events [(first events)])])
       :collapse (if (is-handler? application userid)
                   (when (seq events-collapse)
                     (into [:div]


### PR DESCRIPTION
Close #3119 

This was sort of broken when the application state was minimized. Any possible comment was hidden behind the "show more".

![latest-event4](https://user-images.githubusercontent.com/823661/219444077-93f88df0-edbe-4908-9450-5c3867504253.png)
![latest-event3](https://user-images.githubusercontent.com/823661/219444082-e6246a03-d3eb-41a2-9c9c-136fe97e21aa.png)
![latest-event2](https://user-images.githubusercontent.com/823661/219444083-477a1eb0-7a95-40dc-9c00-02f4cc64d208.png)
![latest-event1](https://user-images.githubusercontent.com/823661/219444088-8c4c54d7-adb8-4c7a-b5a4-b86a63301017.png)

# Checklist for author

Remove items that aren't applicable, check items that are done.

## Reviewability
- [x] Link to issue
- [x] Consider adding screenshots for ease of review

## Documentation
- [x] Update changelog if necessary
