### PR TITLE
Don't always send application data to notification target

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ Changes since v2.31
 - Database connection pool can be configured, see `:hikaricp-extra-params` in `config-defaults.edn`.
 - The debug log level prints details of when the scheduled pollers run, e.g. email and event notification.
 - Search bar automatically trims the whitespace form the left side, which is useful for copied values.
+- The event notification can be configured to not send the application data with `:send-application? false`
 
 ### Fixes
 - Autosaving does not cause the focus to jump anymore (#3112)

--- a/docs/event-notification.md
+++ b/docs/event-notification.md
@@ -29,6 +29,7 @@ The body of the HTTP PUT request will be a JSON object that contains:
 - `"event/time"`: when the event occured
 - `"application/id"`: the id of the application
 - `"event/application"`: the entire application, with this event applied, in the same format as the `/api/applications/:id/raw` endpoint returns (see Swagger docs)
+  This can be left out with `:send-application? false` in the configuration.
 
 Other keys may also be present depending on the event type.
 

--- a/resources/config-defaults.edn
+++ b/resources/config-defaults.edn
@@ -157,6 +157,7 @@
  ;;   :event-types (optional) - an array of event types to send. A missing value means "send everything".
  ;;   :timeout (optional) - timeout for the PUT in seconds. Defaults to 60s.
  ;;   :headers (optional) - a map of additional HTTP headers to send.
+ ;;   :send-application? (optional) - should application be sent in `:event/application` (defaults to true)
  ;;
  ;; See also: docs/event-notification.md
  ;;

--- a/resources/config-defaults.edn
+++ b/resources/config-defaults.edn
@@ -164,7 +164,11 @@
  ;; Example:
  ;;
  ;; :event-notification-targets [{:url "http://events/everything"}
- ;;                              {:url "http://events/filtered"
+ ;;
+ ;;                              {:url "http://events/just-the-event-is-lighter"
+ ;;                               :send-application? false}
+ ;;
+ ;;                              {:url "http://events/filtered-by-type"
  ;;                               :event-types [:application.event/created :application.event/submitted]
  ;;                               :timeout 120
  ;;                               :headers {"Authorization" "abc123"

--- a/src/clj/rems/event_notification.clj
+++ b/src/clj/rems/event_notification.clj
@@ -19,6 +19,9 @@
             "to" (:url target))
   (try
     (let [timeout-ms (* 1000 (get target :timeout default-timeout))
+          body (if (:send-application? target true)
+                 body
+                 (dissoc body :event/application))
           response (http/put (getx target :url)
                              {:body (json/generate-string body)
                               :throw-exceptions false


### PR DESCRIPTION
Sometimes the application can be big, and the event notification target doesn't need it. With `:send-application? false` one can disable the sending.

On top of #3139.

# Checklist for author

Remove items that aren't applicable, check items that are done.

## Reviewability
- [ ] Link to issue

## Backwards compatibility
- [x] Config is backwards compatible

## Documentation
- [x] Update changelog if necessary
- [x] Update docs/ (if applicable)
- [x] New config options in config-defaults.edn

## Testing
- [x] Valuable features are integration / browser / acceptance tested automatically
