### PR TITLE
Fix more info

### DIFF
--- a/src/clj/rems/css/styles.clj
+++ b/src/clj/rems/css/styles.clj
@@ -49,8 +49,8 @@
    (stylesheet/at-media {:max-width (:xs bootstrap-media-breakpoints)}
                         [(s/descendant :.rems-table.cart :tr)
                          {:border-bottom :none}])
-   (stylesheet/at-media {:max-width (:md bootstrap-media-breakpoints)}
-                        [:div.commands.flex-nowrap {:flex-wrap "wrap !important"}]) ; wrap table commands
+   (stylesheet/at-media {:min-width (:md bootstrap-media-breakpoints)}
+                        [:td [:div.commands {:flex-wrap "nowrap"}]])
    (stylesheet/at-media {:max-width (:xl bootstrap-media-breakpoints)}
                         [:.lg-fs70pct {:font-size (u/percent 70)}])
    (stylesheet/at-media {:max-width (u/px 870)}
@@ -658,8 +658,8 @@
                    :gap (u/rem 0.5)
                    :align-items :center
                    :justify-content :flex-end}]
-   [:.page-catalogue [:div.commands {:flex-wrap :nowrap}]]
-   [:td [:div.commands {:justify-content :flex-start}]]
+   [:td [:div.commands {:justify-content :flex-start
+                        :flex-wrap :wrap}]]
    [:td.commands {:width "1rem"}] ; anything smaller than actual results
    [:th.organization {:white-space :normal
                       :min-width (u/rem 5.5)}]

--- a/src/clj/rems/css/styles.clj
+++ b/src/clj/rems/css/styles.clj
@@ -658,6 +658,7 @@
                    :gap (u/rem 0.5)
                    :align-items :center
                    :justify-content :flex-end}]
+   [:.page-catalogue [:div.commands {:flex-wrap :nowrap}]]
    [:td [:div.commands {:justify-content :flex-start}]]
    [:td.commands {:width "1rem"}] ; anything smaller than actual results
    [:th.organization {:white-space :normal

--- a/src/cljs/rems/administration/blacklist.cljs
+++ b/src/cljs/rems/administration/blacklist.cljs
@@ -205,7 +205,7 @@
       :added-by {:value (rems.common.application-util/get-member-name added-by)}
       :added-at {:value added-at :display-value (localize-time added-at)}
       :comment {:value comment}
-      :commands {:display-value [:div.commands.flex-nowrap [remove-button resource user]]}})))
+      :commands {:display-value [:div.commands [remove-button resource user]]}})))
 
 (rf/reg-event-db
  ::fetch-result

--- a/src/cljs/rems/administration/catalogue_items.cljs
+++ b/src/cljs/rems/administration/catalogue_items.cljs
@@ -151,7 +151,7 @@
            :active (let [checked? (status-flags/active? item)]
                      {:display-value [readonly-checkbox {:value checked?}]
                       :sort-value (if checked? 1 2)})
-           :commands {:display-value [:div.commands.flex-nowrap
+           :commands {:display-value [:div.commands
                                       [view-button (:id item)]
                                       [modify-item-dropdown item]]}})
         catalogue)))

--- a/src/cljs/rems/administration/categories.cljs
+++ b/src/cljs/rems/administration/categories.cljs
@@ -64,7 +64,7 @@
                                         (get-in category [:category/title language])]} ; secondary sort-key is the same in the catalogue
            :title {:value (get-in category [:category/title language])}
            :description {:value (get-in category [:category/description language])}
-           :commands {:display-value [:div.commands.flex-nowrap
+           :commands {:display-value [:div.commands
                                       [to-view-category (:category/id category)]
                                       [roles/show-when roles/+admin-write-roles+
                                        [to-edit-category (:category/id category)]]]}})

--- a/src/cljs/rems/administration/forms.cljs
+++ b/src/cljs/rems/administration/forms.cljs
@@ -113,7 +113,7 @@
                       :sort-value 2}
                      {:value nil
                       :sort-value 1})
-           :commands {:display-value [:div.commands.flex-nowrap
+           :commands {:display-value [:div.commands
                                       [to-view-form form]
                                       [modify-form-dropdown form]]}})
         forms)))

--- a/src/cljs/rems/administration/licenses.cljs
+++ b/src/cljs/rems/administration/licenses.cljs
@@ -91,7 +91,7 @@
            :active (let [checked? (status-flags/active? license)]
                      {:display-value [readonly-checkbox {:value checked?}]
                       :sort-value (if checked? 1 2)})
-           :commands {:display-value [:div.commands.flex-nowrap
+           :commands {:display-value [:div.commands
                                       [to-view-license (:id license)]
                                       [modify-license-dropdown license]]}})
         licenses)))

--- a/src/cljs/rems/administration/organizations.cljs
+++ b/src/cljs/rems/administration/organizations.cljs
@@ -105,7 +105,7 @@
       :active (let [checked? (status-flags/active? organization)]
                 {:display-value [readonly-checkbox {:value checked?}]
                  :sort-value (if checked? 1 2)})
-      :commands {:display-value [:div.commands.flex-nowrap
+      :commands {:display-value [:div.commands
                                  [to-view-organization (:organization/id organization)]
                                  [modify-organization-dropdown organization]]}})))
 

--- a/src/cljs/rems/administration/resources.cljs
+++ b/src/cljs/rems/administration/resources.cljs
@@ -89,7 +89,7 @@
            :active (let [checked? (status-flags/active? resource)]
                      {:display-value [readonly-checkbox {:value checked?}]
                       :sort-value (if checked? 1 2)})
-           :commands {:display-value [:div.commands.flex-nowrap
+           :commands {:display-value [:div.commands
                                       [to-view-resource (:id resource)]
                                       [modify-resource-dropdown resource]]}})
         resources)))

--- a/src/cljs/rems/administration/workflows.cljs
+++ b/src/cljs/rems/administration/workflows.cljs
@@ -91,7 +91,7 @@
            :active (let [checked? (status-flags/active? workflow)]
                      {:display-value [readonly-checkbox {:value checked?}]
                       :sort-value (if checked? 1 2)})
-           :commands {:display-value [:div.commands.flex-nowrap
+           :commands {:display-value [:div.commands
                                       [to-view-workflow (:id workflow)]
                                       [modify-workflow-dropdown workflow]]}})
         workflows)))

--- a/src/cljs/rems/catalogue.cljs
+++ b/src/cljs/rems/catalogue.cljs
@@ -77,7 +77,7 @@
      (map (fn [item]
             {:key (:id item)
              :name {:value (get-localized-title item language)}
-             :commands {:display-value [:div.commands.justify-content-end.gap-1
+             :commands {:display-value [:div.commands.flex-nowrap.justify-content-end.gap-1
                                         [catalogue-item-more-info item language config]
                                         (when logged-in?
                                           (if (:enable-cart config)
@@ -140,7 +140,7 @@
                               :col-span #(if (:category/id %) 2 1)}
                              {:key :commands
                               :content #(when-not (:category/id %)
-                                          [:div.commands.justify-content-end.gap-1
+                                          [:div.commands.flex-nowrap.justify-content-end.gap-1
                                            [catalogue-item-more-info % language config]
                                            (when logged-in?
                                              (if (:enable-cart config)

--- a/src/cljs/rems/catalogue.cljs
+++ b/src/cljs/rems/catalogue.cljs
@@ -77,7 +77,7 @@
      (map (fn [item]
             {:key (:id item)
              :name {:value (get-localized-title item language)}
-             :commands {:display-value [:div.commands.flex-nowrap.justify-content-end.gap-1
+             :commands {:display-value [:div.commands.flex-nowrap.justify-content-end
                                         [catalogue-item-more-info item language config]
                                         (when logged-in?
                                           (if (:enable-cart config)
@@ -140,7 +140,7 @@
                               :col-span #(if (:category/id %) 2 1)}
                              {:key :commands
                               :content #(when-not (:category/id %)
-                                          [:div.commands.flex-nowrap.justify-content-end.gap-1
+                                          [:div.commands.flex-nowrap.justify-content-end
                                            [catalogue-item-more-info % language config]
                                            (when logged-in?
                                              (if (:enable-cart config)


### PR DESCRIPTION
Fix the regression in wrapping of the catalogue more info -links.

## The more info -link is still on the same row

![fix-more-info1](https://user-images.githubusercontent.com/823661/231124714-577ed000-3b15-46ae-8849-889d3737caf3.png)

## Admin tables work, wrap on small screen

![fix-more-info3](https://user-images.githubusercontent.com/823661/231124704-c049d6d9-6a64-4b50-b6b8-b44e7bbdfab9.png)
![fix-more-info2](https://user-images.githubusercontent.com/823661/231124708-7547281e-442e-41d5-845c-61a82f07069b.png)


# Checklist for author

Remove items that aren't applicable, check items that are done.

## Reviewability
- [x] Consider adding screenshots for ease of review

## Documentation
- [ ] Update changelog if necessary (not necessary, not released)
