### PR TITLE
fix: linkify label and header fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ have notable changes.
 
 Changes since v2.32
 
+### Fixes
+- Label and header fields have URLs made into links. (#3155)
+
 ## v2.32 "Itämerenkatu" 2023-04-26
 
 **NB: GET /entitlements.csv is deprecated and will be removed in a future release. Please use GET /api/entitlements/export-csv instead.**

--- a/src/clj/rems/service/test_data.clj
+++ b/src/clj/rems/service/test_data.clj
@@ -66,9 +66,9 @@
 (def label-field
   {:field/type :label
    :field/optional false
-   :field/title {:en "This form demonstrates all possible field types. (This text itself is a label field.)"
-                 :fi "Tämä lomake havainnollistaa kaikkia mahdollisia kenttätyyppejä. (Tämä teksti itsessään on lisätietokenttä.)"
-                 :sv "Detta blanket visar alla möjliga fälttyper. (Det här texten är en fält för tilläggsinformation.)"}})
+   :field/title {:en "This form demonstrates all possible field types. This is a link https://www.example.org/label (This text itself is a label field.)"
+                 :fi "Tämä lomake havainnollistaa kaikkia mahdollisia kenttätyyppejä. Tämä on linkki https://www.example.org/label (Tämä teksti itsessään on lisätietokenttä.)"
+                 :sv "Detta blanket visar alla möjliga fälttyper. Det här är en länk  https://www.example.org/label (Det här texten är en fält för tilläggsinformation.)"}})
 (def description-field
   {:field/type :description
    :field/optional false

--- a/src/cljs/rems/fields.cljs
+++ b/src/cljs/rems/fields.cljs
@@ -289,7 +289,7 @@
               (localized label)]))]))
 
 (defn label [opts]
-  (let [title (localized (:field/title opts))]
+  (let [title (-> opts :field/title localized linkify)]
     [non-field-wrapper opts [:label title]]))
 
 (defn multiselect-field [{:keys [validation on-change] :as opts}]
@@ -406,7 +406,7 @@
                            :status (:field/attachment-status opts)}]])
 
 (defn header-field [opts]
-  (let [title (localized (:field/title opts))]
+  (let [title (-> opts :field/title localized linkify)]
     [non-field-wrapper opts [:h3 title]]))
 
 (defn- table-view [{:keys [id readonly columns rows on-change]}]

--- a/test/clj/rems/test_pdf.clj
+++ b/test/clj/rems/test_pdf.clj
@@ -503,7 +503,7 @@
                  [:paragraph "Some text"]]]]
               [[[:heading pdf/heading-style "Form"]
                 [[[:paragraph pdf/field-heading-style
-                   "This form demonstrates all possible field types. (This text itself is a label field.)"]
+                   "This form demonstrates all possible field types. This is a link https://www.example.org/label (This text itself is a label field.)"]
                   [:paragraph ""]]
                  [[:paragraph pdf/field-heading-style "Application title field"]
                   [:paragraph "pdf test"]]


### PR DESCRIPTION
Close #3155 

Linkified both labels and headers for completeness.

![linkified-label](https://github.com/CSCfi/rems/assets/823661/bbc70794-67ae-497e-b316-250b2cea56a4)

# Checklist for author

Remove items that aren't applicable, check items that are done.

## Reviewability
- [x] Link to issue
- [x] Consider adding screenshots for ease of review

## Documentation
- [x] Update changelog if necessary
- [ ] Components are added to guide page

## Testing
- manual
- added URL to all field types example form data
