### PR TITLE
Expirer bot improvement

### DIFF
--- a/src/clj/rems/application/eraser.clj
+++ b/src/clj/rems/application/eraser.clj
@@ -25,7 +25,8 @@
   :start (when (:application-expiration env)
            (scheduler/start! "expired-application-poller"
                              process-applications!
-                             (.toStandardDuration (time/days 1))))
+                             (.toStandardDuration (time/hours 1))
+                             (select-keys env [:buzy-hours])))
   :stop (when expired-application-poller
           (scheduler/stop! expired-application-poller)))
 


### PR DESCRIPTION
Make expirer bot refresh cache only in the end, and respect buzy hours. This will likely improve performance.

# Checklist for author

Remove items that aren't applicable, check items that are done.

## Documentation
- [ ] Update changelog if necessary

## Testing
- [ ] Complex logic is unit tested
- [ ] Valuable features are integration / browser / acceptance tested automatically

## Follow-up
- [ ] New tasks are created for pending or remaining tasks
