### PR TITLE
feat: pdf customization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ have notable changes.
 
 Changes since v2.32
 
+### Additions
+- PDF output can be customized a little. This enables changing the font, which should fix missing diacritics. (#3158)
+
 ### Fixes
 - Label and header fields have URLs made into links. (#3155)
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -156,6 +156,19 @@ Note! REMS sets a Cache-Control max-age of 23 hours for static resources (`:them
 
 Extra pages can be added to the navigation bar using `:extra-pages` configuration parameter. Each extra page can be either a link to an external url or it can show the content of a markdown file to the user. See `:extra-pages` in [config-defaults.edn](https://github.com/CSCfi/rems/blob/master/resources/config-defaults.edn) for examples of how to define the extra pages.
 
+## PDF customization
+
+Should you require to change the PDF output, there are styling options under the `:pdf-metadata` configuration key.
+
+By default a system font will be chosen (randomly), which many not be what you like, and which may not support all the characters you intend to use (diacritics etc.). You can customize the font like so:
+
+```clojure
+:pdf-metadata {:font {:encoding :unicode
+                      :ttf-name "/usr/share/fonts/truetype/ubuntu/Ubuntu-M.ttf"}}
+```
+
+A full list of options is described in [clj-pdf documentation](https://github.com/clj-pdf/clj-pdf#metadata).
+
 ## Logging
 
 REMS uses [Logback](https://logback.qos.ch/) for logging. By default everything is printed to standard output. If you wish to customize logging, create your own Logback configuration file and specify its location using the `logback.configurationFile` system property:

--- a/resources/config-defaults.edn
+++ b/resources/config-defaults.edn
@@ -436,4 +436,14 @@
  :show-resources-section true ; should resources section be shown in the application UI
  :show-attachment-zip-action true ; should the attachment download be shown in the application actions UI
  :show-pdf-action true ; should PDF button be shown in the application actions UI
- :enable-handler-emails true} ; should notification emails be sent to the handlers, reviewers, deciders for application actions (invitation emails will be sent regardless, reminders are also sent if configured)
+ :enable-handler-emails true ; should notification emails be sent to the handlers, reviewers, deciders for application actions (invitation emails will be sent regardless, reminders are also sent if configured)
+
+ ;; Optional metadata to be passed to the PDF generation.
+ ;;
+ ;; See https://github.com/clj-pdf/clj-pdf#metadata
+ ;;
+ ;; Example:
+ ;; :pdf-metadata {:font {:encoding :unicode
+ ;;                       :ttf-name "custom-font-file.ttf"}}
+ ;;
+ :pdf-metadata {}}

--- a/src/clj/rems/pdf.clj
+++ b/src/clj/rems/pdf.clj
@@ -214,7 +214,7 @@
                                            (str/join ", ")))))]))])])))
 
 (defn- render-application [application]
-  [{}
+  [(env :pdf-metadata)
    (render-header application)
    (render-applicants application)
    (when (:show-resources-section env)

--- a/src/clj/rems/service/test_data.clj
+++ b/src/clj/rems/service/test_data.clj
@@ -1058,7 +1058,7 @@
                                                :member (get users-data member)})
       (test-helpers/fill-form! {:application-id app-id
                                 :actor applicant
-                                :field-value "lots of attachments"
+                                :field-value "complicated application with lots of attachments and five special characters \"åöâīē\""
                                 :attachment (test-helpers/create-attachment! {:actor applicant
                                                                               :application-id app-id
                                                                               :filename "applicant_attachment.pdf"})})


### PR DESCRIPTION
Fix #3158.

Allows customization of the PDF output which fixes the bug of missing diacritics when a suitable font is chosen.

![diacritics](https://github.com/CSCfi/rems/assets/823661/c1a70db4-0948-46aa-bbe5-ba93abc96ad0)

# Checklist for author

Remove items that aren't applicable, check items that are done.

## Reviewability
- [x] Link to issue
- [x] Consider adding screenshots for ease of review

## Backwards compatibility
- [x] API is backwards compatible or completely new
- [x] Config is backwards compatible
- [x] Feature appears correctly in PDF print

## Documentation
- [x] Update changelog if necessary
- [x] Update docs/ (if applicable)
- [x] New config options in config-defaults.edn

## Testing
- Difficult to test PDF content automatically, did manual testing only.
