### PR TITLE
Fix overflowing attachments

### DIFF
--- a/src/clj/rems/auth/fake_login.clj
+++ b/src/clj/rems/auth/fake_login.clj
@@ -52,7 +52,7 @@
 
 (defn- user-selection [username]
   (let [url (url (login-url) {:username username})]
-    [:div.user.m-3 {:onclick (str "window.location.href='" url "';")}
+    [:div.user.m-3
      [:a.btn.btn-primary.text-truncate {:href url :style "width: 12rem"}
       username]]))
 

--- a/src/clj/rems/css/styles.clj
+++ b/src/clj/rems/css/styles.clj
@@ -853,10 +853,10 @@
    (actions-float-menu)
    [(s/descendant :.document :h3) {:margin-top (u/rem 4)}]
 
-   [:.attachment-row {:display :flex
-                      :flex-direction :row
-                      :align-items :center
-                      :gap (u/rem 0.5)}]
+   [:.attachments {:display :flex
+                   :flex-flow "row wrap"
+                   :align-items :center
+                   :gap (u/rem 0.5)}]
 
    ;; print styling
    (stylesheet/at-media

--- a/src/cljs/rems/application.cljs
+++ b/src/cljs/rems/application.cljs
@@ -741,8 +741,8 @@
       (when comment
         [:div.form-control.event-comment comment])
       (when (seq attachments)
-        (into [:<>] (for [attachments-row (partition-all 3 attachments)]
-                      [fields/attachment-row attachments-row])))]]))
+        [:div.event-attachments.pt-2
+         [fields/render-attachments attachments]])]]))
 
 (rf/reg-sub
  ::enrich-event-by-id

--- a/src/cljs/rems/fields.cljs
+++ b/src/cljs/rems/fields.cljs
@@ -383,22 +383,22 @@
              (text :t.form/attachment-remove)]]))
    [upload-button (str "upload-" id) status on-attach]])
 
-(defn attachment-row [attachments]
-  (into [:div.attachment-row.py-2]
+(defn render-attachments [attachments]
+  (into [:div.attachments]
         (for [attachment attachments]
           [attachment-link attachment])))
 
 (defn attachment-field
   [{:keys [on-attach on-remove-attachment] :as opts}]
   [field-wrapper (assoc opts
-                        :readonly-component [attachment-row (:field/attachments opts)]
+                        :readonly-component [render-attachments (:field/attachments opts)]
                         :diff-component [:div {:style {:display :flex}}
                                          [:div
                                           (text :t.form/previous-value) ": "
-                                          [attachment-row (:field/previous-attachments opts)]]
+                                          [render-attachments (:field/previous-attachments opts)]]
                                          [:div
                                           (text :t.form/current-value) ": "
-                                          [attachment-row (:field/attachments opts)]]])
+                                          [render-attachments (:field/attachments opts)]]])
    [multi-attachment-view {:id (field-name opts)
                            :attachments (:field/attachments opts)
                            :on-attach on-attach


### PR DESCRIPTION
- Attachment row overflowed smaller screens because of uncontrolled flex. Row wrap was the intended effect.
- Fake login had duplicate URI handler, which resulted in weird log warnings from Jetty. No longer.

# Checklist for author

Remove items that aren't applicable, check items that are done.

## Reviewability
- [x] Consider adding screenshots for ease of review

## Documentation
- [ ] Update changelog if necessary (not applicable)

## Screenshots

### Big screen
![Screenshot 2023-04-19 at 16 03 49](https://user-images.githubusercontent.com/794087/233084266-9f487257-4f15-4d7e-b01e-240e26d4e195.png)

---

![Screenshot 2023-04-19 at 16 09 28](https://user-images.githubusercontent.com/794087/233084757-37eca375-57fd-46d4-b01d-c7f33c33ff4b.png)

### Small screen
![Screenshot 2023-04-19 at 16 03 24](https://user-images.githubusercontent.com/794087/233084272-36488058-d0fa-4f3a-b274-79e4b0dd32fc.png)

---

![Screenshot 2023-04-19 at 16 03 09](https://user-images.githubusercontent.com/794087/233084274-9fd44c28-98b2-49c1-8834-79b1bbc73256.png)
