### PR TITLE
Configurable connection pool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Changes since v2.31
   This does not include the invitation emails, which will always be sent, to be able to invite users.
   This also does not include any reminder emails that you can separately enable if you wish.
 - Any individual email can be disabled by setting its translation to empty string `""` (#3117).
+- Database connection pool can be configured, see `:hikaricp-extra-params` in `config-defaults.edn`.
 
 ### Fixes
 - Autosaving does not cause the focus to jump anymore (#3112)

--- a/resources/config-defaults.edn
+++ b/resources/config-defaults.edn
@@ -36,6 +36,11 @@
  ;; Value for PostgreSQL idle_in_transaction_session_timeout
  :database-idle-in-transaction-session-timeout "20s"
 
+ ;; Extra parameters to override database connection pool settings on startup.
+ ;; A useful debugging parameter could be :leak-detection-threshold for example.
+ ;; For all possible configuration options, see https://github.com/brettwooldridge/HikariCP
+ :hikaricp-extra-params {}
+
  ;; Path to a writable directory where to store the Lucene search index files.
  :search-index-path "search-index"
 

--- a/src/clj/rems/db/core.clj
+++ b/src/clj/rems/db/core.clj
@@ -17,12 +17,12 @@
 ;; See docs/architecture/010-transactions.md
 (defn- hikaricp-settings []
   ;; HikariConfig wants an actual String, no support for parameterized queries...
-  {:connection-init-sql
-   (str/join [(when (:database-lock-timeout env)
-                (str "SET lock_timeout TO '" (:database-lock-timeout env) "';"))
-              (when (:database-idle-in-transaction-session-timeout env)
-                (str "SET idle_in_transaction_session_timeout TO '" (:database-idle-in-transaction-session-timeout env) "';"))])})
-
+  (merge {:connection-init-sql
+          (str/join [(when (:database-lock-timeout env)
+                       (str "SET lock_timeout TO '" (:database-lock-timeout env) "';"))
+                     (when (:database-idle-in-transaction-session-timeout env)
+                       (str "SET idle_in_transaction_session_timeout TO '" (:database-idle-in-transaction-session-timeout env) "';"))])}
+         (:hikaricp-extra-params env)))
 
 (defstate ^:dynamic *db*
   :start (try (let [db (cond (:test (mount/args)) (conman/connect! (merge (hikaricp-settings)


### PR DESCRIPTION
Allow merging extra parameters into HikariCP, for example `:leak-detection-threshold` or `:maximum-pool-size`. All configuration options should be discoverable at the [project documentation page](https://github.com/brettwooldridge/HikariCP#gear-configuration-knobs-baby).

# Checklist for author

Remove items that aren't applicable, check items that are done.

## Backwards compatibility
- [x] Config is backwards compatible

## Documentation
- [x] Update changelog if necessary
- [x] New config options in config-defaults.edn (`:hikaricp-extra-parameters`)
