### PR TITLE
fix: do not require form in catalogue item dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ have notable changes.
 
 Changes since v2.34.2
 
+### Fixes
+- Catalogue item unarchive should no longer fail when form does not exist. (#3217)
+
 ## v2.34.2 "Santakatu +2" 2023-11-03
 
 ### Fixes

--- a/test/clj/rems/service/test_dependencies.clj
+++ b/test/clj/rems/service/test_dependencies.clj
@@ -44,7 +44,10 @@
                                                     :categories [{:category/id category-1}]})
         cat-2 (test-helpers/create-catalogue-item! {:resource-id res-1
                                                     :form-id shared-form
-                                                    :workflow-id wf-2})]
+                                                    :workflow-id wf-2})
+        cat-without-form (test-helpers/create-catalogue-item! {:resource-id res-1
+                                                               :form-id nil
+                                                               :workflow-id wf-2})]
 
     (testing "dependencies"
       (is (= {:dependencies
@@ -78,6 +81,9 @@
                                             {:form/id shared-form}
                                             {:workflow/id wf-2}
                                             {:organization/id "default"}}
+               {:catalogue-item/id cat-without-form} #{{:resource/id res-1}
+                                                       {:workflow/id wf-2}
+                                                       {:organization/id "default"}}
                {:category/id category-2} #{{:category/id category-1}}}
               :reverse-dependencies
               {{:license/id shared-license} #{{:resource/id res-1}
@@ -87,16 +93,19 @@
                                                        {:resource/id res-2}}
                {:license/id resource-license} #{{:resource/id res-2}}
                {:resource/id res-1} #{{:catalogue-item/id cat-1}
-                                      {:catalogue-item/id cat-2}}
+                                      {:catalogue-item/id cat-2}
+                                      {:catalogue-item/id cat-without-form}}
                {:form/id shared-form} #{{:workflow/id wf-1}
                                         {:workflow/id wf-2}
                                         {:catalogue-item/id cat-2}}
                {:form/id cat-form} #{{:catalogue-item/id cat-1}}
                {:form/id wf-form} #{{:workflow/id wf-2}}
                {:workflow/id wf-1} #{{:catalogue-item/id cat-1}}
-               {:workflow/id wf-2} #{{:catalogue-item/id cat-2}}
+               {:workflow/id wf-2} #{{:catalogue-item/id cat-2}
+                                     {:catalogue-item/id cat-without-form}}
                {:organization/id "default"} #{{:catalogue-item/id cat-1}
                                               {:catalogue-item/id cat-2}
+                                              {:catalogue-item/id cat-without-form}
                                               {:form/id shared-form}
                                               {:form/id wf-form}
                                               {:form/id cat-form}


### PR DESCRIPTION
fixes #3217 

Form can be nil because it is optional, but it should not fail unarchive operation on catalogue item.

# Checklist for author

Remove items that aren't applicable, check items that are done.

## Reviewability
- [x] Link to issue

## Documentation
- [x] Update changelog if necessary

## Testing
- [x] Complex logic is unit tested
