### PR TITLE
Extended logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Changes since v2.33
 - (Experimental) Workflow can be configured to enable voting for the approval. Currently all handlers can vote (including bots). Use `:enable-voting`. (#3174)
 - There is now a Danish language translation (#3176). We are considering supporting a limited set of languages officially, and improving support for community maintained translations (see #3179).
 - Added experimental support for named format parameters in translations. (#3183)
+- Added `extended-logging` configuration option, for additionally logging content of mutating operations. (#3184)
 
 ### Fixes
 - Email template parameters for `:application-expiration-notification` event are now documented. The parameters are different from standard event email parameters, which may have caused confusion.

--- a/dev-config.edn
+++ b/dev-config.edn
@@ -92,7 +92,7 @@
  :enable-catalogue-tree true
  :enable-save-compaction true
  :enable-autosave true
- :extended-logging true
+ :enable-extended-logging true
 
  ;; let's use plugins in dev
  :oidc-require-name false

--- a/dev-config.edn
+++ b/dev-config.edn
@@ -92,6 +92,17 @@
  :enable-catalogue-tree true
  :enable-save-compaction true
  :enable-autosave true
+ :extended-logging-routes ["/api/catalogue-items/create"
+                           "/api/catalogue-items/edit"
+                           "/api/categories/create"
+                           "/api/categories/edit"
+                           "/api/forms/create"
+                           "/api/forms/edit"
+                           "/api/users/create"
+                           "/api/users/edit"
+                           "/api/user-settings/edit"
+                           "/api/workflows/create"
+                           "/api/workflows/edit"]
 
  ;; let's use plugins in dev
  :oidc-require-name false

--- a/dev-config.edn
+++ b/dev-config.edn
@@ -92,17 +92,7 @@
  :enable-catalogue-tree true
  :enable-save-compaction true
  :enable-autosave true
- :extended-logging-routes ["/api/catalogue-items/create"
-                           "/api/catalogue-items/edit"
-                           "/api/categories/create"
-                           "/api/categories/edit"
-                           "/api/forms/create"
-                           "/api/forms/edit"
-                           "/api/users/create"
-                           "/api/users/edit"
-                           "/api/user-settings/edit"
-                           "/api/workflows/create"
-                           "/api/workflows/edit"]
+ :extended-logging true
 
  ;; let's use plugins in dev
  :oidc-require-name false

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -183,7 +183,7 @@ REMS uses [Logback](https://logback.qos.ch/) for logging. By default everything 
 
 ### Extended Logging
 
-The config option `:extended-logging` can be enabled to additionally log the content of entity mutations.
+The config option `:enable-extended-logging` can be toggled to additionally log the content of entity mutations.
 
 These logs enable auditors to unequivocally determine the state of a given entity at a given time. Which may aid with various regulatory requirements.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -183,29 +183,14 @@ REMS uses [Logback](https://logback.qos.ch/) for logging. By default everything 
 
 ### Extended Logging
 
-The config option `:extended-logging` is for routes that should additionally log the content of entity mutations.
-
-Logging is at `INFO` level and the log messages are prefixed with `extended-logging (:uri request)` e.g. `extended-logging /api/forms/edit`.
+The config option `:extended-logging` can be enabled to additionally log the content of entity mutations.
 
 These logs enable auditors to unequivocally determine the state of a given entity at a given time. Which may aid with various regulatory requirements.
 
-Logging occurs after request data has been coerced to a schema, but before the mutation is persisted.
-as such, the logged information is only authoritative about the state of the respective entity iff the request was successful.
+Logging is at `INFO` level and the log messages are prefixed with `extended-logging (:uri request)` e.g. `extended-logging /api/forms/edit`.
 
-Only routes that mutate an existing entity benefit from extended logging, the possible routes are as follows:
-```
- ["/api/catalogue-items/create"
-  "/api/catalogue-items/edit"
-  "/api/categories/create"
-  "/api/categories/edit"
-  "/api/forms/create"
-  "/api/forms/edit"
-  "/api/users/create"
-  "/api/users/edit"
-  "/api/user-settings/edit"
-  "/api/workflows/create"
-  "/api/workflows/edit"]
-```
+Logging occurs before the mutation is persisted. As such, the logged information is only authoritative about the state of the respective entity iff the request was successful.
+
 ## Application expiration scheduler
 
 REMS can be configured to delete applications after a set period of time has passed since last activity. Expiration can be defined for application states with ISO-8601 duration formatting, and optionally email notification can be configured to be sent to applicant and members before deletion. Application expiration scheduler is disabled by default. See `:application-expiration` in [config-defaults.edn](https://github.com/CSCfi/rems/blob/master/resources/config-defaults.edn) for details.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -181,6 +181,31 @@ REMS uses [Logback](https://logback.qos.ch/) for logging. By default everything 
 
     java -Dlogback.configurationFile=logback-prod.xml -jar rems.jar run
 
+### Extended Logging
+
+The config option `:extended-logging` is for routes that should additionally log the content of entity mutations.
+
+Logging is at `INFO` level and the log messages are prefixed with `extended-logging (:uri request)` e.g. `extended-logging /api/forms/edit`.
+
+These logs enable auditors to unequivocally determine the state of a given entity at a given time. Which may aid with various regulatory requirements.
+
+Logging occurs after request data has been coerced to a schema, but before the mutation is persisted.
+as such, the logged information is only authoritative about the state of the respective entity iff the request was successful.
+
+Only routes that mutate an existing entity benefit from extended logging, the possible routes are as follows:
+```
+ ["/api/catalogue-items/create"
+  "/api/catalogue-items/edit"
+  "/api/categories/create"
+  "/api/categories/edit"
+  "/api/forms/create"
+  "/api/forms/edit"
+  "/api/users/create"
+  "/api/users/edit"
+  "/api/user-settings/edit"
+  "/api/workflows/create"
+  "/api/workflows/edit"]
+```
 ## Application expiration scheduler
 
 REMS can be configured to delete applications after a set period of time has passed since last activity. Expiration can be defined for application states with ISO-8601 duration formatting, and optionally email notification can be configured to be sent to applicant and members before deletion. Application expiration scheduler is disabled by default. See `:application-expiration` in [config-defaults.edn](https://github.com/CSCfi/rems/blob/master/resources/config-defaults.edn) for details.

--- a/resources/config-defaults.edn
+++ b/resources/config-defaults.edn
@@ -432,20 +432,7 @@
 
  ;; Extended logging for routes that should additionally log content of entity mutation.
  ;; logging is at INFO level and the log message is prefixed with "extended-logging (:uri request)"
- ;;
- ;; only routes that mutate an existing entity can be logged, the possible routes are as follows:
- ;; ["/api/catalogue-items/create"
- ;;  "/api/catalogue-items/edit"
- ;;  "/api/categories/create"
- ;;  "/api/categories/edit"
- ;;  "/api/forms/create"
- ;;  "/api/forms/edit"
- ;;  "/api/users/create"
- ;;  "/api/users/edit"
- ;;  "/api/user-settings/edit"
- ;;  "/api/workflows/create"
- ;;  "/api/workflows/edit"]
- :extended-logging-routes []
+ :extended-logging-routes false
 
  ;; which columns in applications list(s) should be hidden in UI
  ;; allowed values: [:description :resource :applicant :handlers :state :todo :created :submitted :last-activity :view]

--- a/resources/config-defaults.edn
+++ b/resources/config-defaults.edn
@@ -432,10 +432,6 @@
 
  ;; Extended logging for routes that should additionally log content of entity mutation.
  ;; logging is at INFO level and the log message is prefixed with "extended-logging (:uri request)"
- ;; the logs enable auditors to unequivocally determine the state of a given entity at a given time. Which may aid with various regulatory requirements.
- ;;
- ;; logging occurs after request data has been coerced to a schema, but before the mutation is persisted.
- ;; as such, the logged information is only authoritative about the state of the respective entitiy iff the request was successful.
  ;;
  ;; only routes that mutate an existing entity can be logged, the possible routes are as follows:
  ;; ["/api/catalogue-items/create"

--- a/resources/config-defaults.edn
+++ b/resources/config-defaults.edn
@@ -432,7 +432,7 @@
 
  ;; Extended logging for routes that should additionally log content of entity mutation.
  ;; logging is at INFO level and the log message is prefixed with "extended-logging (:uri request)"
- :extended-logging-routes false
+ :enable-extended-logging false
 
  ;; which columns in applications list(s) should be hidden in UI
  ;; allowed values: [:description :resource :applicant :handlers :state :todo :created :submitted :last-activity :view]

--- a/resources/config-defaults.edn
+++ b/resources/config-defaults.edn
@@ -429,6 +429,28 @@
  :enable-cart true ; show shopping cart and allow bundling multiple resources into one application
  :enable-save-compaction false ; whether to merge consecutive saves into one event (EXPERIMENTAL)
  :enable-autosave false ; whether to automatically save the application as the applicant types (EXPERIMENTAL)
+
+ ;; Extended logging for routes that should additionally log content of entity mutation.
+ ;; logging is at INFO level and the log message is prefixed with "extended-logging (:uri request)"
+ ;; the logs enable auditors to unequivocally determine the state of a given entity at a given time. Which may aid with various regulatory requirements.
+ ;;
+ ;; logging occurs after request data has been coerced to a schema, but before the mutation is persisted.
+ ;; as such, the logged information is only authoritative about the state of the respective entitiy iff the request was successful.
+ ;;
+ ;; only routes that mutate an existing entity can be logged, the possible routes are as follows:
+ ;; ["/api/catalogue-items/create"
+ ;;  "/api/catalogue-items/edit"
+ ;;  "/api/categories/create"
+ ;;  "/api/categories/edit"
+ ;;  "/api/forms/create"
+ ;;  "/api/forms/edit"
+ ;;  "/api/users/create"
+ ;;  "/api/users/edit"
+ ;;  "/api/user-settings/edit"
+ ;;  "/api/workflows/create"
+ ;;  "/api/workflows/edit"]
+ :extended-logging-routes []
+
  ;; which columns in applications list(s) should be hidden in UI
  ;; allowed values: [:description :resource :applicant :handlers :state :todo :created :submitted :last-activity :view]
  :application-list-hidden-columns []

--- a/src/clj/rems/api/catalogue_items.clj
+++ b/src/clj/rems/api/catalogue_items.clj
@@ -107,7 +107,7 @@
       :roles +admin-write-roles+
       :body [command CreateCatalogueItemCommand]
       :return CreateCatalogueItemResponse
-      (extended-logging request command)
+      (extended-logging request)
       (ok (catalogue/create-catalogue-item! command)))
 
     (PUT "/edit" request
@@ -115,7 +115,7 @@
       :roles +admin-write-roles+
       :body [command EditCatalogueItemCommand]
       :return schema/SuccessResponse
-      (extended-logging request command)
+      (extended-logging request)
       (if (nil? (catalogue/get-localized-catalogue-item (:id command)))
         (not-found-json-response)
         (ok (catalogue/edit-catalogue-item! command))))

--- a/src/clj/rems/api/catalogue_items.clj
+++ b/src/clj/rems/api/catalogue_items.clj
@@ -3,7 +3,7 @@
             [compojure.api.sweet :refer :all]
             [rems.api.schema :as schema]
             [rems.service.catalogue :as catalogue]
-            [rems.api.util :refer [not-found-json-response check-user]] ; required for route :roles
+            [rems.api.util :refer [not-found-json-response check-user extended-logging]] ; required for route :roles
             [rems.common.roles :refer [+admin-write-roles+]]
             [rems.common.util :refer [apply-filters]]
             [rems.schema-base :as schema-base]
@@ -102,18 +102,20 @@
         (ok it)
         (not-found-json-response)))
 
-    (POST "/create" []
+    (POST "/create" request
       :summary "Create a new catalogue item"
       :roles +admin-write-roles+
       :body [command CreateCatalogueItemCommand]
       :return CreateCatalogueItemResponse
+      (extended-logging request command)
       (ok (catalogue/create-catalogue-item! command)))
 
-    (PUT "/edit" []
+    (PUT "/edit" request
       :summary "Edit a catalogue item"
       :roles +admin-write-roles+
       :body [command EditCatalogueItemCommand]
       :return schema/SuccessResponse
+      (extended-logging request command)
       (if (nil? (catalogue/get-localized-catalogue-item (:id command)))
         (not-found-json-response)
         (ok (catalogue/edit-catalogue-item! command))))

--- a/src/clj/rems/api/categories.clj
+++ b/src/clj/rems/api/categories.clj
@@ -3,7 +3,7 @@
             [rems.api.schema :as schema]
             [rems.schema-base :as schema-base]
             [rems.service.category :as category]
-            [rems.api.util :refer [not-found-json-response]]
+            [rems.api.util :refer [not-found-json-response extended-logging]]
             [rems.common.roles :refer [+admin-read-roles+ +admin-write-roles+]]
             [ring.util.http-response :refer :all]
             [schema.core :as s]))
@@ -33,18 +33,20 @@
         (ok category)
         (not-found-json-response)))
 
-    (POST "/create" []
+    (POST "/create" request
       :summary "Create category"
       :roles +admin-write-roles+
       :body [command schema/CreateCategoryCommand]
       :return CreateCategoryResponse
+      (extended-logging request command)
       (ok (category/create-category! command)))
 
-    (PUT "/edit" []
+    (PUT "/edit" request
       :summary "Update category"
       :roles +admin-write-roles+
       :body [command schema/UpdateCategoryCommand]
       :return schema/SuccessResponse
+      (extended-logging request command)
       (if (category/get-category (:category/id command))
         (ok (category/update-category! command))
         (not-found-json-response)))

--- a/src/clj/rems/api/categories.clj
+++ b/src/clj/rems/api/categories.clj
@@ -38,7 +38,7 @@
       :roles +admin-write-roles+
       :body [command schema/CreateCategoryCommand]
       :return CreateCategoryResponse
-      (extended-logging request command)
+      (extended-logging request)
       (ok (category/create-category! command)))
 
     (PUT "/edit" request
@@ -46,7 +46,7 @@
       :roles +admin-write-roles+
       :body [command schema/UpdateCategoryCommand]
       :return schema/SuccessResponse
-      (extended-logging request command)
+      (extended-logging request)
       (if (category/get-category (:category/id command))
         (ok (category/update-category! command))
         (not-found-json-response)))

--- a/src/clj/rems/api/forms.clj
+++ b/src/clj/rems/api/forms.clj
@@ -50,7 +50,7 @@
       :roles +admin-write-roles+
       :body [command CreateFormCommand]
       :return CreateFormResponse
-      (extended-logging request command)
+      (extended-logging request)
       (ok (form/create-form! command)))
 
     (GET "/:form-id" []
@@ -75,7 +75,7 @@
       :roles +admin-write-roles+
       :body [command EditFormCommand]
       :return schema/SuccessResponse
-      (extended-logging request command)
+      (extended-logging request)
       (ok (form/edit-form! command)))
 
     (PUT "/archived" []

--- a/src/clj/rems/api/forms.clj
+++ b/src/clj/rems/api/forms.clj
@@ -2,7 +2,7 @@
   (:require [compojure.api.sweet :refer :all]
             [rems.service.form :as form]
             [rems.api.schema :as schema]
-            [rems.api.util :refer [not-found-json-response]] ; required for route :roles
+            [rems.api.util :refer [not-found-json-response extended-logging]] ; required for route :roles
             [rems.common.roles :refer [+admin-read-roles+ +admin-write-roles+]]
             [ring.swagger.json-schema :as rjs]
             [rems.schema-base :as schema-base]
@@ -45,11 +45,12 @@
       (ok (get-form-templates (merge (when-not disabled {:enabled true})
                                      (when-not archived {:archived false})))))
 
-    (POST "/create" []
+    (POST "/create" request
       :summary "Create form"
       :roles +admin-write-roles+
       :body [command CreateFormCommand]
       :return CreateFormResponse
+      (extended-logging request command)
       (ok (form/create-form! command)))
 
     (GET "/:form-id" []
@@ -69,11 +70,12 @@
       :return schema/SuccessResponse
       (ok (form/form-editable form-id)))
 
-    (PUT "/edit" []
+    (PUT "/edit" request
       :summary "Edit form"
       :roles +admin-write-roles+
       :body [command EditFormCommand]
       :return schema/SuccessResponse
+      (extended-logging request command)
       (ok (form/edit-form! command)))
 
     (PUT "/archived" []

--- a/src/clj/rems/api/organizations.clj
+++ b/src/clj/rems/api/organizations.clj
@@ -1,7 +1,7 @@
 (ns rems.api.organizations
   (:require [compojure.api.sweet :refer :all]
             [rems.api.schema :as schema]
-            [rems.api.util :refer [not-found-json-response]] ; required for route :roles
+            [rems.api.util :refer [not-found-json-response extended-logging]] ; required for route :roles
             [rems.service.organizations :as organizations]
             [rems.schema-base :as schema-base]
             [rems.util :refer [getx-user-id]]
@@ -46,19 +46,21 @@
                                                   (when-not disabled {:enabled true})
                                                   (when-not archived {:archived false})))))
 
-    (POST "/create" []
+    (POST "/create" request
       :summary "Create organization"
       :roles #{:owner}
       :body [command CreateOrganizationCommand]
       :return CreateOrganizationResponse
+      (extended-logging request command)
       (ok (organizations/add-organization! command)))
 
-    (PUT "/edit" []
+    (PUT "/edit" request
       :summary "Edit organization. Organization owners cannot change the owners."
       ;; explicit roles seem clearer here instead of +admin-write-roles+
       :roles #{:owner :organization-owner}
       :body [command EditOrganizationCommand]
       :return EditOrganizationResponse
+      (extended-logging request command)
       (ok (organizations/edit-organization! command)))
 
     (PUT "/archived" []

--- a/src/clj/rems/api/organizations.clj
+++ b/src/clj/rems/api/organizations.clj
@@ -51,7 +51,7 @@
       :roles #{:owner}
       :body [command CreateOrganizationCommand]
       :return CreateOrganizationResponse
-      (extended-logging request command)
+      (extended-logging request)
       (ok (organizations/add-organization! command)))
 
     (PUT "/edit" request
@@ -60,7 +60,7 @@
       :roles #{:owner :organization-owner}
       :body [command EditOrganizationCommand]
       :return EditOrganizationResponse
-      (extended-logging request command)
+      (extended-logging request)
       (ok (organizations/edit-organization! command)))
 
     (PUT "/archived" []

--- a/src/clj/rems/api/user_settings.clj
+++ b/src/clj/rems/api/user_settings.clj
@@ -1,6 +1,7 @@
 (ns rems.api.user-settings
   (:require [compojure.api.sweet :refer :all]
             [rems.api.schema :as schema]
+            [rems.api.util :refer [extended-logging]]
             [rems.config :refer [env]]
             [rems.service.ega :as ega]
             [rems.service.user-settings :as user-settings]
@@ -32,11 +33,12 @@
       :return GetUserSettings
       (ok (user-settings/get-user-settings (get-user-id))))
 
-    (PUT "/edit" []
+    (PUT "/edit" request
       :summary "Update user settings"
       :roles #{:logged-in}
       :body [settings UpdateUserSettings]
       :return schema/SuccessResponse
+      (extended-logging request settings)
       (ok (user-settings/update-user-settings! (getx-user-id) settings)))
 
     (PUT "/" []

--- a/src/clj/rems/api/user_settings.clj
+++ b/src/clj/rems/api/user_settings.clj
@@ -38,7 +38,7 @@
       :roles #{:logged-in}
       :body [settings UpdateUserSettings]
       :return schema/SuccessResponse
-      (extended-logging request settings)
+      (extended-logging request)
       (ok (user-settings/update-user-settings! (getx-user-id) settings)))
 
     (PUT "/" []

--- a/src/clj/rems/api/users.clj
+++ b/src/clj/rems/api/users.clj
@@ -1,7 +1,7 @@
 (ns rems.api.users
   (:require [compojure.api.sweet :refer :all]
             [rems.api.schema :as schema]
-            [rems.api.util] ; required for route :roles
+            [rems.api.util :refer [extended-logging]] ; required for route :roles
             [rems.db.users :as users]
             [rems.middleware :as middleware]
             [rems.schema-base :as schema-base]
@@ -24,19 +24,21 @@
   (context "/users" []
     :tags ["users"]
 
-    (POST "/create" []
+    (POST "/create" request
       :summary "Create or update user"
       :roles #{:owner :user-owner}
       :body [command CreateUserCommand]
       :return schema/SuccessResponse
+      (extended-logging request command)
       (users/add-user! command)
       (ok {:success true}))
 
-    (PUT "/edit" []
+    (PUT "/edit" request
       :summary "Update user"
       :roles #{:owner :user-owner}
       :body [command EditUserCommand]
       :return schema/SuccessResponse
+      (extended-logging request command)
       (users/edit-user! command)
       (ok {:success true}))
 

--- a/src/clj/rems/api/users.clj
+++ b/src/clj/rems/api/users.clj
@@ -29,7 +29,7 @@
       :roles #{:owner :user-owner}
       :body [command CreateUserCommand]
       :return schema/SuccessResponse
-      (extended-logging request command)
+      (extended-logging request)
       (users/add-user! command)
       (ok {:success true}))
 
@@ -38,7 +38,7 @@
       :roles #{:owner :user-owner}
       :body [command EditUserCommand]
       :return schema/SuccessResponse
-      (extended-logging request command)
+      (extended-logging request)
       (users/edit-user! command)
       (ok {:success true}))
 

--- a/src/clj/rems/api/util.clj
+++ b/src/clj/rems/api/util.clj
@@ -52,6 +52,6 @@
     (-> (http-response/unprocessable-entity body)
         (http-response/content-type "application/json"))))
 
-(defn extended-logging [request mutation]
-  (-> (when (some (partial = (:uri request)) (:extended-logging-routes env))
-        (log/info "extended-logging" (:uri request) mutation))))
+(defn extended-logging [request]
+  (-> (when (:extended-logging env)
+        (log/info "extended-logging" (:uri request) (:params request)))))

--- a/src/clj/rems/api/util.clj
+++ b/src/clj/rems/api/util.clj
@@ -1,9 +1,11 @@
 (ns rems.api.util
   (:require [clojure.string :as str]
+            [clojure.tools.logging :as log]
             [compojure.api.meta :refer [restructure-param]]
             [ring.util.http-response :as http-response]
             [rems.auth.util :refer [throw-unauthorized throw-forbidden]]
             [rems.common.roles :refer [has-roles?]]
+            [rems.config :refer [env]]
             [rems.json :as json]
             [rems.util :refer [errorf get-user-id]]))
 
@@ -49,3 +51,7 @@
   (let [body (json/generate-string {:error (or message "unprocessable entity")})]
     (-> (http-response/unprocessable-entity body)
         (http-response/content-type "application/json"))))
+
+(defn extended-logging [request mutation]
+  (-> (when (some (partial = (:uri request)) (:extended-logging-routes env))
+        (log/info "extended-logging" (:uri request) mutation))))

--- a/src/clj/rems/api/util.clj
+++ b/src/clj/rems/api/util.clj
@@ -53,5 +53,5 @@
         (http-response/content-type "application/json"))))
 
 (defn extended-logging [request]
-  (-> (when (:extended-logging env)
+  (-> (when (:enable-extended-logging env)
         (log/info "extended-logging" (:uri request) (:params request)))))

--- a/src/clj/rems/api/workflows.clj
+++ b/src/clj/rems/api/workflows.clj
@@ -55,7 +55,7 @@
       :roles +admin-write-roles+
       :body [command CreateWorkflowCommand]
       :return CreateWorkflowResponse
-      (extended-logging request command)
+      (extended-logging request)
       (ok (workflow/create-workflow! command)))
 
     (PUT "/edit" request
@@ -63,7 +63,7 @@
       :roles +admin-write-roles+
       :body [command EditWorkflowCommand]
       :return schema/SuccessResponse
-      (extended-logging request command)
+      (extended-logging request)
       (ok (workflow/edit-workflow! command)))
 
     (PUT "/archived" []

--- a/src/clj/rems/api/workflows.clj
+++ b/src/clj/rems/api/workflows.clj
@@ -2,7 +2,7 @@
   (:require [compojure.api.sweet :refer :all]
             [rems.api.schema :as schema]
             [rems.service.workflow :as workflow]
-            [rems.api.util :refer [not-found-json-response]] ; required for route :roles
+            [rems.api.util :refer [not-found-json-response extended-logging]] ; required for route :roles
             [rems.application.events :as events]
             [rems.common.roles :refer [+admin-read-roles+ +admin-write-roles+]]
             [rems.schema-base :as schema-base]
@@ -50,18 +50,20 @@
       (ok (workflow/get-workflows (merge (when-not disabled {:enabled true})
                                          (when-not archived {:archived false})))))
 
-    (POST "/create" []
+    (POST "/create" request
       :summary "Create workflow"
       :roles +admin-write-roles+
       :body [command CreateWorkflowCommand]
       :return CreateWorkflowResponse
+      (extended-logging request command)
       (ok (workflow/create-workflow! command)))
 
-    (PUT "/edit" []
+    (PUT "/edit" request
       :summary "Edit workflow title and handlers"
       :roles +admin-write-roles+
       :body [command EditWorkflowCommand]
       :return schema/SuccessResponse
+      (extended-logging request command)
       (ok (workflow/edit-workflow! command)))
 
     (PUT "/archived" []


### PR DESCRIPTION
Implements #3184

Though I wish I'd found a more elegant solution, this does the job quite handily, while ensuring backwards compatibility. But a more experience clojure developer probably has a solution that circumvents the need for adding this to every relevant route.

I tried a general approach at the logging middleware, but I couldn't read request data, as it is a read-once bytestream on the HttpRequest. And since the result is not in the response, but loaded in a subsequent request, it cannot be pulled from that either.

I started looking into the Compojure wrappers, but my cursory look didn't yield a more elegant solution.

## Reviewability
- [x] Link to issue

## Backwards compatibility
- [x] API is backwards compatible or completely new
- [x] Config is backwards compatible

## Documentation
- [x] Update changelog if necessary
- [x] Update docs/ (if applicable)
- [x] New config options in config-defaults.edn
