### PR TITLE
Release 2.34.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,12 @@ have notable changes.
 
 ## Unreleased
 
-Changes since v2.34.1
+Changes since v2.34.2
+
+## v2.34.2 "Santakatu +2" 2023-11-03
+
+### Fixes
+- DUO codes in draft saved event no longer cause schema validation error when `:enable-duo` config is false.
 
 ## v2.34.1 "Santakatu +1" 2023-11-03
 

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject rems "2.34.1"
+(defproject rems "2.34.2"
   :description "Resource Entitlement Management System is a tool for managing access rights to resources, such as research datasets."
   :url "https://github.com/CSCfi/rems"
 

--- a/src/clj/rems/api/schema.clj
+++ b/src/clj/rems/api/schema.clj
@@ -218,6 +218,15 @@
 (s/defschema Permissions
   #{(apply s/enum (conj commands/command-names :see-everything))})
 
+(s/defschema DuoCodeMatch
+  {:duo/id s/Str
+   :duo/shorthand s/Str
+   :duo/label {s/Keyword s/Any}
+   :resource/id s/Int
+   :duo/validation {:validity s/Keyword
+                    (s/optional-key :errors) [{:type s/Keyword
+                                               s/Keyword s/Any}]}})
+
 (s/defschema Application
   {:application/id s/Int
    :application/external-id (rjs/field
@@ -267,13 +276,7 @@
    (s/optional-key :entitlement/end) (s/maybe DateTime)
    (s/optional-key :application/votes) {schema-base/UserId s/Str}
    (s/optional-key :application/duo) {(s/optional-key :duo/codes) [schema-base/DuoCodeFull]
-                                      :duo/matches [{:duo/id s/Str
-                                                     :duo/shorthand s/Str
-                                                     :duo/label {s/Keyword s/Any}
-                                                     :resource/id s/Int
-                                                     :duo/validation {:validity s/Keyword
-                                                                      (s/optional-key :errors) [{:type s/Keyword
-                                                                                                 s/Keyword s/Any}]}}]}})
+                                      (s/optional-key :duo/matches) [DuoCodeMatch]}})
 
 (s/defschema ApplicationRaw
   (-> Application


### PR DESCRIPTION
Contains fix to issue where previously added duo codes would fail schema validation when config `:enable-duo` was false.