### PR TITLE
Wider action link click area in dropdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ have notable changes.
 
 Changes since v2.34.2
 
+### Fixes
+- Administration dropdown buttons should now respond to clicks more widely, and not only by directly clicking text. (#3167)
+
 ## v2.34.2 "Santakatu +2" 2023-11-03
 
 ### Fixes

--- a/src/cljs/rems/atoms.cljs
+++ b/src/cljs/rems/atoms.cljs
@@ -324,7 +324,7 @@
          :label (:label action)
          :href (:url action)
          :on-click (:on-click action)
-         :class (str "dropdown-item btn btn-link py-2 " (:class action))}])
+         :class (str/trim (str "btn btn-link " (:class action)))}])
 
 (defn edit-action
   "Standard edit action helper."
@@ -365,7 +365,7 @@
         label]
        (into [:div.dropdown-menu.dropdown-menu-right]
              (for [action actions]
-               [action-link action]))])))
+               [action-link (update action :class #(str "dropdown-item py-2 " %))]))])))
 
 (defn guide []
   (let [state (r/atom false)

--- a/src/cljs/rems/atoms.cljs
+++ b/src/cljs/rems/atoms.cljs
@@ -324,7 +324,7 @@
          :label (:label action)
          :href (:url action)
          :on-click (:on-click action)
-         :class (str "btn btn-link " (:class action))}])
+         :class (str "dropdown-item btn btn-link py-2 " (:class action))}])
 
 (defn edit-action
   "Standard edit action helper."
@@ -363,11 +363,9 @@
        [:button.modify-dropdown.btn.btn-secondary.dropdown-toggle
         {:data-toggle :dropdown}
         label]
-       [:div.dropdown-menu.dropdown-menu-right
-        (into [:div.d-flex.flex-column]
-              (for [action actions]
-                [:div.dropdown-item
-                 [action-link action]]))]])))
+       (into [:div.dropdown-menu.dropdown-menu-right]
+             (for [action actions]
+               [action-link action]))])))
 
 (defn guide []
   (let [state (r/atom false)


### PR DESCRIPTION
fixes #3167 

Bootstrap examples use dropdown-item class directly in anchor link, and that is now implemented in `atoms/action-link`.

`atoms/action-link` seems to lose underlining in this process, but it is only used in the dropdown (other action-links found by grep reference `actions/components`), so maybe it is not needed?

https://github.com/CSCfi/rems/assets/794087/edc511ae-3122-4cd7-b9b1-ef2f47b3b1c2

# Checklist for author

Remove items that aren't applicable, check items that are done.

## Reviewability
- [x] Link to issue
- [x] Consider adding screenshots for ease of review (quicktime recording)

## Documentation
- [x] Update changelog if necessary
