### PR TITLE
Limit repeated action clicking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Changes since v2.33
 - The tables take advantage of a new paging feature. Especially, the handler Actions page and its handled applications table uses paging and only fetches handled applications when so requested. The first 50 rows are only fetched by default. Paging can be also configured per table, if the default is not good (page size 50 rows). (#3191)
 - If reminder email is configured for the, expirer bot, it will delete an old draft application if and only if the reminder email is sent and the specified amount of time has passed. Previously it would just delete if the application was very old (esp. when enabling expiry for the first time).
 - Allow leaving `:form` field away from catalogue item creation API calls. Previously the value was optional but now the key too.
+- Application action buttons now wait until request has completed. This should prevent duplicate concurrent requests caused by repeated clicking. (#3204)
 
 ### Additions
 - (Experimental) Workflow can be configured to enable voting for the approval. Currently all handlers can vote (including bots). Use `:enable-voting`. (#3174)

--- a/src/cljs/rems/actions/accept_licenses.cljs
+++ b/src/cljs/rems/actions/accept_licenses.cljs
@@ -1,6 +1,6 @@
 (ns rems.actions.accept-licenses
   (:require [re-frame.core :as rf]
-            [rems.atoms :as atoms]
+            [rems.actions.components :refer [perform-action-button]]
             [rems.flash-message :as flash-message]
             [rems.text :refer [text]]
             [rems.util :refer [post!]]))
@@ -18,10 +18,9 @@
    {}))
 
 (defn accept-licenses-action-button [application-id licenses on-finished]
-  [atoms/rate-limited-button {:id "accept-licenses-button"
-                              :text (text :t.actions/accept-licenses)
-                              :class "btn-primary"
-                              :disabled @(rf/subscribe [:rems.spa/pending-request "/api/applications/accept-licenses"])
-                              :on-click #(rf/dispatch [::send-accept-licenses {:application-id application-id
-                                                                               :licenses licenses
-                                                                               :on-finished on-finished}])}])
+  [perform-action-button {:id "accept-licenses-button"
+                          :text (text :t.actions/accept-licenses)
+                          :class "btn-primary"
+                          :on-click #(rf/dispatch [::send-accept-licenses {:application-id application-id
+                                                                           :licenses licenses
+                                                                           :on-finished on-finished}])}])

--- a/src/cljs/rems/actions/accept_licenses.cljs
+++ b/src/cljs/rems/actions/accept_licenses.cljs
@@ -10,8 +10,7 @@
  (fn [_ [_ {:keys [application-id licenses on-finished]}]]
    (let [description [text :t.actions/accept-licenses]]
      (post! "/api/applications/accept-licenses"
-            {:rems/request-id ::request-id
-             :params {:application-id application-id
+            {:params {:application-id application-id
                       :accepted-licenses licenses}
              :handler (flash-message/default-success-handler
                        :accept-licenses description (fn [_] (on-finished)))
@@ -22,7 +21,7 @@
   [atoms/rate-limited-button {:id "accept-licenses-button"
                               :text (text :t.actions/accept-licenses)
                               :class "btn-primary"
-                              :disabled @(rf/subscribe [:rems.spa/pending-request ::request-id])
+                              :disabled @(rf/subscribe [:rems.spa/pending-request "/api/applications/accept-licenses"])
                               :on-click #(rf/dispatch [::send-accept-licenses {:application-id application-id
                                                                                :licenses licenses
                                                                                :on-finished on-finished}])}])

--- a/src/cljs/rems/actions/accept_licenses.cljs
+++ b/src/cljs/rems/actions/accept_licenses.cljs
@@ -1,6 +1,6 @@
 (ns rems.actions.accept-licenses
   (:require [re-frame.core :as rf]
-            [rems.actions.components :refer [button-wrapper]]
+            [rems.atoms :as atoms]
             [rems.flash-message :as flash-message]
             [rems.text :refer [text]]
             [rems.util :refer [post!]]))
@@ -10,7 +10,8 @@
  (fn [_ [_ {:keys [application-id licenses on-finished]}]]
    (let [description [text :t.actions/accept-licenses]]
      (post! "/api/applications/accept-licenses"
-            {:params {:application-id application-id
+            {:rems/request-id ::request-id
+             :params {:application-id application-id
                       :accepted-licenses licenses}
              :handler (flash-message/default-success-handler
                        :accept-licenses description (fn [_] (on-finished)))
@@ -18,9 +19,10 @@
    {}))
 
 (defn accept-licenses-action-button [application-id licenses on-finished]
-  [button-wrapper {:id "accept-licenses-button"
-                   :text (text :t.actions/accept-licenses)
-                   :class "btn-primary"
-                   :on-click #(rf/dispatch [::send-accept-licenses {:application-id application-id
-                                                                    :licenses licenses
-                                                                    :on-finished on-finished}])}])
+  [atoms/rate-limited-button {:id "accept-licenses-button"
+                              :text (text :t.actions/accept-licenses)
+                              :class "btn-primary"
+                              :disabled @(rf/subscribe [:rems.spa/pending-request ::request-id])
+                              :on-click #(rf/dispatch [::send-accept-licenses {:application-id application-id
+                                                                               :licenses licenses
+                                                                               :on-finished on-finished}])}])

--- a/src/cljs/rems/actions/add_licenses.cljs
+++ b/src/cljs/rems/actions/add_licenses.cljs
@@ -54,8 +54,7 @@
  (fn [_ [_ {:keys [application-id licenses comment on-finished]}]]
    (let [description [text :t.actions/add-licenses]]
      (post! "/api/applications/add-licenses"
-            {:rems/request-id ::request-id
-             :params {:application-id application-id
+            {:params {:application-id application-id
                       :comment comment
                       :licenses (map :id licenses)}
              :handler (flash-message/default-success-handler
@@ -79,7 +78,7 @@
    [[atoms/rate-limited-button {:id "add-licenses"
                                 :text (text :t.actions/add-licenses)
                                 :class "btn-primary"
-                                :disabled @(rf/subscribe [:rems.spa/pending-request ::request-id])
+                                :disabled @(rf/subscribe [:rems.spa/pending-request "/api/applications/add-licenses"])
                                 :on-click on-send}]]
    [:div
     [comment-field {:field-key action-form-id

--- a/src/cljs/rems/actions/add_licenses.cljs
+++ b/src/cljs/rems/actions/add_licenses.cljs
@@ -1,8 +1,7 @@
 (ns rems.actions.add-licenses
   (:require [clojure.string :as str]
             [re-frame.core :as rf]
-            [rems.actions.components :refer [action-button action-form-view comment-field collapse-action-form]]
-            [rems.atoms :as atoms]
+            [rems.actions.components :refer [action-button action-form-view comment-field collapse-action-form perform-action-button]]
             [rems.dropdown :as dropdown]
             [rems.flash-message :as flash-message]
             [rems.text :refer [text get-localized-title]]
@@ -75,11 +74,10 @@
   [{:keys [selected-licenses potential-licenses language on-set-licenses on-send]}]
   [action-form-view action-form-id
    (text :t.actions/add-licenses)
-   [[atoms/rate-limited-button {:id "add-licenses"
-                                :text (text :t.actions/add-licenses)
-                                :class "btn-primary"
-                                :disabled @(rf/subscribe [:rems.spa/pending-request "/api/applications/add-licenses"])
-                                :on-click on-send}]]
+   [[perform-action-button {:id "add-licenses"
+                            :text (text :t.actions/add-licenses)
+                            :class "btn-primary"
+                            :on-click on-send}]]
    [:div
     [comment-field {:field-key action-form-id
                     :label (text :t.form/add-comments-shown-to-applicant)}]

--- a/src/cljs/rems/actions/add_licenses.cljs
+++ b/src/cljs/rems/actions/add_licenses.cljs
@@ -1,7 +1,8 @@
 (ns rems.actions.add-licenses
   (:require [clojure.string :as str]
             [re-frame.core :as rf]
-            [rems.actions.components :refer [action-button action-form-view comment-field button-wrapper collapse-action-form]]
+            [rems.actions.components :refer [action-button action-form-view comment-field collapse-action-form]]
+            [rems.atoms :as atoms]
             [rems.dropdown :as dropdown]
             [rems.flash-message :as flash-message]
             [rems.text :refer [text get-localized-title]]
@@ -53,7 +54,8 @@
  (fn [_ [_ {:keys [application-id licenses comment on-finished]}]]
    (let [description [text :t.actions/add-licenses]]
      (post! "/api/applications/add-licenses"
-            {:params {:application-id application-id
+            {:rems/request-id ::request-id
+             :params {:application-id application-id
                       :comment comment
                       :licenses (map :id licenses)}
              :handler (flash-message/default-success-handler
@@ -74,10 +76,11 @@
   [{:keys [selected-licenses potential-licenses language on-set-licenses on-send]}]
   [action-form-view action-form-id
    (text :t.actions/add-licenses)
-   [[button-wrapper {:id "add-licenses"
-                     :text (text :t.actions/add-licenses)
-                     :class "btn-primary"
-                     :on-click on-send}]]
+   [[atoms/rate-limited-button {:id "add-licenses"
+                                :text (text :t.actions/add-licenses)
+                                :class "btn-primary"
+                                :disabled @(rf/subscribe [:rems.spa/pending-request ::request-id])
+                                :on-click on-send}]]
    [:div
     [comment-field {:field-key action-form-id
                     :label (text :t.form/add-comments-shown-to-applicant)}]

--- a/src/cljs/rems/actions/add_member.cljs
+++ b/src/cljs/rems/actions/add_member.cljs
@@ -1,13 +1,11 @@
 (ns rems.actions.add-member
   (:require [re-frame.core :as rf]
-            [rems.actions.components :refer [action-button action-form-view button-wrapper collapse-action-form]]
+            [rems.actions.components :refer [action-button action-form-view collapse-action-form]]
             [rems.atoms :as atoms]
             [rems.dropdown :as dropdown]
             [rems.flash-message :as flash-message]
             [rems.text :refer [text]]
             [rems.util :refer [fetch post!]]))
-
-
 
 (rf/reg-fx
  ::fetch-potential-members
@@ -43,7 +41,8 @@
  (fn [_ [_ {:keys [member application-id on-finished]}]]
    (let [description [text :t.actions/add-member]]
      (post! "/api/applications/add-member"
-            {:params {:application-id application-id
+            {:rems/request-id ::request-id
+             :params {:application-id application-id
                       :member (select-keys member [:userid])}
              :handler (flash-message/default-success-handler
                        :change-members
@@ -63,10 +62,11 @@
   [{:keys [selected-member potential-members on-set-member on-send]}]
   [action-form-view action-form-id
    (text :t.actions/add-member)
-   [[button-wrapper {:id "add-member-submit"
-                     :text (text :t.actions/add-member)
-                     :class "btn-primary"
-                     :on-click on-send}]]
+   [[atoms/rate-limited-button {:id "add-member-submit"
+                                :text (text :t.actions/add-member)
+                                :class "btn-primary"
+                                :disabled @(rf/subscribe [:rems.spa/pending-request ::request-id])
+                                :on-click on-send}]]
    [:div
     [:div.form-group
      [:label {:for dropdown-id} (text :t.actions/member)]

--- a/src/cljs/rems/actions/add_member.cljs
+++ b/src/cljs/rems/actions/add_member.cljs
@@ -41,8 +41,7 @@
  (fn [_ [_ {:keys [member application-id on-finished]}]]
    (let [description [text :t.actions/add-member]]
      (post! "/api/applications/add-member"
-            {:rems/request-id ::request-id
-             :params {:application-id application-id
+            {:params {:application-id application-id
                       :member (select-keys member [:userid])}
              :handler (flash-message/default-success-handler
                        :change-members
@@ -65,7 +64,7 @@
    [[atoms/rate-limited-button {:id "add-member-submit"
                                 :text (text :t.actions/add-member)
                                 :class "btn-primary"
-                                :disabled @(rf/subscribe [:rems.spa/pending-request ::request-id])
+                                :disabled @(rf/subscribe [:rems.spa/pending-request "/api/applications/add-member"])
                                 :on-click on-send}]]
    [:div
     [:div.form-group

--- a/src/cljs/rems/actions/add_member.cljs
+++ b/src/cljs/rems/actions/add_member.cljs
@@ -1,6 +1,6 @@
 (ns rems.actions.add-member
   (:require [re-frame.core :as rf]
-            [rems.actions.components :refer [action-button action-form-view collapse-action-form]]
+            [rems.actions.components :refer [action-button action-form-view collapse-action-form perform-action-button]]
             [rems.atoms :as atoms]
             [rems.dropdown :as dropdown]
             [rems.flash-message :as flash-message]
@@ -61,11 +61,10 @@
   [{:keys [selected-member potential-members on-set-member on-send]}]
   [action-form-view action-form-id
    (text :t.actions/add-member)
-   [[atoms/rate-limited-button {:id "add-member-submit"
-                                :text (text :t.actions/add-member)
-                                :class "btn-primary"
-                                :disabled @(rf/subscribe [:rems.spa/pending-request "/api/applications/add-member"])
-                                :on-click on-send}]]
+   [[perform-action-button {:id "add-member-submit"
+                            :text (text :t.actions/add-member)
+                            :class "btn-primary"
+                            :on-click on-send}]]
    [:div
     [:div.form-group
      [:label {:for dropdown-id} (text :t.actions/member)]

--- a/src/cljs/rems/actions/approve_reject.cljs
+++ b/src/cljs/rems/actions/approve_reject.cljs
@@ -3,8 +3,8 @@
             [cljs-time.core :as time]
             [cljs-time.format :as time-format]
             [re-frame.core :as rf]
-            [rems.actions.components :refer [action-attachment action-button comment-field action-form-view command!]]
-            [rems.atoms :as atoms :refer [close-symbol]]
+            [rems.actions.components :refer [action-attachment action-button comment-field action-form-view command! perform-action-button]]
+            [rems.atoms :as atoms]
             [rems.text :refer [text localize-utc-date]]))
 
 (def ^:private action-form-id "approve-reject")
@@ -64,18 +64,14 @@
   [{:keys [application-id end on-set-entitlement-end on-approve on-reject]}]
   [action-form-view action-form-id
    (text :t.actions/approve-reject)
-   [[atoms/rate-limited-button {:id "reject"
-                                :text (text :t.actions/reject)
-                                :class "btn-danger"
-                                :disabled @(rf/subscribe [:rems.spa/any-pending-request #{:application.command/approve
-                                                                                          :application.command/reject}])
-                                :on-click on-reject}]
-    [atoms/rate-limited-button {:id "approve"
-                                :text (text :t.actions/approve)
-                                :class "btn-success"
-                                :disabled @(rf/subscribe [:rems.spa/any-pending-request #{:application.command/approve
-                                                                                          :application.command/reject}])
-                                :on-click on-approve}]]
+   [[perform-action-button {:id "reject"
+                            :text (text :t.actions/reject)
+                            :class "btn-danger"
+                            :on-click on-reject}]
+    [perform-action-button {:id "approve"
+                            :text (text :t.actions/approve)
+                            :class "btn-success"
+                            :on-click on-approve}]]
    [:<>
     [comment-field {:field-key action-form-id
                     :label (text :t.form/add-comments-shown-to-applicant)}]
@@ -98,7 +94,7 @@
          [:button.btn.btn-outline-secondary
           {:on-click #(on-set-entitlement-end nil)
            :aria-label (text :t.actions/clear)}
-          [close-symbol]]])]]]])
+          [atoms/close-symbol]]])]]]])
 
 (defn approve-reject-form [application-id on-finished]
   (let [comment @(rf/subscribe [:rems.actions.components/comment action-form-id])

--- a/src/cljs/rems/actions/approve_reject.cljs
+++ b/src/cljs/rems/actions/approve_reject.cljs
@@ -3,8 +3,8 @@
             [cljs-time.core :as time]
             [cljs-time.format :as time-format]
             [re-frame.core :as rf]
-            [rems.actions.components :refer [action-attachment action-button comment-field action-form-view button-wrapper command!]]
-            [rems.atoms :refer [close-symbol]]
+            [rems.actions.components :refer [action-attachment action-button comment-field action-form-view command!]]
+            [rems.atoms :as atoms :refer [close-symbol]]
             [rems.text :refer [text localize-utc-date]]))
 
 (def ^:private action-form-id "approve-reject")
@@ -64,14 +64,18 @@
   [{:keys [application-id end on-set-entitlement-end on-approve on-reject]}]
   [action-form-view action-form-id
    (text :t.actions/approve-reject)
-   [[button-wrapper {:id "reject"
-                     :text (text :t.actions/reject)
-                     :class "btn-danger"
-                     :on-click on-reject}]
-    [button-wrapper {:id "approve"
-                     :text (text :t.actions/approve)
-                     :class "btn-success"
-                     :on-click on-approve}]]
+   (let [pending-approve-or-reject (or @(rf/subscribe [:rems.spa/pending-request :application.command/approve])
+                                       @(rf/subscribe [:rems.spa/pending-request :application.command/reject]))]
+     [[atoms/rate-limited-button {:id "reject"
+                                  :text (text :t.actions/reject)
+                                  :class "btn-danger"
+                                  :disabled pending-approve-or-reject
+                                  :on-click on-reject}]
+      [atoms/rate-limited-button {:id "approve"
+                                  :text (text :t.actions/approve)
+                                  :class "btn-success"
+                                  :disabled pending-approve-or-reject
+                                  :on-click on-approve}]])
    [:<>
     [comment-field {:field-key action-form-id
                     :label (text :t.form/add-comments-shown-to-applicant)}]

--- a/src/cljs/rems/actions/approve_reject.cljs
+++ b/src/cljs/rems/actions/approve_reject.cljs
@@ -64,18 +64,18 @@
   [{:keys [application-id end on-set-entitlement-end on-approve on-reject]}]
   [action-form-view action-form-id
    (text :t.actions/approve-reject)
-   (let [pending-approve-or-reject (or @(rf/subscribe [:rems.spa/pending-request :application.command/approve])
-                                       @(rf/subscribe [:rems.spa/pending-request :application.command/reject]))]
-     [[atoms/rate-limited-button {:id "reject"
-                                  :text (text :t.actions/reject)
-                                  :class "btn-danger"
-                                  :disabled pending-approve-or-reject
-                                  :on-click on-reject}]
-      [atoms/rate-limited-button {:id "approve"
-                                  :text (text :t.actions/approve)
-                                  :class "btn-success"
-                                  :disabled pending-approve-or-reject
-                                  :on-click on-approve}]])
+   [[atoms/rate-limited-button {:id "reject"
+                                :text (text :t.actions/reject)
+                                :class "btn-danger"
+                                :disabled @(rf/subscribe [:rems.spa/any-pending-request #{:application.command/approve
+                                                                                          :application.command/reject}])
+                                :on-click on-reject}]
+    [atoms/rate-limited-button {:id "approve"
+                                :text (text :t.actions/approve)
+                                :class "btn-success"
+                                :disabled @(rf/subscribe [:rems.spa/any-pending-request #{:application.command/approve
+                                                                                          :application.command/reject}])
+                                :on-click on-approve}]]
    [:<>
     [comment-field {:field-key action-form-id
                     :label (text :t.form/add-comments-shown-to-applicant)}]

--- a/src/cljs/rems/actions/assign_external_id.cljs
+++ b/src/cljs/rems/actions/assign_external_id.cljs
@@ -1,8 +1,7 @@
 (ns rems.actions.assign-external-id
   (:require [clojure.string :as str]
             [re-frame.core :as rf]
-            [rems.actions.components :refer [action-button action-form-view command!]]
-            [rems.atoms :as atoms]
+            [rems.actions.components :refer [action-button action-form-view command! perform-action-button]]
             [rems.text :refer [text]]))
 
 (rf/reg-event-fx
@@ -35,11 +34,10 @@
   [{:keys [external-id on-set-external-id on-send]}]
   [action-form-view action-form-id
    (text :t.actions/assign-external-id)
-   [[atoms/rate-limited-button {:id "assign-external-id-button"
-                                :text (text :t.actions/assign-external-id)
-                                :class "btn-primary"
-                                :disabled @(rf/subscribe [:rems.spa/pending-request :application.command/assign-external-id])
-                                :on-click on-send}]]
+   [[perform-action-button {:id "assign-external-id-button"
+                            :text (text :t.actions/assign-external-id)
+                            :class "btn-primary"
+                            :on-click on-send}]]
    (let [id (str action-form-id "-field")]
      [:div.form-group
       [:label {:for id}

--- a/src/cljs/rems/actions/assign_external_id.cljs
+++ b/src/cljs/rems/actions/assign_external_id.cljs
@@ -1,7 +1,8 @@
 (ns rems.actions.assign-external-id
   (:require [clojure.string :as str]
             [re-frame.core :as rf]
-            [rems.actions.components :refer [action-button action-form-view button-wrapper command!]]
+            [rems.actions.components :refer [action-button action-form-view command!]]
+            [rems.atoms :as atoms]
             [rems.text :refer [text]]))
 
 (rf/reg-event-fx
@@ -34,10 +35,11 @@
   [{:keys [external-id on-set-external-id on-send]}]
   [action-form-view action-form-id
    (text :t.actions/assign-external-id)
-   [[button-wrapper {:id "assign-external-id-button"
-                     :text (text :t.actions/assign-external-id)
-                     :class "btn-primary"
-                     :on-click on-send}]]
+   [[atoms/rate-limited-button {:id "assign-external-id-button"
+                                :text (text :t.actions/assign-external-id)
+                                :class "btn-primary"
+                                :disabled @(rf/subscribe [:rems.spa/pending-request :application.command/assign-external-id])
+                                :on-click on-send}]]
    (let [id (str action-form-id "-field")]
      [:div.form-group
       [:label {:for id}

--- a/src/cljs/rems/actions/change_applicant.cljs
+++ b/src/cljs/rems/actions/change_applicant.cljs
@@ -1,6 +1,7 @@
 (ns rems.actions.change-applicant
   (:require [re-frame.core :as rf]
-            [rems.actions.components :refer [action-button action-form-view comment-field button-wrapper collapse-action-form]]
+            [rems.actions.components :refer [action-button action-form-view comment-field collapse-action-form]]
+            [rems.atoms :as atoms]
             [rems.flash-message :as flash-message]
             [rems.text :refer [text]]
             [rems.util :refer [post!]]))
@@ -17,7 +18,8 @@
  (fn [_ [_ {:keys [collapse-id application-id member comment on-finished]}]]
    (let [description [text :t.actions/change-applicant]]
      (post! "/api/applications/change-applicant"
-            {:params {:application-id application-id
+            {:rems/request-id ::request-id
+             :params {:application-id application-id
                       :member (select-keys member [:userid])
                       :comment comment}
              :handler (flash-message/default-success-handler
@@ -43,10 +45,11 @@
   (let [element-id (qualify-parent-id parent-id)]
     [action-form-view element-id
      (text :t.actions/change-applicant)
-     [[button-wrapper {:id (str element-id "-submit")
-                       :text (text :t.actions/change-applicant)
-                       :class "btn-primary"
-                       :on-click on-send}]]
+     [[atoms/rate-limited-button {:id (str element-id "-submit")
+                                  :text (text :t.actions/change-applicant)
+                                  :class "btn-primary"
+                                  :disabled @(rf/subscribe [:rems.spa/pending-request ::request-id])
+                                  :on-click on-send}]]
      [comment-field {:field-key (str element-id "-comment")
                      :label (text :t.form/add-comments-shown-to-applicant)}]
      {:collapse-id parent-id}]))

--- a/src/cljs/rems/actions/change_applicant.cljs
+++ b/src/cljs/rems/actions/change_applicant.cljs
@@ -1,7 +1,6 @@
 (ns rems.actions.change-applicant
   (:require [re-frame.core :as rf]
-            [rems.actions.components :refer [action-button action-form-view comment-field collapse-action-form]]
-            [rems.atoms :as atoms]
+            [rems.actions.components :refer [action-button action-form-view comment-field collapse-action-form perform-action-button]]
             [rems.flash-message :as flash-message]
             [rems.text :refer [text]]
             [rems.util :refer [post!]]))
@@ -44,11 +43,10 @@
   (let [element-id (qualify-parent-id parent-id)]
     [action-form-view element-id
      (text :t.actions/change-applicant)
-     [[atoms/rate-limited-button {:id (str element-id "-submit")
-                                  :text (text :t.actions/change-applicant)
-                                  :class "btn-primary"
-                                  :disabled @(rf/subscribe [:rems.spa/pending-request "/api/applications/change-applicant"])
-                                  :on-click on-send}]]
+     [[perform-action-button {:id (str element-id "-submit")
+                              :text (text :t.actions/change-applicant)
+                              :class "btn-primary"
+                              :on-click on-send}]]
      [comment-field {:field-key (str element-id "-comment")
                      :label (text :t.form/add-comments-shown-to-applicant)}]
      {:collapse-id parent-id}]))

--- a/src/cljs/rems/actions/change_applicant.cljs
+++ b/src/cljs/rems/actions/change_applicant.cljs
@@ -18,8 +18,7 @@
  (fn [_ [_ {:keys [collapse-id application-id member comment on-finished]}]]
    (let [description [text :t.actions/change-applicant]]
      (post! "/api/applications/change-applicant"
-            {:rems/request-id ::request-id
-             :params {:application-id application-id
+            {:params {:application-id application-id
                       :member (select-keys member [:userid])
                       :comment comment}
              :handler (flash-message/default-success-handler
@@ -48,7 +47,7 @@
      [[atoms/rate-limited-button {:id (str element-id "-submit")
                                   :text (text :t.actions/change-applicant)
                                   :class "btn-primary"
-                                  :disabled @(rf/subscribe [:rems.spa/pending-request ::request-id])
+                                  :disabled @(rf/subscribe [:rems.spa/pending-request "/api/applications/change-applicant"])
                                   :on-click on-send}]]
      [comment-field {:field-key (str element-id "-comment")
                      :label (text :t.form/add-comments-shown-to-applicant)}]

--- a/src/cljs/rems/actions/change_resources.cljs
+++ b/src/cljs/rems/actions/change_resources.cljs
@@ -1,7 +1,6 @@
 (ns rems.actions.change-resources
   (:require [re-frame.core :as rf]
-            [rems.actions.components :refer [action-button action-form-view comment-field collapse-action-form]]
-            [rems.atoms :as atoms]
+            [rems.actions.components :refer [action-button action-form-view comment-field collapse-action-form perform-action-button]]
             [rems.dropdown :as dropdown]
             [rems.flash-message :as flash-message]
             [medley.core :refer [distinct-by]]
@@ -84,13 +83,12 @@
         config @(rf/subscribe [:rems.config/config])]
     [action-form-view action-form-id
      (text :t.actions/change-resources)
-     [[atoms/rate-limited-button {:id "change-resources"
-                                  :text (text :t.actions/change-resources)
-                                  :class "btn-primary"
-                                  :disabled (or (empty? selected-resources)
-                                                (= selected-resources initial-resources)
-                                                @(rf/subscribe [:rems.spa/pending-request "/api/applications/change-resources"]))
-                                  :on-click on-send}]]
+     [[perform-action-button {:id "change-resources"
+                              :text (text :t.actions/change-resources)
+                              :class "btn-primary"
+                              :disabled (or (empty? selected-resources)
+                                            (= selected-resources initial-resources))
+                              :on-click on-send}]]
      (if (empty? catalogue)
        [spinner/big]
        ;; TODO: Nowadays the user cannot select resources that have an

--- a/src/cljs/rems/actions/change_resources.cljs
+++ b/src/cljs/rems/actions/change_resources.cljs
@@ -53,8 +53,7 @@
  (fn [_ [_ {:keys [application-id resources comment on-finished]}]]
    (let [description [text :t.actions/change-resources]]
      (post! "/api/applications/change-resources"
-            {:rems/request-id ::request-id
-             :params (merge {:application-id application-id
+            {:params (merge {:application-id application-id
                              :catalogue-item-ids (vec resources)}
                             (when comment
                               {:comment comment}))
@@ -90,7 +89,7 @@
                                   :class "btn-primary"
                                   :disabled (or (empty? selected-resources)
                                                 (= selected-resources initial-resources)
-                                                @(rf/subscribe [:rems.spa/pending-request ::request-id]))
+                                                @(rf/subscribe [:rems.spa/pending-request "/api/applications/change-resources"]))
                                   :on-click on-send}]]
      (if (empty? catalogue)
        [spinner/big]

--- a/src/cljs/rems/actions/close.cljs
+++ b/src/cljs/rems/actions/close.cljs
@@ -1,6 +1,7 @@
 (ns rems.actions.close
   (:require [re-frame.core :as rf]
-            [rems.actions.components :refer [action-attachment action-button comment-field action-form-view button-wrapper command!]]
+            [rems.actions.components :refer [action-attachment action-button comment-field action-form-view command!]]
+            [rems.atoms :as atoms]
             [rems.text :refer [text]]))
 
 (def ^:private action-form-id "close")
@@ -32,10 +33,11 @@
   [{:keys [application-id show-comment-field? on-send]}]
   [action-form-view action-form-id
    (text :t.actions/close)
-   [[button-wrapper {:id "close"
-                     :text (text :t.actions/close)
-                     :class "btn-danger"
-                     :on-click on-send}]]
+   [[atoms/rate-limited-button {:id "close"
+                                :text (text :t.actions/close)
+                                :class "btn-danger"
+                                :disabled @(rf/subscribe [:rems.spa/pending-request :application.command/close])
+                                :on-click on-send}]]
    [:div
     (text :t.actions/close-intro)
     (when show-comment-field?

--- a/src/cljs/rems/actions/close.cljs
+++ b/src/cljs/rems/actions/close.cljs
@@ -1,7 +1,6 @@
 (ns rems.actions.close
   (:require [re-frame.core :as rf]
-            [rems.actions.components :refer [action-attachment action-button comment-field action-form-view command!]]
-            [rems.atoms :as atoms]
+            [rems.actions.components :refer [action-attachment action-button comment-field action-form-view command! perform-action-button]]
             [rems.text :refer [text]]))
 
 (def ^:private action-form-id "close")
@@ -33,11 +32,10 @@
   [{:keys [application-id show-comment-field? on-send]}]
   [action-form-view action-form-id
    (text :t.actions/close)
-   [[atoms/rate-limited-button {:id "close"
-                                :text (text :t.actions/close)
-                                :class "btn-danger"
-                                :disabled @(rf/subscribe [:rems.spa/pending-request :application.command/close])
-                                :on-click on-send}]]
+   [[perform-action-button {:id "close"
+                            :text (text :t.actions/close)
+                            :class "btn-danger"
+                            :on-click on-send}]]
    [:div
     (text :t.actions/close-intro)
     (when show-comment-field?

--- a/src/cljs/rems/actions/components.cljs
+++ b/src/cljs/rems/actions/components.cljs
@@ -225,7 +225,7 @@
   (assert (qualified-keyword? command)
           (pr-str command))
   (post! (str "/api/applications/" (name command))
-         {:rems/request-id command
+         {:request-id command
           :params params
           :handler (flash-message/default-success-handler
                     :actions

--- a/src/cljs/rems/actions/components.cljs
+++ b/src/cljs/rems/actions/components.cljs
@@ -225,7 +225,8 @@
   (assert (qualified-keyword? command)
           (pr-str command))
   (post! (str "/api/applications/" (name command))
-         {:params params
+         {:rems/request-id command
+          :params params
           :handler (flash-message/default-success-handler
                     :actions
                     description

--- a/src/cljs/rems/actions/components.cljs
+++ b/src/cljs/rems/actions/components.cljs
@@ -235,5 +235,11 @@
                       (on-finished)))
           :error-handler (flash-message/default-error-handler :actions description)}))
 
+(defn perform-action-button [{:keys [loading?] :as props}]
+  [atoms/rate-limited-button
+   (-> props
+       (dissoc (when (or loading? @(rf/subscribe [:rems.spa/any-pending-request?]))
+                 :on-click)))])
+
 (defn guide []
   [:div])

--- a/src/cljs/rems/actions/components.cljs
+++ b/src/cljs/rems/actions/components.cljs
@@ -1,6 +1,6 @@
 (ns rems.actions.components
   (:require [re-frame.core :as rf]
-            [rems.atoms :refer [attachment-link checkbox enrich-user textarea]]
+            [rems.atoms :as atoms :refer [attachment-link checkbox enrich-user textarea]]
             [rems.common.attachment-util :as attachment-util]
             [rems.dropdown :as dropdown]
             [rems.fetcher :as fetcher]
@@ -14,13 +14,6 @@
 
 (defn- action-button-id [action-id]
   (str action-id "-action-button"))
-
-(defn button-wrapper [{:keys [text class] :as props}]
-  [:button.btn
-   (merge {:type :button
-           :class (or class :btn-secondary)}
-          (dissoc props :class :text))
-   text])
 
 (defn collapse-action-form [id]
   (.collapse (js/$ (str "#" (action-collapse-id id))) "hide"))

--- a/src/cljs/rems/actions/decide.cljs
+++ b/src/cljs/rems/actions/decide.cljs
@@ -1,6 +1,7 @@
 (ns rems.actions.decide
   (:require [re-frame.core :as rf]
-            [rems.actions.components :refer [action-attachment action-button comment-field action-form-view button-wrapper command!]]
+            [rems.actions.components :refer [action-attachment action-button comment-field action-form-view command!]]
+            [rems.atoms :as atoms]
             [rems.text :refer [text]]))
 
 (def ^:private action-form-id "decide")
@@ -34,14 +35,16 @@
   [{:keys [application-id on-send]}]
   [action-form-view action-form-id
    (text :t.actions/decide)
-   [[button-wrapper {:id "decide-reject"
-                     :text (text :t.actions/reject)
-                     :class "btn-danger"
-                     :on-click #(on-send :rejected)}]
-    [button-wrapper {:id "decide-approve"
-                     :text (text :t.actions/approve)
-                     :class "btn-success"
-                     :on-click #(on-send :approved)}]]
+   [[atoms/rate-limited-button {:id "decide-reject"
+                                :text (text :t.actions/reject)
+                                :class "btn-danger"
+                                :disabled @(rf/subscribe [:rems.spa/pending-request :application.command/decide])
+                                :on-click #(on-send :rejected)}]
+    [atoms/rate-limited-button {:id "decide-approve"
+                                :text (text :t.actions/approve)
+                                :class "btn-success"
+                                :disabled @(rf/subscribe [:rems.spa/pending-request :application.command/decide])
+                                :on-click #(on-send :approved)}]]
    [:<>
     [comment-field {:field-key action-form-id
                     :label (text :t.form/add-comments-not-shown-to-applicant)}]

--- a/src/cljs/rems/actions/decide.cljs
+++ b/src/cljs/rems/actions/decide.cljs
@@ -1,7 +1,6 @@
 (ns rems.actions.decide
   (:require [re-frame.core :as rf]
-            [rems.actions.components :refer [action-attachment action-button comment-field action-form-view command!]]
-            [rems.atoms :as atoms]
+            [rems.actions.components :refer [action-attachment action-button comment-field action-form-view command! perform-action-button]]
             [rems.text :refer [text]]))
 
 (def ^:private action-form-id "decide")
@@ -35,16 +34,14 @@
   [{:keys [application-id on-send]}]
   [action-form-view action-form-id
    (text :t.actions/decide)
-   [[atoms/rate-limited-button {:id "decide-reject"
-                                :text (text :t.actions/reject)
-                                :class "btn-danger"
-                                :disabled @(rf/subscribe [:rems.spa/pending-request :application.command/decide])
-                                :on-click #(on-send :rejected)}]
-    [atoms/rate-limited-button {:id "decide-approve"
-                                :text (text :t.actions/approve)
-                                :class "btn-success"
-                                :disabled @(rf/subscribe [:rems.spa/pending-request :application.command/decide])
-                                :on-click #(on-send :approved)}]]
+   [[perform-action-button {:id "decide-reject"
+                            :text (text :t.actions/reject)
+                            :class "btn-danger"
+                            :on-click #(on-send :rejected)}]
+    [perform-action-button {:id "decide-approve"
+                            :text (text :t.actions/approve)
+                            :class "btn-success"
+                            :on-click #(on-send :approved)}]]
    [:<>
     [comment-field {:field-key action-form-id
                     :label (text :t.form/add-comments-not-shown-to-applicant)}]

--- a/src/cljs/rems/actions/delete.cljs
+++ b/src/cljs/rems/actions/delete.cljs
@@ -1,6 +1,7 @@
 (ns rems.actions.delete
   (:require [re-frame.core :as rf]
-            [rems.actions.components :refer [action-button action-form-view button-wrapper command!]]
+            [rems.actions.components :refer [action-button action-form-view command!]]
+            [rems.atoms :as atoms]
             [rems.text :refer [text]]))
 
 (def ^:private action-form-id "delete")
@@ -22,10 +23,11 @@
 (defn delete-form [application-id on-finished]
   [action-form-view action-form-id
    (text :t.actions/delete)
-   [[button-wrapper {:id "delete"
-                     :text (text :t.actions/delete)
-                     :class "btn-danger"
-                     :on-click #(rf/dispatch [::send-delete {:application-id application-id
-                                                             :on-finished on-finished}])}]]
+   [[atoms/rate-limited-button {:id "delete"
+                                :text (text :t.actions/delete)
+                                :class "btn-danger"
+                                :disabled @(rf/subscribe [:rems.spa/pending-request :application.command/delete])
+                                :on-click #(rf/dispatch [::send-delete {:application-id application-id
+                                                                        :on-finished on-finished}])}]]
    [:div
     (text :t.actions/delete-intro)]])

--- a/src/cljs/rems/actions/delete.cljs
+++ b/src/cljs/rems/actions/delete.cljs
@@ -1,7 +1,6 @@
 (ns rems.actions.delete
   (:require [re-frame.core :as rf]
-            [rems.actions.components :refer [action-button action-form-view command!]]
-            [rems.atoms :as atoms]
+            [rems.actions.components :refer [action-button action-form-view command! perform-action-button]]
             [rems.text :refer [text]]))
 
 (def ^:private action-form-id "delete")
@@ -23,11 +22,10 @@
 (defn delete-form [application-id on-finished]
   [action-form-view action-form-id
    (text :t.actions/delete)
-   [[atoms/rate-limited-button {:id "delete"
-                                :text (text :t.actions/delete)
-                                :class "btn-danger"
-                                :disabled @(rf/subscribe [:rems.spa/pending-request :application.command/delete])
-                                :on-click #(rf/dispatch [::send-delete {:application-id application-id
-                                                                        :on-finished on-finished}])}]]
+   [[perform-action-button {:id "delete"
+                            :text (text :t.actions/delete)
+                            :class "btn-danger"
+                            :on-click #(rf/dispatch [::send-delete {:application-id application-id
+                                                                    :on-finished on-finished}])}]]
    [:div
     (text :t.actions/delete-intro)]])

--- a/src/cljs/rems/actions/invite_decider_reviewer.cljs
+++ b/src/cljs/rems/actions/invite_decider_reviewer.cljs
@@ -1,10 +1,9 @@
 (ns rems.actions.invite-decider-reviewer
   (:require [re-frame.core :as rf]
-            [rems.actions.components :refer [action-attachment action-link action-form-view button-wrapper command!
-                                             comment-field email-field name-field]]
+            [rems.actions.components :refer [action-attachment action-link action-form-view command! comment-field email-field name-field]]
+            [rems.atoms :as atoms]
             [rems.flash-message :as flash-message]
             [rems.text :refer [text]]))
-
 
 (rf/reg-event-fx
  ::open-form
@@ -71,11 +70,11 @@
   [action-form-view
    decider-form-id
    (text :t.actions/request-decision-via-email)
-   [[button-wrapper {:id "invite-decider"
-                     :text (text :t.actions/request-decision)
-                     :class "btn-primary"
-                     :on-click on-send
-                     :disabled disabled}]]
+   [[atoms/rate-limited-button {:id "invite-decider"
+                                :text (text :t.actions/request-decision)
+                                :class "btn-primary"
+                                :on-click on-send
+                                :disabled (or disabled @(rf/subscribe [:rems.spa/pending-request :application.command/invite-decider]))}]]
    [:<>
     [name-field {:field-key decider-form-id}]
     [email-field {:field-key decider-form-id}]
@@ -89,11 +88,11 @@
   [action-form-view
    reviewer-form-id
    (text :t.actions/request-review-via-email)
-   [[button-wrapper {:id "invite-reviewer"
-                     :text (text :t.actions/request-review)
-                     :class "btn-primary"
-                     :on-click on-send
-                     :disabled disabled}]]
+   [[atoms/rate-limited-button {:id "invite-reviewer"
+                                :text (text :t.actions/request-review)
+                                :class "btn-primary"
+                                :on-click on-send
+                                :disabled (or disabled @(rf/subscribe [:rems.spa/pending-request :application.command/invite-reviewer]))}]]
    [:<>
     [name-field {:field-key reviewer-form-id}]
     [email-field {:field-key reviewer-form-id}]

--- a/src/cljs/rems/actions/invite_decider_reviewer.cljs
+++ b/src/cljs/rems/actions/invite_decider_reviewer.cljs
@@ -1,7 +1,6 @@
 (ns rems.actions.invite-decider-reviewer
   (:require [re-frame.core :as rf]
-            [rems.actions.components :refer [action-attachment action-link action-form-view command! comment-field email-field name-field]]
-            [rems.atoms :as atoms]
+            [rems.actions.components :refer [action-attachment action-link action-form-view command! comment-field email-field name-field perform-action-button]]
             [rems.flash-message :as flash-message]
             [rems.text :refer [text]]))
 
@@ -70,12 +69,11 @@
   [action-form-view
    decider-form-id
    (text :t.actions/request-decision-via-email)
-   [[atoms/rate-limited-button {:id "invite-decider"
-                                :text (text :t.actions/request-decision)
-                                :class "btn-primary"
-                                :on-click on-send
-                                :disabled (or disabled
-                                              @(rf/subscribe [:rems.spa/pending-request :application.command/invite-decider]))}]]
+   [[perform-action-button {:id "invite-decider"
+                            :text (text :t.actions/request-decision)
+                            :class "btn-primary"
+                            :on-click on-send
+                            :disabled disabled}]]
    [:<>
     [name-field {:field-key decider-form-id}]
     [email-field {:field-key decider-form-id}]
@@ -89,12 +87,11 @@
   [action-form-view
    reviewer-form-id
    (text :t.actions/request-review-via-email)
-   [[atoms/rate-limited-button {:id "invite-reviewer"
-                                :text (text :t.actions/request-review)
-                                :class "btn-primary"
-                                :on-click on-send
-                                :disabled (or disabled
-                                              @(rf/subscribe [:rems.spa/pending-request :application.command/invite-reviewer]))}]]
+   [[perform-action-button {:id "invite-reviewer"
+                            :text (text :t.actions/request-review)
+                            :class "btn-primary"
+                            :on-click on-send
+                            :disabled disabled}]]
    [:<>
     [name-field {:field-key reviewer-form-id}]
     [email-field {:field-key reviewer-form-id}]

--- a/src/cljs/rems/actions/invite_decider_reviewer.cljs
+++ b/src/cljs/rems/actions/invite_decider_reviewer.cljs
@@ -74,7 +74,8 @@
                                 :text (text :t.actions/request-decision)
                                 :class "btn-primary"
                                 :on-click on-send
-                                :disabled (or disabled @(rf/subscribe [:rems.spa/pending-request :application.command/invite-decider]))}]]
+                                :disabled (or disabled
+                                              @(rf/subscribe [:rems.spa/pending-request :application.command/invite-decider]))}]]
    [:<>
     [name-field {:field-key decider-form-id}]
     [email-field {:field-key decider-form-id}]
@@ -92,7 +93,8 @@
                                 :text (text :t.actions/request-review)
                                 :class "btn-primary"
                                 :on-click on-send
-                                :disabled (or disabled @(rf/subscribe [:rems.spa/pending-request :application.command/invite-reviewer]))}]]
+                                :disabled (or disabled
+                                              @(rf/subscribe [:rems.spa/pending-request :application.command/invite-reviewer]))}]]
    [:<>
     [name-field {:field-key reviewer-form-id}]
     [email-field {:field-key reviewer-form-id}]

--- a/src/cljs/rems/actions/invite_member.cljs
+++ b/src/cljs/rems/actions/invite_member.cljs
@@ -26,8 +26,7 @@
      (if-let [errors (validate-member member)]
        (flash-message/show-error! :invite-member-errors (flash-message/format-errors errors))
        (post! "/api/applications/invite-member"
-              {:rems/request-id ::request-id
-               :params {:application-id application-id
+              {:params {:application-id application-id
                         :member member}
                :handler (flash-message/default-success-handler
                          :change-members
@@ -50,7 +49,7 @@
    [[atoms/rate-limited-button {:id "invite-member"
                                 :text (text :t.actions/invite-member)
                                 :class "btn-primary"
-                                :disabled @(rf/subscribe [:rems.spa/pending-request ::request-id])
+                                :disabled @(rf/subscribe [:rems.spa/pending-request "/api/applications/invite-member"])
                                 :on-click on-send}]]
    [:div
     [flash-message/component :invite-member-errors]

--- a/src/cljs/rems/actions/invite_member.cljs
+++ b/src/cljs/rems/actions/invite_member.cljs
@@ -1,7 +1,6 @@
 (ns rems.actions.invite-member
   (:require [re-frame.core :as rf]
-            [rems.actions.components :refer [action-button action-form-view collapse-action-form email-field name-field]]
-            [rems.atoms :as atoms]
+            [rems.actions.components :refer [action-button action-form-view collapse-action-form email-field name-field perform-action-button]]
             [rems.flash-message :as flash-message]
             [rems.text :refer [text]]
             [rems.util :refer [post!]]))
@@ -46,11 +45,10 @@
   [{:keys [on-send]}]
   [action-form-view action-form-id
    (text :t.actions/invite-member)
-   [[atoms/rate-limited-button {:id "invite-member"
-                                :text (text :t.actions/invite-member)
-                                :class "btn-primary"
-                                :disabled @(rf/subscribe [:rems.spa/pending-request "/api/applications/invite-member"])
-                                :on-click on-send}]]
+   [[perform-action-button {:id "invite-member"
+                            :text (text :t.actions/invite-member)
+                            :class "btn-primary"
+                            :on-click on-send}]]
    [:div
     [flash-message/component :invite-member-errors]
     [name-field {:field-key action-form-id}]

--- a/src/cljs/rems/actions/invite_member.cljs
+++ b/src/cljs/rems/actions/invite_member.cljs
@@ -1,11 +1,10 @@
 (ns rems.actions.invite-member
   (:require [re-frame.core :as rf]
-            [rems.actions.components :refer [action-button action-form-view button-wrapper collapse-action-form
-                                             email-field name-field]]
+            [rems.actions.components :refer [action-button action-form-view collapse-action-form email-field name-field]]
+            [rems.atoms :as atoms]
             [rems.flash-message :as flash-message]
             [rems.text :refer [text]]
             [rems.util :refer [post!]]))
-
 
 (def ^:private action-form-id "invite-member")
 
@@ -27,7 +26,8 @@
      (if-let [errors (validate-member member)]
        (flash-message/show-error! :invite-member-errors (flash-message/format-errors errors))
        (post! "/api/applications/invite-member"
-              {:params {:application-id application-id
+              {:rems/request-id ::request-id
+               :params {:application-id application-id
                         :member member}
                :handler (flash-message/default-success-handler
                          :change-members
@@ -47,10 +47,11 @@
   [{:keys [on-send]}]
   [action-form-view action-form-id
    (text :t.actions/invite-member)
-   [[button-wrapper {:id "invite-member"
-                     :text (text :t.actions/invite-member)
-                     :class "btn-primary"
-                     :on-click on-send}]]
+   [[atoms/rate-limited-button {:id "invite-member"
+                                :text (text :t.actions/invite-member)
+                                :class "btn-primary"
+                                :disabled @(rf/subscribe [:rems.spa/pending-request ::request-id])
+                                :on-click on-send}]]
    [:div
     [flash-message/component :invite-member-errors]
     [name-field {:field-key action-form-id}]

--- a/src/cljs/rems/actions/redact_attachments.cljs
+++ b/src/cljs/rems/actions/redact_attachments.cljs
@@ -1,7 +1,7 @@
 (ns rems.actions.redact-attachments
-  (:require [medley.core :refer [assoc-some]]
-            [re-frame.core :as rf]
-            [rems.actions.components :refer [action-attachment action-button action-form-view button-wrapper command! select-attachments-field comment-field comment-public-field]]
+  (:require [re-frame.core :as rf]
+            [rems.actions.components :refer [action-attachment action-button action-form-view command! select-attachments-field comment-field comment-public-field]]
+            [rems.atoms :as atoms]
             [rems.text :refer [text]]))
 
 (def ^:private action-form-id "redact-attachments")
@@ -49,13 +49,13 @@
 (defn redact-attachments-view [{:keys [application-id user redactable-attachments new-attachments on-submit]}]
   [action-form-view action-form-id
    (text :t.actions/redact-attachments)
-   [[button-wrapper (-> {:id action-form-id
-                         :text (if (seq new-attachments)
-                                 (text :t.actions/replace-attachments)
-                                 (text :t.actions/remove-attachments))
-                         :class :btn-danger}
-                        (assoc-some :on-click on-submit
-                                    :disabled (nil? on-submit)))]]
+   [[atoms/rate-limited-button {:id action-form-id
+                                :text (if (seq new-attachments)
+                                        (text :t.actions/replace-attachments)
+                                        (text :t.actions/remove-attachments))
+                                :class :btn-danger
+                                :disabled (or (nil? on-submit) @(rf/subscribe [:rems.spa/pending-request :application.command/redact-attachments]))
+                                :on-click on-submit}]]
    [:<>
     [select-attachments-field {:field-key action-form-id
                                :attachments redactable-attachments

--- a/src/cljs/rems/actions/redact_attachments.cljs
+++ b/src/cljs/rems/actions/redact_attachments.cljs
@@ -1,7 +1,6 @@
 (ns rems.actions.redact-attachments
   (:require [re-frame.core :as rf]
-            [rems.actions.components :refer [action-attachment action-button action-form-view command! select-attachments-field comment-field comment-public-field]]
-            [rems.atoms :as atoms]
+            [rems.actions.components :refer [action-attachment action-button action-form-view command! select-attachments-field comment-field comment-public-field perform-action-button]]
             [rems.text :refer [text]]))
 
 (def ^:private action-form-id "redact-attachments")
@@ -49,14 +48,13 @@
 (defn redact-attachments-view [{:keys [application-id user redactable-attachments new-attachments on-submit]}]
   [action-form-view action-form-id
    (text :t.actions/redact-attachments)
-   [[atoms/rate-limited-button {:id action-form-id
-                                :text (if (seq new-attachments)
-                                        (text :t.actions/replace-attachments)
-                                        (text :t.actions/remove-attachments))
-                                :class :btn-danger
-                                :disabled (or (nil? on-submit)
-                                              @(rf/subscribe [:rems.spa/pending-request :application.command/redact-attachments]))
-                                :on-click on-submit}]]
+   [[perform-action-button {:id action-form-id
+                            :text (if (seq new-attachments)
+                                    (text :t.actions/replace-attachments)
+                                    (text :t.actions/remove-attachments))
+                            :class :btn-danger
+                            :disabled (nil? on-submit)
+                            :on-click on-submit}]]
    [:<>
     [select-attachments-field {:field-key action-form-id
                                :attachments redactable-attachments

--- a/src/cljs/rems/actions/redact_attachments.cljs
+++ b/src/cljs/rems/actions/redact_attachments.cljs
@@ -54,7 +54,8 @@
                                         (text :t.actions/replace-attachments)
                                         (text :t.actions/remove-attachments))
                                 :class :btn-danger
-                                :disabled (or (nil? on-submit) @(rf/subscribe [:rems.spa/pending-request :application.command/redact-attachments]))
+                                :disabled (or (nil? on-submit)
+                                              @(rf/subscribe [:rems.spa/pending-request :application.command/redact-attachments]))
                                 :on-click on-submit}]]
    [:<>
     [select-attachments-field {:field-key action-form-id

--- a/src/cljs/rems/actions/remark.cljs
+++ b/src/cljs/rems/actions/remark.cljs
@@ -1,7 +1,6 @@
 (ns rems.actions.remark
   (:require [re-frame.core :as rf]
-            [rems.actions.components :refer [action-attachment action-button action-form-view comment-field command! comment-public-field]]
-            [rems.atoms :as atoms]
+            [rems.actions.components :refer [action-attachment action-button action-form-view comment-field command! comment-public-field perform-action-button]]
             [rems.text :refer [text]]))
 
 (def ^:private action-form-id "remark")
@@ -35,12 +34,11 @@
   [{:keys [application-id disabled on-send]}]
   [action-form-view action-form-id
    (text :t.actions/remark)
-   [[atoms/rate-limited-button {:id action-form-id
-                                :text (text :t.actions/remark)
-                                :class "btn-primary"
-                                :disabled (or disabled
-                                              @(rf/subscribe [:rems.spa/pending-request :application.command/remark]))
-                                :on-click on-send}]]
+   [[perform-action-button {:id action-form-id
+                            :text (text :t.actions/remark)
+                            :class "btn-primary"
+                            :disabled disabled
+                            :on-click on-send}]]
    [:div
     [comment-field {:field-key action-form-id
                     :label (text :t.form/add-remark)}]

--- a/src/cljs/rems/actions/remark.cljs
+++ b/src/cljs/rems/actions/remark.cljs
@@ -1,6 +1,7 @@
 (ns rems.actions.remark
   (:require [re-frame.core :as rf]
-            [rems.actions.components :refer [action-attachment action-button action-form-view comment-field button-wrapper command! comment-public-field]]
+            [rems.actions.components :refer [action-attachment action-button action-form-view comment-field command! comment-public-field]]
+            [rems.atoms :as atoms]
             [rems.text :refer [text]]))
 
 (def ^:private action-form-id "remark")
@@ -34,11 +35,11 @@
   [{:keys [application-id disabled on-send]}]
   [action-form-view action-form-id
    (text :t.actions/remark)
-   [[button-wrapper {:id action-form-id
-                     :text (text :t.actions/remark)
-                     :class "btn-primary"
-                     :disabled disabled
-                     :on-click on-send}]]
+   [[atoms/rate-limited-button {:id action-form-id
+                                :text (text :t.actions/remark)
+                                :class "btn-primary"
+                                :disabled (or disabled @(rf/subscribe [:rems.spa/pending-request :application.command/remark]))
+                                :on-click on-send}]]
    [:div
     [comment-field {:field-key action-form-id
                     :label (text :t.form/add-remark)}]
@@ -52,7 +53,8 @@
         comment @(rf/subscribe [:rems.actions.components/comment action-form-id])
         public @(rf/subscribe [:rems.actions.components/comment-public action-form-id])]
     [remark-view {:application-id application-id
-                  :disabled (and (empty? comment) (empty? attachments))
+                  :disabled (and (empty? comment)
+                                 (empty? attachments))
                   :on-send #(rf/dispatch [::send-remark {:application-id application-id
                                                          :comment comment
                                                          :public public

--- a/src/cljs/rems/actions/remark.cljs
+++ b/src/cljs/rems/actions/remark.cljs
@@ -38,7 +38,8 @@
    [[atoms/rate-limited-button {:id action-form-id
                                 :text (text :t.actions/remark)
                                 :class "btn-primary"
-                                :disabled (or disabled @(rf/subscribe [:rems.spa/pending-request :application.command/remark]))
+                                :disabled (or disabled
+                                              @(rf/subscribe [:rems.spa/pending-request :application.command/remark]))
                                 :on-click on-send}]]
    [:div
     [comment-field {:field-key action-form-id

--- a/src/cljs/rems/actions/remove_member.cljs
+++ b/src/cljs/rems/actions/remove_member.cljs
@@ -20,8 +20,7 @@
      (post! (if (:userid member)
               "/api/applications/remove-member"
               "/api/applications/uninvite-member")
-            {:rems/request-id ::request-id
-             :params {:application-id application-id
+            {:params {:application-id application-id
                       :member (if (:userid member)
                                 (select-keys member [:userid])
                                 (select-keys member [:name :email]))
@@ -52,7 +51,8 @@
      [[atoms/rate-limited-button {:id (str element-id "-submit")
                                   :text (text :t.actions/remove-member)
                                   :class "btn-primary"
-                                  :disabled @(rf/subscribe [:rems.spa/pending-request ::request-id])
+                                  :disabled @(rf/subscribe [:rems.spa/any-pending-request #{"/api/applications/remove-member"
+                                                                                            "/api/applications/uninvite-member"}])
                                   :on-click on-send}]]
      [comment-field {:field-key (str element-id "-comment")
                      :label (text :t.form/add-comments-shown-to-applicant)}]

--- a/src/cljs/rems/actions/remove_member.cljs
+++ b/src/cljs/rems/actions/remove_member.cljs
@@ -1,6 +1,7 @@
 (ns rems.actions.remove-member
   (:require [re-frame.core :as rf]
-            [rems.actions.components :refer [action-button action-form-view comment-field button-wrapper collapse-action-form]]
+            [rems.actions.components :refer [action-button action-form-view comment-field collapse-action-form]]
+            [rems.atoms :as atoms]
             [rems.flash-message :as flash-message]
             [rems.text :refer [text]]
             [rems.util :refer [post!]]))
@@ -9,7 +10,6 @@
  ::reset-form
  (fn [_ [_ element-id]]
    {:dispatch [:rems.actions.components/set-comment (str element-id "-comment") ""]}))
-
 
 ;; The API allows us to add attachments to these commands
 ;; but this is left out from the UI for simplicity
@@ -20,7 +20,8 @@
      (post! (if (:userid member)
               "/api/applications/remove-member"
               "/api/applications/uninvite-member")
-            {:params {:application-id application-id
+            {:rems/request-id ::request-id
+             :params {:application-id application-id
                       :member (if (:userid member)
                                 (select-keys member [:userid])
                                 (select-keys member [:name :email]))
@@ -48,10 +49,11 @@
   (let [element-id (qualify-parent-id parent-id)]
     [action-form-view element-id
      (text :t.actions/remove-member)
-     [[button-wrapper {:id (str element-id "-submit")
-                       :text (text :t.actions/remove-member)
-                       :class "btn-primary"
-                       :on-click on-send}]]
+     [[atoms/rate-limited-button {:id (str element-id "-submit")
+                                  :text (text :t.actions/remove-member)
+                                  :class "btn-primary"
+                                  :disabled @(rf/subscribe [:rems.spa/pending-request ::request-id])
+                                  :on-click on-send}]]
      [comment-field {:field-key (str element-id "-comment")
                      :label (text :t.form/add-comments-shown-to-applicant)}]
      {:collapse-id parent-id}]))

--- a/src/cljs/rems/actions/remove_member.cljs
+++ b/src/cljs/rems/actions/remove_member.cljs
@@ -1,7 +1,6 @@
 (ns rems.actions.remove-member
   (:require [re-frame.core :as rf]
-            [rems.actions.components :refer [action-button action-form-view comment-field collapse-action-form]]
-            [rems.atoms :as atoms]
+            [rems.actions.components :refer [action-button action-form-view comment-field collapse-action-form perform-action-button]]
             [rems.flash-message :as flash-message]
             [rems.text :refer [text]]
             [rems.util :refer [post!]]))
@@ -48,12 +47,10 @@
   (let [element-id (qualify-parent-id parent-id)]
     [action-form-view element-id
      (text :t.actions/remove-member)
-     [[atoms/rate-limited-button {:id (str element-id "-submit")
-                                  :text (text :t.actions/remove-member)
-                                  :class "btn-primary"
-                                  :disabled @(rf/subscribe [:rems.spa/any-pending-request #{"/api/applications/remove-member"
-                                                                                            "/api/applications/uninvite-member"}])
-                                  :on-click on-send}]]
+     [[perform-action-button {:id (str element-id "-submit")
+                              :text (text :t.actions/remove-member)
+                              :class "btn-primary"
+                              :on-click on-send}]]
      [comment-field {:field-key (str element-id "-comment")
                      :label (text :t.form/add-comments-shown-to-applicant)}]
      {:collapse-id parent-id}]))

--- a/src/cljs/rems/actions/request_decision.cljs
+++ b/src/cljs/rems/actions/request_decision.cljs
@@ -1,7 +1,6 @@
 (ns rems.actions.request-decision
   (:require [re-frame.core :as rf]
-            [rems.actions.components :refer [action-attachment action-link comment-field action-form-view command! user-selection]]
-            [rems.atoms :as atoms]
+            [rems.actions.components :refer [action-attachment action-link comment-field action-form-view command! user-selection perform-action-button]]
             [rems.text :refer [text]]))
 
 (def ^:private action-form-id "request-decision")
@@ -36,12 +35,11 @@
   [{:keys [application-id disabled on-send]}]
   [action-form-view action-form-id
    (text :t.actions/request-decision-from-user)
-   [[atoms/rate-limited-button {:id "request-decision"
-                                :text (text :t.actions/request-decision)
-                                :class "btn-primary"
-                                :on-click on-send
-                                :disabled (or disabled
-                                              @(rf/subscribe [:rems.spa/pending-request :application.command/request-decision]))}]]
+   [[perform-action-button {:id "request-decision"
+                            :text (text :t.actions/request-decision)
+                            :class "btn-primary"
+                            :on-click on-send
+                            :disabled disabled}]]
    [:div
     [user-selection {:field-key action-form-id
                      :subscription [:rems.actions.components/deciders]}]

--- a/src/cljs/rems/actions/request_decision.cljs
+++ b/src/cljs/rems/actions/request_decision.cljs
@@ -40,7 +40,8 @@
                                 :text (text :t.actions/request-decision)
                                 :class "btn-primary"
                                 :on-click on-send
-                                :disabled (or disabled @(rf/subscribe [:rems.spa/pending-request :application.command/request-decision]))}]]
+                                :disabled (or disabled
+                                              @(rf/subscribe [:rems.spa/pending-request :application.command/request-decision]))}]]
    [:div
     [user-selection {:field-key action-form-id
                      :subscription [:rems.actions.components/deciders]}]

--- a/src/cljs/rems/actions/request_decision.cljs
+++ b/src/cljs/rems/actions/request_decision.cljs
@@ -1,6 +1,7 @@
 (ns rems.actions.request-decision
   (:require [re-frame.core :as rf]
-            [rems.actions.components :refer [action-attachment action-link comment-field action-form-view button-wrapper command! user-selection]]
+            [rems.actions.components :refer [action-attachment action-link comment-field action-form-view command! user-selection]]
+            [rems.atoms :as atoms]
             [rems.text :refer [text]]))
 
 (def ^:private action-form-id "request-decision")
@@ -35,11 +36,11 @@
   [{:keys [application-id disabled on-send]}]
   [action-form-view action-form-id
    (text :t.actions/request-decision-from-user)
-   [[button-wrapper {:id "request-decision"
-                     :text (text :t.actions/request-decision)
-                     :class "btn-primary"
-                     :on-click on-send
-                     :disabled disabled}]]
+   [[atoms/rate-limited-button {:id "request-decision"
+                                :text (text :t.actions/request-decision)
+                                :class "btn-primary"
+                                :on-click on-send
+                                :disabled (or disabled @(rf/subscribe [:rems.spa/pending-request :application.command/request-decision]))}]]
    [:div
     [user-selection {:field-key action-form-id
                      :subscription [:rems.actions.components/deciders]}]

--- a/src/cljs/rems/actions/request_review.cljs
+++ b/src/cljs/rems/actions/request_review.cljs
@@ -41,7 +41,8 @@
                                 :text (text :t.actions/request-review)
                                 :class "btn-primary"
                                 :on-click on-send
-                                :disabled (or disabled @(rf/subscribe [:rems.spa/pending-request :application.command/request-review]))}]]
+                                :disabled (or disabled
+                                              @(rf/subscribe [:rems.spa/pending-request :application.command/request-review]))}]]
    [:div
     [user-selection {:field-key action-form-id
                      :subscription [:rems.actions.components/reviewers]}]

--- a/src/cljs/rems/actions/request_review.cljs
+++ b/src/cljs/rems/actions/request_review.cljs
@@ -1,6 +1,7 @@
 (ns rems.actions.request-review
   (:require [re-frame.core :as rf]
-            [rems.actions.components :refer [action-attachment action-button action-link comment-field action-form-view button-wrapper command! user-selection]]
+            [rems.actions.components :refer [action-attachment action-link comment-field action-form-view command! user-selection]]
+            [rems.atoms :as atoms]
             [rems.text :refer [text]]))
 
 (def ^:private action-form-id "request-review")
@@ -36,11 +37,11 @@
   [{:keys [application-id disabled on-send]}]
   [action-form-view action-form-id
    (text :t.actions/request-review-from-user)
-   [[button-wrapper {:id "request-review-button"
-                     :text (text :t.actions/request-review)
-                     :class "btn-primary"
-                     :on-click on-send
-                     :disabled disabled}]]
+   [[atoms/rate-limited-button {:id "request-review-button"
+                                :text (text :t.actions/request-review)
+                                :class "btn-primary"
+                                :on-click on-send
+                                :disabled (or disabled @(rf/subscribe [:rems.spa/pending-request :application.command/request-review]))}]]
    [:div
     [user-selection {:field-key action-form-id
                      :subscription [:rems.actions.components/reviewers]}]

--- a/src/cljs/rems/actions/request_review.cljs
+++ b/src/cljs/rems/actions/request_review.cljs
@@ -1,7 +1,6 @@
 (ns rems.actions.request-review
   (:require [re-frame.core :as rf]
-            [rems.actions.components :refer [action-attachment action-link comment-field action-form-view command! user-selection]]
-            [rems.atoms :as atoms]
+            [rems.actions.components :refer [action-attachment action-link comment-field action-form-view command! user-selection perform-action-button]]
             [rems.text :refer [text]]))
 
 (def ^:private action-form-id "request-review")
@@ -37,12 +36,11 @@
   [{:keys [application-id disabled on-send]}]
   [action-form-view action-form-id
    (text :t.actions/request-review-from-user)
-   [[atoms/rate-limited-button {:id "request-review-button"
-                                :text (text :t.actions/request-review)
-                                :class "btn-primary"
-                                :on-click on-send
-                                :disabled (or disabled
-                                              @(rf/subscribe [:rems.spa/pending-request :application.command/request-review]))}]]
+   [[perform-action-button {:id "request-review-button"
+                            :text (text :t.actions/request-review)
+                            :class "btn-primary"
+                            :on-click on-send
+                            :disabled disabled}]]
    [:div
     [user-selection {:field-key action-form-id
                      :subscription [:rems.actions.components/reviewers]}]

--- a/src/cljs/rems/actions/return_action.cljs
+++ b/src/cljs/rems/actions/return_action.cljs
@@ -1,7 +1,6 @@
 (ns rems.actions.return-action
   (:require [re-frame.core :as rf]
-            [rems.actions.components :refer [action-attachment action-button comment-field action-form-view command!]]
-            [rems.atoms :as atoms]
+            [rems.actions.components :refer [action-attachment action-button comment-field action-form-view command! perform-action-button]]
             [rems.text :refer [text]]))
 
 (def ^:private action-form-id "return")
@@ -33,11 +32,10 @@
   [{:keys [application-id on-send]}]
   [action-form-view action-form-id
    (text :t.actions/return)
-   [[atoms/rate-limited-button {:id "return"
-                                :text (text :t.actions/return)
-                                :class "btn-primary"
-                                :disabled @(rf/subscribe [:rems.spa/pending-request :application.command/return])
-                                :on-click on-send}]]
+   [[perform-action-button {:id "return"
+                            :text (text :t.actions/return)
+                            :class "btn-primary"
+                            :on-click on-send}]]
    [:<>
     [comment-field {:field-key action-form-id
                     :label (text :t.form/add-comments-shown-to-applicant)}]

--- a/src/cljs/rems/actions/return_action.cljs
+++ b/src/cljs/rems/actions/return_action.cljs
@@ -1,6 +1,7 @@
 (ns rems.actions.return-action
   (:require [re-frame.core :as rf]
-            [rems.actions.components :refer [action-attachment action-button comment-field action-form-view button-wrapper command!]]
+            [rems.actions.components :refer [action-attachment action-button comment-field action-form-view command!]]
+            [rems.atoms :as atoms]
             [rems.text :refer [text]]))
 
 (def ^:private action-form-id "return")
@@ -32,10 +33,11 @@
   [{:keys [application-id on-send]}]
   [action-form-view action-form-id
    (text :t.actions/return)
-   [[button-wrapper {:id "return"
-                     :text (text :t.actions/return)
-                     :class "btn-primary"
-                     :on-click on-send}]]
+   [[atoms/rate-limited-button {:id "return"
+                                :text (text :t.actions/return)
+                                :class "btn-primary"
+                                :disabled @(rf/subscribe [:rems.spa/pending-request :application.command/return])
+                                :on-click on-send}]]
    [:<>
     [comment-field {:field-key action-form-id
                     :label (text :t.form/add-comments-shown-to-applicant)}]

--- a/src/cljs/rems/actions/review.cljs
+++ b/src/cljs/rems/actions/review.cljs
@@ -1,6 +1,7 @@
 (ns rems.actions.review
   (:require [re-frame.core :as rf]
-            [rems.actions.components :refer [action-attachment action-button comment-field action-form-view button-wrapper command!]]
+            [rems.actions.components :refer [action-attachment action-button comment-field action-form-view command!]]
+            [rems.atoms :as atoms]
             [rems.text :refer [text]]))
 
 (def ^:private action-form-id "review")
@@ -32,11 +33,11 @@
   [{:keys [application-id disabled on-send]}]
   [action-form-view action-form-id
    (text :t.actions/review)
-   [[button-wrapper {:id "review-button"
-                     :text (text :t.actions/review)
-                     :class "btn-primary"
-                     :disabled disabled
-                     :on-click on-send}]]
+   [[atoms/rate-limited-button {:id "review-button"
+                                :text (text :t.actions/review)
+                                :class "btn-primary"
+                                :disabled (or disabled @(rf/subscribe [:rems.spa/pending-request :application.command/review]))
+                                :on-click on-send}]]
    [:<>
     [comment-field {:field-key action-form-id
                     :label (text :t.form/add-comments-not-shown-to-applicant)}]

--- a/src/cljs/rems/actions/review.cljs
+++ b/src/cljs/rems/actions/review.cljs
@@ -1,7 +1,6 @@
 (ns rems.actions.review
   (:require [re-frame.core :as rf]
-            [rems.actions.components :refer [action-attachment action-button comment-field action-form-view command!]]
-            [rems.atoms :as atoms]
+            [rems.actions.components :refer [action-attachment action-button comment-field action-form-view command! perform-action-button]]
             [rems.text :refer [text]]))
 
 (def ^:private action-form-id "review")
@@ -33,12 +32,11 @@
   [{:keys [application-id disabled on-send]}]
   [action-form-view action-form-id
    (text :t.actions/review)
-   [[atoms/rate-limited-button {:id "review-button"
-                                :text (text :t.actions/review)
-                                :class "btn-primary"
-                                :disabled (or disabled
-                                              @(rf/subscribe [:rems.spa/pending-request :application.command/review]))
-                                :on-click on-send}]]
+   [[perform-action-button {:id "review-button"
+                            :text (text :t.actions/review)
+                            :class "btn-primary"
+                            :disabled disabled
+                            :on-click on-send}]]
    [:<>
     [comment-field {:field-key action-form-id
                     :label (text :t.form/add-comments-not-shown-to-applicant)}]

--- a/src/cljs/rems/actions/review.cljs
+++ b/src/cljs/rems/actions/review.cljs
@@ -36,7 +36,8 @@
    [[atoms/rate-limited-button {:id "review-button"
                                 :text (text :t.actions/review)
                                 :class "btn-primary"
-                                :disabled (or disabled @(rf/subscribe [:rems.spa/pending-request :application.command/review]))
+                                :disabled (or disabled
+                                              @(rf/subscribe [:rems.spa/pending-request :application.command/review]))
                                 :on-click on-send}]]
    [:<>
     [comment-field {:field-key action-form-id

--- a/src/cljs/rems/actions/revoke.cljs
+++ b/src/cljs/rems/actions/revoke.cljs
@@ -1,7 +1,6 @@
 (ns rems.actions.revoke
   (:require [re-frame.core :as rf]
-            [rems.actions.components :refer [action-attachment action-button comment-field action-form-view command!]]
-            [rems.atoms :as atoms]
+            [rems.actions.components :refer [action-attachment action-button comment-field action-form-view command! perform-action-button]]
             [rems.text :refer [text]]))
 
 (def ^:private action-form-id "revoke")
@@ -33,11 +32,10 @@
   [{:keys [application-id on-send]}]
   [action-form-view action-form-id
    (text :t.actions/revoke)
-   [[atoms/rate-limited-button {:id "revoke"
-                                :text (text :t.actions/revoke)
-                                :class "btn-danger"
-                                :disabled @(rf/subscribe [:rems.spa/pending-request :application.command/revoke])
-                                :on-click on-send}]]
+   [[perform-action-button {:id "revoke"
+                            :text (text :t.actions/revoke)
+                            :class "btn-danger"
+                            :on-click on-send}]]
    [:<>
     [comment-field {:field-key action-form-id
                     :label (text :t.form/add-comments-shown-to-applicant)}]

--- a/src/cljs/rems/actions/revoke.cljs
+++ b/src/cljs/rems/actions/revoke.cljs
@@ -1,6 +1,7 @@
 (ns rems.actions.revoke
   (:require [re-frame.core :as rf]
-            [rems.actions.components :refer [action-attachment action-button comment-field action-form-view button-wrapper command!]]
+            [rems.actions.components :refer [action-attachment action-button comment-field action-form-view command!]]
+            [rems.atoms :as atoms]
             [rems.text :refer [text]]))
 
 (def ^:private action-form-id "revoke")
@@ -32,10 +33,11 @@
   [{:keys [application-id on-send]}]
   [action-form-view action-form-id
    (text :t.actions/revoke)
-   [[button-wrapper {:id "revoke"
-                     :text (text :t.actions/revoke)
-                     :class "btn-danger"
-                     :on-click on-send}]]
+   [[atoms/rate-limited-button {:id "revoke"
+                                :text (text :t.actions/revoke)
+                                :class "btn-danger"
+                                :disabled @(rf/subscribe [:rems.spa/pending-request :application.command/revoke])
+                                :on-click on-send}]]
    [:<>
     [comment-field {:field-key action-form-id
                     :label (text :t.form/add-comments-shown-to-applicant)}]

--- a/src/cljs/rems/actions/vote.cljs
+++ b/src/cljs/rems/actions/vote.cljs
@@ -4,7 +4,8 @@
             [goog.string.format]
             [re-frame.core :as rf]
             [reagent.core :as rc]
-            [rems.actions.components :refer [action-attachment action-button comment-field action-form-view button-wrapper command!]]
+            [rems.actions.components :refer [action-attachment action-button comment-field action-form-view command!]]
+            [rems.atoms :as atoms]
             [rems.common.application-util :as application-util]
             [rems.common.util :refer [build-index]]
             [rems.dropdown :as dropdown]
@@ -58,11 +59,11 @@
   [{:keys [application-id previous-vote disabled vote on-vote on-send]}]
   [action-form-view action-form-id
    (text :t.actions/vote)
-   [[button-wrapper {:id "vote-button"
-                     :text (text :t.actions/vote)
-                     :class "btn-primary"
-                     :disabled disabled
-                     :on-click on-send}]]
+   [[atoms/rate-limited-button {:id "vote-button"
+                                :text (text :t.actions/vote)
+                                :class "btn-primary"
+                                :disabled (or disabled @(rf/subscribe [:rems.spa/pending-request :application.command/vote]))
+                                :on-click on-send}]]
    [:<>
     (when previous-vote
       (text-format :t.applications.voting/previously-voted

--- a/src/cljs/rems/actions/vote.cljs
+++ b/src/cljs/rems/actions/vote.cljs
@@ -4,8 +4,7 @@
             [goog.string.format]
             [re-frame.core :as rf]
             [reagent.core :as rc]
-            [rems.actions.components :refer [action-attachment action-button comment-field action-form-view command!]]
-            [rems.atoms :as atoms]
+            [rems.actions.components :refer [action-attachment action-button comment-field action-form-view command! perform-action-button]]
             [rems.common.application-util :as application-util]
             [rems.common.util :refer [build-index]]
             [rems.dropdown :as dropdown]
@@ -59,11 +58,11 @@
   [{:keys [application-id previous-vote disabled vote on-vote on-send]}]
   [action-form-view action-form-id
    (text :t.actions/vote)
-   [[atoms/rate-limited-button {:id "vote-button"
-                                :text (text :t.actions/vote)
-                                :class "btn-primary"
-                                :disabled (or disabled @(rf/subscribe [:rems.spa/pending-request :application.command/vote]))
-                                :on-click on-send}]]
+   [[perform-action-button {:id "vote-button"
+                            :text (text :t.actions/vote)
+                            :class "btn-primary"
+                            :disabled disabled
+                            :on-click on-send}]]
    [:<>
     (when previous-vote
       (text-format :t.applications.voting/previously-voted

--- a/src/cljs/rems/administration/blacklist.cljs
+++ b/src/cljs/rems/administration/blacklist.cljs
@@ -180,7 +180,8 @@
         {:id :blacklist-add
          :class "btn-primary"
          :type :submit
-         :text (text :t.administration/add)}]]]]))
+         :text (text :t.administration/add)
+         :disabled @(rf/subscribe [:rems.spa/any-pending-request?])}]]]]))
 
 (defn add-user-form [resource]
   [roles/show-when +blacklist-add-roles+ [add-user-form-impl resource]])

--- a/src/cljs/rems/administration/blacklist.cljs
+++ b/src/cljs/rems/administration/blacklist.cljs
@@ -36,8 +36,7 @@
  (fn [{:keys [db]} [_ resource user comment]]
    (let [description [text :t.administration/add]]
      (post! "/api/blacklist/add"
-            {:rems/request-id ::request-id
-             :params {:blacklist/resource (select-keys resource [:resource/ext-id])
+            {:params {:blacklist/resource (select-keys resource [:resource/ext-id])
                       :blacklist/user (select-keys user [:userid])
                       :comment (or comment "")}
              :handler (flash-message/default-success-handler
@@ -56,8 +55,7 @@
  (fn [{:keys [db]} [_ resource user comment]]
    (let [description [text :t.administration/remove]]
      (post! "/api/blacklist/remove"
-            {:rems/request-id ::request-id
-             :params {:blacklist/resource (select-keys resource [:resource/ext-id])
+            {:params {:blacklist/resource (select-keys resource [:resource/ext-id])
                       :blacklist/user (select-keys user [:userid])
                       :comment (or comment "")}
              :handler (flash-message/default-success-handler
@@ -181,7 +179,8 @@
         {:id :blacklist-add
          :class "btn-primary"
          :type :submit
-         :disabled @(rf/subscribe [:rems.spa/pending-request ::request-id])
+         :disabled @(rf/subscribe [:rems.spa/any-pending-request #{"/api/blacklist/add"
+                                                                   "/api/blacklist/remove"}])
          :text (text :t.administration/add)}]]]]))
 
 (defn add-user-form [resource]
@@ -190,7 +189,8 @@
 (defn- remove-button [resource user]
   [atoms/rate-limited-button
    {:class "btn-secondary button-min-width"
-    :disabled @(rf/subscribe [:rems.spa/pending-request ::request-id])
+    :disabled @(rf/subscribe [:rems.spa/any-pending-request #{"/api/blacklist/add"
+                                                              "/api/blacklist/remove"}])
     :on-click (fn [_event]
                 ;; TODO add form & field for comment
                 (rf/dispatch [::remove-from-blacklist resource user ""]))

--- a/src/cljs/rems/administration/blacklist.cljs
+++ b/src/cljs/rems/administration/blacklist.cljs
@@ -10,7 +10,7 @@
             [rems.common.roles :as roles]
             [rems.spinner :as spinner]
             [rems.table :as table]
-            [rems.text :refer [text text-format localize-time]]
+            [rems.text :refer [text localize-time]]
             [rems.util :refer [fetch post!]]))
 
 (def +blacklist-add-roles+ #{:owner :handler}) ;; same roles as in rems.api.blacklist
@@ -142,17 +142,7 @@
         comment-field-id "blacklist-comment"
         selected-user @(rf/subscribe [::selected-user])
         comment @(rf/subscribe [::comment])]
-    [:form
-     {:on-submit (fn [event]
-                   (.preventDefault event)
-                   (if-some [errors (cond-> nil
-                                      (nil? selected-user) (assoc :user [#(text-format :t.form.validation/required
-                                                                                       (text :t.administration/user))]))]
-                     (do
-                       (rf/dispatch [::set-validation-errors errors])
-                       (.focus (js/document.getElementById user-field-id)))
-                     (rf/dispatch [::add-to-blacklist resource selected-user comment])))}
-
+    [:div
      [:div.form-group.row
       [:label.col-sm-1.col-form-label
        {:for user-field-id}
@@ -179,9 +169,9 @@
        [perform-action-button
         {:id :blacklist-add
          :class "btn-primary"
-         :type :submit
+         :on-click #(rf/dispatch [::add-to-blacklist resource selected-user comment])
          :text (text :t.administration/add)
-         :disabled @(rf/subscribe [:rems.spa/any-pending-request?])}]]]]))
+         :disabled (nil? selected-user)}]]]]))
 
 (defn add-user-form [resource]
   [roles/show-when +blacklist-add-roles+ [add-user-form-impl resource]])

--- a/src/cljs/rems/administration/blacklist.cljs
+++ b/src/cljs/rems/administration/blacklist.cljs
@@ -2,6 +2,7 @@
   "Implements both a blacklist component and the blacklist-page"
   (:require [re-frame.core :as rf]
             [rems.administration.administration :as administration]
+            [rems.administration.components :refer [perform-action-button]]
             [rems.common.application-util]
             [rems.atoms :as atoms]
             [rems.dropdown :as dropdown]
@@ -175,22 +176,18 @@
      [:div.form-group.row
       [:div.col-sm-1]
       [:div.col-sm-6
-       [atoms/rate-limited-button
+       [perform-action-button
         {:id :blacklist-add
          :class "btn-primary"
          :type :submit
-         :disabled @(rf/subscribe [:rems.spa/any-pending-request #{"/api/blacklist/add"
-                                                                   "/api/blacklist/remove"}])
          :text (text :t.administration/add)}]]]]))
 
 (defn add-user-form [resource]
   [roles/show-when +blacklist-add-roles+ [add-user-form-impl resource]])
 
 (defn- remove-button [resource user]
-  [atoms/rate-limited-button
+  [perform-action-button
    {:class "btn-secondary button-min-width"
-    :disabled @(rf/subscribe [:rems.spa/any-pending-request #{"/api/blacklist/add"
-                                                              "/api/blacklist/remove"}])
     :on-click (fn [_event]
                 ;; TODO add form & field for comment
                 (rf/dispatch [::remove-from-blacklist resource user ""]))

--- a/src/cljs/rems/administration/components.cljs
+++ b/src/cljs/rems/administration/components.cljs
@@ -15,7 +15,7 @@
     :label  - String, shown to the user as-is."
   (:require [clojure.string :as str]
             [re-frame.core :as rf]
-            [rems.atoms :refer [info-field textarea]]
+            [rems.atoms :as atoms :refer [info-field textarea]]
             [rems.collapsible :as collapsible]
             [rems.dropdown :as dropdown]
             [rems.fields :as fields]
@@ -345,3 +345,9 @@
                                                        new-value])
                                          (on-change new-value))}]
      [field-validation-message (get-in form-errors keys) label]]))
+
+(defn perform-action-button [{:keys [loading?] :as props}]
+  [atoms/rate-limited-button
+   (-> props
+       (dissoc (when (or loading? @(rf/subscribe [:rems.spa/any-pending-request?]))
+                 :on-click)))])

--- a/src/cljs/rems/application.cljs
+++ b/src/cljs/rems/application.cljs
@@ -1021,7 +1021,7 @@
   (let [app-id (:application/id application)
         show-comment-field? (is-handling-user? application)
         actions (action-buttons application config)
-        reload (partial reload! app-id)
+        reload (r/partial reload! app-id)
         go-to-catalogue #(do (flash-message/show-default-success! :top [text :t.actions/delete])
                              (navigate! "/catalogue"))]
     (when (seq actions)

--- a/src/cljs/rems/application.cljs
+++ b/src/cljs/rems/application.cljs
@@ -244,8 +244,7 @@
 (defn- save-draft! [description application edit-application handler & [{:keys [error-handler]}]]
   (flash-message/clear-message! :actions)
   (post! "/api/applications/save-draft"
-         {:rems/request-id ::save-draft
-          :params {:application-id (:application/id application)
+         {:params {:application-id (:application/id application)
                    :field-values (field-values-to-api application (:field-values edit-application))
                    :duo-codes (duo-codes-to-api (vals (:duo-codes edit-application)))}
           :handler handler
@@ -307,8 +306,7 @@
                     (if-not (:success response)
                       (handle-validations! response description application)
                       (post! "/api/applications/submit"
-                             {:rems/request-id ::submit
-                              :params {:application-id (:application/id application)}
+                             {:params {:application-id (:application/id application)}
                               :handler (fn [response]
                                          (handle-validations!
                                           response
@@ -326,8 +324,7 @@
    (let [application-id (get-in db [::application :data :application/id])
          description [text :t.form/copy-as-new]]
      (post! "/api/applications/copy-as-new"
-            {:rems/request-id ::copy-as-new
-             :params {:application-id application-id}
+            {:params {:application-id application-id}
              :handler (flash-message/default-success-handler
                        :top ; the message will be shown on the new application's page
                        description
@@ -509,20 +506,26 @@
 (defn- save-button []
   [atoms/rate-limited-button {:id "save"
                               :text (text :t.form/save)
-                              :disabled @(rf/subscribe [:rems.spa/pending-request ::save-draft])
+                              :disabled @(rf/subscribe [:rems.spa/any-pending-request #{"/api/applications/save-draft"
+                                                                                        "/api/applications/submit"
+                                                                                        "/api/applications/copy-as-new"}])
                               :on-click #(rf/dispatch [::save-application [text :t.form/save]])}])
 
 (defn- submit-button []
   [atoms/rate-limited-button {:id "submit"
                               :text (text :t.form/submit)
                               :class :btn-primary
-                              :disabled @(rf/subscribe [:rems.spa/pending-request ::submit])
+                              :disabled @(rf/subscribe [:rems.spa/any-pending-request #{"/api/applications/save-draft"
+                                                                                        "/api/applications/submit"
+                                                                                        "/api/applications/copy-as-new"}])
                               :on-click #(rf/dispatch [::submit-application [text :t.form/submit]])}])
 
 (defn- copy-as-new-button []
   [atoms/rate-limited-button {:id "copy-as-new"
                               :text (text :t.form/copy-as-new)
-                              :disabled @(rf/subscribe [:rems.spa/pending-request ::copy-as-new])
+                              :disabled @(rf/subscribe [:rems.spa/any-pending-request #{"/api/applications/save-draft"
+                                                                                        "/api/applications/submit"
+                                                                                        "/api/applications/copy-as-new"}])
                               :on-click #(rf/dispatch [::copy-as-new-application])}])
 
 (rf/reg-sub

--- a/src/cljs/rems/spa.cljs
+++ b/src/cljs/rems/spa.cljs
@@ -212,14 +212,9 @@
    {}))
 
 (rf/reg-sub
- :rems.spa/pending-request
- (fn [db [_ k]]
-   (get-in db [:rems.spa/request k])))
-
-(rf/reg-sub
- :rems.spa/any-pending-request
- (fn [db [_ ks]]
-   (some #(get-in db [:rems.spa/request %]) ks)))
+ :rems.spa/any-pending-request?
+ (fn [db _]
+   (some? (not-empty (:rems.spa/request db)))))
 
 (rf/reg-event-db
  :rems.spa/on-request

--- a/src/cljs/rems/spa.cljs
+++ b/src/cljs/rems/spa.cljs
@@ -3,6 +3,7 @@
             [clojure.string :as str]
             [goog.events :as events]
             [goog.history.EventType :as HistoryEventType]
+            [medley.core :refer [dissoc-in]]
             [re-frame.core :as rf]
             [reagent.core :as r]
             [reagent.dom :as rd]
@@ -57,7 +58,7 @@
             [rems.profile :refer [profile-page missing-email-warning]]
             [rems.text :refer [text text-format]]
             [rems.user-settings]
-            [rems.util :refer [navigate! fetch replace-url! set-location!]]
+            [rems.util :refer [fetch navigate! replace-url! set-location!]]
             [secretary.core :as secretary])
   (:import goog.history.Html5History))
 
@@ -209,6 +210,21 @@
      (on-loaded)
      (.setTimeout js/window #(rf/dispatch [:after-translations-are-loaded on-loaded]) 100))
    {}))
+
+(rf/reg-sub
+ :rems.spa/pending-request
+ (fn [db [_ k]]
+   (get-in db [:rems.spa/request k])))
+
+(rf/reg-event-db
+ :rems.spa/on-request
+ (fn [db [_ k]]
+   (assoc-in db [:rems.spa/request k] true)))
+
+(rf/reg-event-db
+ :rems.spa/on-request-finished
+ (fn [db [_ k]]
+   (dissoc-in db [:rems.spa/request k])))
 
 ;;;; Pages
 (defn login-intro []

--- a/src/cljs/rems/spa.cljs
+++ b/src/cljs/rems/spa.cljs
@@ -216,6 +216,11 @@
  (fn [db [_ k]]
    (get-in db [:rems.spa/request k])))
 
+(rf/reg-sub
+ :rems.spa/any-pending-request
+ (fn [db [_ ks]]
+   (some #(get-in db [:rems.spa/request %]) ks)))
+
 (rf/reg-event-db
  :rems.spa/on-request
  (fn [db [_ k]]

--- a/src/cljs/rems/util.cljs
+++ b/src/cljs/rems/util.cljs
@@ -2,9 +2,10 @@
   (:require [accountant.core :as accountant]
             [ajax.core :refer [GET PUT POST]]
             [clojure.string :as str]
+            [clojure.test :refer [deftest are testing]]
             [goog.string :refer [format]]
-            [re-frame.core :as rf]
-            [clojure.test :refer [deftest are testing]]))
+            [medley.core :refer [update-existing]]
+            [re-frame.core :as rf]))
 
 ;; TODO move to cljc
 (defn getx
@@ -58,53 +59,90 @@
             true)
       false)))
 
-(defn- wrap-default-error-handler [handler]
-  (fn [err]
-    (when-not (redirect-when-unauthorized-or-forbidden! err)
+(defn- wrap-default-error-handler [handler opts]
+  (cond
+    (:custom-error-handler? opts)
+    handler
+
+    :else
+    (fn [err]
+      (when-not (redirect-when-unauthorized-or-forbidden! err)
+        (when handler
+          (handler err))))))
+
+(defn- wrap-default-finally-handler [handler opts]
+  (cond
+    (:rems/request-id opts)
+    (fn []
+      (rf/dispatch [:rems.spa/on-request-finished (:rems/request-id opts)])
       (when handler
-        (handler err)))))
+        (handler)))
+
+    :else
+    handler))
+
+(defn- wrap-default-handlers [opts]
+  (-> opts
+      (update :error-handler wrap-default-error-handler opts)
+      (update :finally wrap-default-finally-handler opts)))
+
+(defn- save-request-id [opts]
+  (when-some [id (:rems/request-id opts)]
+    (rf/dispatch [:rems.spa/on-request id])))
 
 (defn fetch
   "Fetches data from the given url with optional map of options like #'ajax.core/GET.
 
   Has sensible defaults with error handler, JSON and keywords.
-  You can use :custom-error-handler? to decide weather you would like use wrapper for the error handling.
+
+  Default error handler redirects when request was unauthorized or forbidden, and only calls
+  given error handler if neither is the case. This behaviour can be omitted by passing
+  `:custom-error-handler? true` in `opts`.
 
   Additionally calls event hooks."
   [url opts]
   (js/window.rems.hooks.get url (clj->js opts))
-  (GET url (-> (merge {:response-format :transit
-                       :handler (fn [])}
-                      opts
-                      (if (:custom-error-handler? opts)
-                        {:error-handler (:error-handler opts)}
-                        {:error-handler (wrap-default-error-handler (:error-handler opts))})))))
+  (save-request-id opts)
+  (let [fetch-defaults {:response-format :transit
+                        :handler (constantly nil)}]
+    (GET url (merge fetch-defaults
+                    (wrap-default-handlers opts)))))
 
 (defn put!
   "Dispatches a command to the given url with optional map of options like #'ajax.core/PUT.
 
   Has sensible defaults with error handler, JSON and keywords.
 
+  Default error handler redirects when request was unauthorized or forbidden, and only calls
+  given error handler if neither is the case. This behaviour can be omitted by passing
+  `:custom-error-handler? true` in `opts`.
+
   Additionally calls event hooks."
   [url opts]
   (js/window.rems.hooks.put url (clj->js opts))
-  (PUT url (merge {:format :transit
-                   :response-format :transit}
-                  opts
-                  {:error-handler (wrap-default-error-handler (:error-handler opts))})))
+  (save-request-id opts)
+  (let [put-defaults {:format :transit
+                      :response-format :transit}]
+    (PUT url (merge put-defaults
+                    (wrap-default-handlers opts)))))
 
 (defn post!
   "Dispatches a command to the given url with optional map of options like #'ajax.core/POST.
 
   Has sensible defaults with error handler, JSON and keywords.
 
+  Default error handler redirects when request was unauthorized or forbidden, and only calls
+  given error handler if neither is the case. This behaviour can be omitted by passing
+  `:custom-error-handler? true` in `opts`.
+
   Additionally calls event hooks."
   [url opts]
   (js/window.rems.hooks.put url (clj->js opts))
-  (POST url (merge {:format :transit
-                    :response-format :transit}
-                   opts
-                   {:error-handler (wrap-default-error-handler (:error-handler opts))})))
+  (save-request-id opts)
+  (let [post-defaults {:format :transit
+                       :response-format :transit}]
+    (POST url (merge post-defaults
+                     (wrap-default-handlers opts)))))
 
 ;; String manipulation
 

--- a/src/cljs/rems/util.cljs
+++ b/src/cljs/rems/util.cljs
@@ -71,7 +71,8 @@
 
 (defn- wrap-default-finally-handler [handler {:keys [request-id]}]
   (fn []
-    (rf/dispatch [:rems.spa/on-request-finished request-id])
+    (when request-id
+      (rf/dispatch [:rems.spa/on-request-finished request-id]))
     (when handler
       (handler))))
 
@@ -92,10 +93,8 @@
   Additionally calls event hooks."
   [url opts]
   (let [fetch-defaults {:response-format :transit
-                        :handler (constantly nil)}
-        opts (update opts :request-id (fnil identity url))]
+                        :handler (constantly nil)}]
     (js/window.rems.hooks.get url (clj->js opts))
-    (rf/dispatch [:rems.spa/on-request (:request-id opts)])
     (GET url (merge fetch-defaults
                     (wrap-default-handlers opts)))))
 


### PR DESCRIPTION
implements #3204

rems.atoms/rate-limited-button wraps click handler and allows only 1 click every 2 seconds. `perform-action-button` wraps this and additionally subscribes to `rems.spa/any-pending-request?` to wait until any put/post requests are done. This should prevent repeated clicking which creates duplicate requests to API

`rems.actions.*` [accept-licenses add-licenses add-member approve-reject assign-external-id change-applicant change-resources close decide delete invite-decider-reviewer invite-member redact-attachments remove-member request-decision request-review return-action review revoke vote]
`rems.administration.blacklist`
`rems.application.*` [save-draft submit copy-as-new]

# Checklist for author

Remove items that aren't applicable, check items that are done.

## Reviewability
- [x] Link to issue

## Documentation
- [x] Update changelog if necessary
- [x] Components are added to guide page

## Follow-up
- [ ] New tasks are created for pending or remaining tasks
