### PR TITLE
Application expiration improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,13 +11,13 @@ Changes since v2.34.2
 **NB: This release removes the experimental application PDF export API. The non-experimental PDF export API is preferred instead. (#3098)**
 
 ### Changes
-- Application expiration now logs before each delete and send expiration notifications command. Additionally application delete is logged afterwards.
+- Application expiration now logs before each delete and send expiration notifications command. Additionally application delete is logged afterwards. (#3225)
 
 ### Fixes
 - Administration dropdown buttons should now respond to clicks more widely, and not only by directly clicking text. (#3167)
 - Catalogue item unarchive should no longer fail when form does not exist. (#3217)
 - Current page updates correctly. (#3218)
-- Fixed faulty check in application expiration that prevents sending expiration notifications for applications, and expiring those applications.
+- Fixed faulty check in application expiration that prevents sending expiration notifications for applications, and expiring those applications. (#3225)
 
 ## v2.34.2 "Santakatu +2" 2023-11-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,13 +11,16 @@ Changes since v2.34.2
 **NB: This release removes the experimental application PDF export API. The non-experimental PDF export API is preferred instead. (#3098)**
 
 ### Changes
-- Application expiration now logs before each delete and send expiration notifications command. Additionally application delete is logged afterwards. (#3225)
+- Application expiration now logs more, and more often. (#3225)
 
 ### Fixes
 - Administration dropdown buttons should now respond to clicks more widely, and not only by directly clicking text. (#3167)
 - Catalogue item unarchive should no longer fail when form does not exist. (#3217)
 - Current page updates correctly. (#3218)
 - Fixed faulty check in application expiration that prevents sending expiration notifications for applications, and expiring those applications. (#3225)
+
+### Additions
+- Application expiration can be configured with `:application-expiration-process-limit` to process a subset of applications instead of everything at once. (#3225)
 
 ## v2.34.2 "Santakatu +2" 2023-11-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,14 @@ Changes since v2.34.2
 
 **NB: This release removes the experimental application PDF export API. The non-experimental PDF export API is preferred instead. (#3098)**
 
+### Changes
+- Application expiration now logs before each delete and send expiration notifications command. Additionally application delete is logged afterwards.
+
 ### Fixes
 - Administration dropdown buttons should now respond to clicks more widely, and not only by directly clicking text. (#3167)
 - Catalogue item unarchive should no longer fail when form does not exist. (#3217)
 - Current page updates correctly. (#3218)
+- Fixed faulty check in application expiration that prevents sending expiration notifications for applications, and expiring those applications.
 
 ## v2.34.2 "Santakatu +2" 2023-11-03
 

--- a/project.clj
+++ b/project.clj
@@ -2,7 +2,8 @@
   :description "Resource Entitlement Management System is a tool for managing access rights to resources, such as research datasets."
   :url "https://github.com/CSCfi/rems"
 
-  :dependencies [[buddy/buddy-auth "3.0.323"]
+  :dependencies [[better-cond "2.1.5"]
+                 [buddy/buddy-auth "3.0.323"]
                  [buddy/buddy-sign "3.4.333"]
                  [ch.qos.logback/logback-classic "1.4.5"]
                  [clj-http "3.12.3"]

--- a/resources/config-defaults.edn
+++ b/resources/config-defaults.edn
@@ -395,6 +395,10 @@
  ;; https://en.wikipedia.org/wiki/ISO_8601#Durations for duration formatting reference.
  :application-expiration nil
 
+ ;; How many applications may application expiration process at a time?
+ ;; defaults to 50
+ :application-expiration-process-limit nil
+
  ;; enable /api/permissions/:user
  ;; see also docs/ga4gh-visas.md
  :enable-permissions-api false
@@ -468,7 +472,7 @@
  :plugins nil ; by default no plugins
  :extension-points nil ; by default no plugins
  :enable-voting false ; voting (experimental)
- 
+
  ;; If `:scanner-path` is defined, it is assumed to be an executable that:
  ;; can take a binary file from `STDIN` and return a status code of zero if and only if the file passes the scan.
  ;;
@@ -502,7 +506,7 @@
  ;;   :rems.application/previous-applications-except-current
  ;;   :rems.applications/my-applications
  ;;   :rems.applications/all-applications
- 
+
  :tables {}
 
  ;; REMS can be configured to avoid heavy work

--- a/src/clj/rems/application/commands.clj
+++ b/src/clj/rems/application/commands.clj
@@ -114,7 +114,8 @@
 (s/defschema SubmitCommand
   CommandBase)
 (s/defschema DeleteCommand
-  CommandBase)
+  (assoc CommandBase
+         (s/optional-key :expires-on) DateTime))
 (s/defschema UninviteMemberCommand
   (assoc CommandWithComment
          :member {:name s/Str
@@ -698,8 +699,6 @@
   (add-comment-and-attachments cmd application injections
                                {:event/type :application.event/voted
                                 :vote/value (:vote cmd)}))
-
-
 
 (defn- forbidden-error [application cmd]
   (let [permissions (if application

--- a/src/clj/rems/application/eraser.clj
+++ b/src/clj/rems/application/eraser.clj
@@ -43,6 +43,10 @@
                                (.toStandardDuration (time/seconds 10)))
       :stop (scheduler/stop! expired-application-poller-test)))
 
+  (with-redefs [env (assoc env :application-expiration {:application.state/draft {:delete-after "P90D"
+                                                                                  :reminder-before "P7D"}})]
+    (process-applications!))
+
   (mount/start #{#'expired-application-poller-test})
   (mount/stop #{#'expired-application-poller-test}))
 

--- a/src/clj/rems/application/eraser.clj
+++ b/src/clj/rems/application/eraser.clj
@@ -16,7 +16,9 @@
     (doseq [cmd (->> (applications/get-all-unrestricted-applications)
                      (keep expirer-bot/run-expirer-bot))]
       (log/info (:type cmd) (select-keys cmd [:application-id :expires-on]))
-      (command/command! cmd))
+      (let [result (command/command! cmd)]
+        (when (not-empty (:errors result))
+          (log/warn "Command validation failed:" (:type cmd) (select-keys cmd [:application-id]) (select-keys result [:errors])))))
     (log/warnf "Cannot process applications, because user %s does not exist"
                expirer-bot/bot-userid))
   (applications/reload-cache!)

--- a/src/clj/rems/application/eraser.clj
+++ b/src/clj/rems/application/eraser.clj
@@ -35,7 +35,7 @@
     (empty? cmds)
     (log/info "No applications to process")
 
-    :let [process-limit (:application-expiration-process-limit env 50)]
+    :let [process-limit (or (:application-expiration-process-limit env) 50)]
     :do (log/infof "Total of %s applications due for processing (%s expired, %s to send expiration notifications for). Processing is limited to %s applications at a time."
                    (count cmds)
                    (count (->> cmds (filter #(= :application.command/delete (:type %)))))

--- a/src/clj/rems/application/eraser.clj
+++ b/src/clj/rems/application/eraser.clj
@@ -1,5 +1,6 @@
 (ns rems.application.eraser
-  (:require [clojure.tools.logging :as log]
+  (:require [better-cond.core :as b]
+            [clojure.tools.logging :as log]
             [clj-time.core :as time]
             [mount.core :as mount]
             [rems.service.command :as command]
@@ -9,19 +10,40 @@
             [rems.db.users :as users]
             [rems.scheduler :as scheduler]))
 
+(defn run-commands-and-reload-cache! [cmds]
+  (doseq [cmd cmds]
+    (log/info (:type cmd) (select-keys cmd [:application-id :expires-on]))
+    (let [result (command/command! cmd)]
+      (when (not-empty (:errors result))
+        (log/warn "Command validation failed:"
+                  (:type cmd)
+                  (select-keys cmd [:application-id])
+                  (select-keys result [:errors])))))
+
+  (applications/reload-cache!))
+
 (defn process-applications! []
   (log/info :start #'process-applications!)
-  ;; check that bot user exists, else log missing
-  (if (users/user-exists? expirer-bot/bot-userid)
-    (doseq [cmd (->> (applications/get-all-unrestricted-applications)
-                     (keep expirer-bot/run-expirer-bot))]
-      (log/info (:type cmd) (select-keys cmd [:application-id :expires-on]))
-      (let [result (command/command! cmd)]
-        (when (not-empty (:errors result))
-          (log/warn "Command validation failed:" (:type cmd) (select-keys cmd [:application-id]) (select-keys result [:errors])))))
-    (log/warnf "Cannot process applications, because user %s does not exist"
-               expirer-bot/bot-userid))
-  (applications/reload-cache!)
+
+  (b/cond
+    (not (users/user-exists? "expirer-bot"))
+    (log/warn "Cannot process applications, because user expirer-bot does not exist")
+
+    :let [cmds (->> (applications/get-all-unrestricted-applications)
+                    (keep expirer-bot/run-expirer-bot))]
+
+    (empty? cmds)
+    (log/info "No applications to process")
+
+    :let [process-limit (:application-expiration-process-limit env 50)]
+    :do (log/infof "Total of %s applications due for processing (%s expired, %s to send expiration notifications for). Processing is limited to %s applications at a time."
+                   (count cmds)
+                   (count (->> cmds (filter #(= :application.command/delete (:type %)))))
+                   (count (->> cmds (filter #(= :application.command/send-expiration-notifications (:type %)))))
+                   process-limit)
+
+    (run-commands-and-reload-cache! (take process-limit cmds)))
+
   (log/info :finish #'process-applications!))
 
 (mount/defstate expired-application-poller
@@ -34,21 +56,22 @@
           (scheduler/stop! expired-application-poller)))
 
 (comment
-  (let [config {:application.state/draft {:delete-after "P1D"
-                                          :reminder-before "P1D"}}]
-    (mount/defstate expired-application-poller-test
-      :start (scheduler/start! "expired-application-poller-test"
-                               (fn [] (with-redefs [env (assoc env
-                                                               :application-expiration
-                                                               config)]
-                                        (process-applications!)))
-                               (.toStandardDuration (time/seconds 10)))
-      :stop (scheduler/stop! expired-application-poller-test)))
-
-  (with-redefs [env (assoc env :application-expiration {:application.state/draft {:delete-after "P90D"
-                                                                                  :reminder-before "P7D"}})]
-    (process-applications!))
+  (mount/defstate expired-application-poller-test
+    :start (scheduler/start! "expired-application-poller-test"
+                             (fn [] (with-redefs [env (assoc env
+                                                             :application-expiration {:application.state/draft {:delete-after "P1D"
+                                                                                                                :reminder-before "P1D"}}
+                                                             :application-expiration-process-limit 1)]
+                                      (process-applications!)))
+                             (.toStandardDuration (time/seconds 10)))
+    :stop (scheduler/stop! expired-application-poller-test))
 
   (mount/start #{#'expired-application-poller-test})
-  (mount/stop #{#'expired-application-poller-test}))
+  (mount/stop #{#'expired-application-poller-test})
+
+  (with-redefs [env (assoc env
+                           :application-expiration {:application.state/draft {:delete-after "P90D"
+                                                                              :reminder-before "P7D"}}
+                           :application-expiration-process-limit 1)]
+    (process-applications!)))
 

--- a/src/clj/rems/application/eraser.clj
+++ b/src/clj/rems/application/eraser.clj
@@ -11,11 +11,12 @@
 
 (defn process-applications! []
   (log/info :start #'process-applications!)
-  ; check that bot user exists, else log missing
+  ;; check that bot user exists, else log missing
   (if (users/user-exists? expirer-bot/bot-userid)
-    (doseq [application (applications/get-all-unrestricted-applications)]
-      (when-some [cmd (expirer-bot/run-expirer-bot application)]
-        (command/command! cmd)))
+    (doseq [cmd (->> (applications/get-all-unrestricted-applications)
+                     (keep expirer-bot/run-expirer-bot))]
+      (log/info (:type cmd) (select-keys cmd [:application-id :expires-on]))
+      (command/command! cmd))
     (log/warnf "Cannot process applications, because user %s does not exist"
                expirer-bot/bot-userid))
   (applications/reload-cache!)

--- a/src/clj/rems/application/expirer_bot.clj
+++ b/src/clj/rems/application/expirer_bot.clj
@@ -3,8 +3,7 @@
    application is about to expire.
 
    See also: docs/bots.md"
-  (:require [better-cond.core :as b]
-            [clojure.test :refer [deftest testing is]]
+  (:require [clojure.test :refer [deftest testing is]]
             [clj-time.core :as time]
             [rems.common.application-util :as application-util]
             [rems.common.util :refer [getx]]

--- a/src/clj/rems/application/expirer_bot.clj
+++ b/src/clj/rems/application/expirer_bot.clj
@@ -37,8 +37,8 @@
   (:reminder-before expiration))
 
 (defn- expiration-notification-sent?
-  "Has the expiration notification been sent and nothing else has happened since."
-  [expiration application]
+  "Has the expiration notification been sent and nothing else has happened since?"
+  [application]
   (some? (get-last-event-when-notification application)))
 
 (defn- calculate-reminder-time [expiration application]
@@ -59,7 +59,7 @@
 
 (defn- need-to-wait-for-notification? [expiration application now]
   (and (is-reminder-configured? expiration)
-       (or (not (expiration-notification-sent? expiration application))
+       (or (not (expiration-notification-sent? application))
            (not (enough-time-has-passed-since-notification? expiration application now)))))
 
 (defn- expire-application [expiration application now]
@@ -70,7 +70,8 @@
         {:type :application.command/delete
          :time now
          :actor bot-userid
-         :application-id (:application/id application)}))))
+         :application-id (:application/id application)
+         :expires-on expiration-time}))))
 
 (deftest test-expire-application
   (let [now (time/now)
@@ -186,7 +187,7 @@
 
 (defn- should-send-notification-email? [expiration application now]
   (when-let [reminder-time (calculate-reminder-time expiration application)]
-    (and (not (expiration-notification-sent? expiration application))
+    (and (not (expiration-notification-sent? application))
          (time/before? reminder-time now))))
 
 (defn- send-expiration-notifications [expiration application now]

--- a/src/clj/rems/application/process_managers.clj
+++ b/src/clj/rems/application/process_managers.clj
@@ -34,7 +34,7 @@
 
 (defn delete-orphan-attachments [application-id]
   (let [application (applications/get-application-internal application-id)
-        attachments-in-use (attachment/get-attachments-in-use application)
+        attachments-in-use (set (attachment/get-attachments-in-use application))
         all-attachments (set (map :attachment/id (:application/attachments application)))]
     (doseq [attachment-id (difference all-attachments attachments-in-use)]
       (attachments/delete-attachment! attachment-id))))

--- a/src/clj/rems/service/test_data.clj
+++ b/src/clj/rems/service/test_data.clj
@@ -391,6 +391,10 @@
 
     (test-helpers/create-draft! applicant [catid] "draft application")
 
+    (doseq [n (range 80 100 2)
+            :let [created-at (time/minus (time/now) (time/days n))]]
+      (test-helpers/create-draft! applicant [catid] "forgotten draft" created-at))
+
     (let [app-id (test-helpers/create-draft! applicant [catid] "applied")]
       (test-helpers/command! {:type :application.command/submit
                               :application-id app-id

--- a/src/cljc/rems/common/application_util.cljc
+++ b/src/cljc/rems/common/application_util.cljc
@@ -14,6 +14,9 @@
     :application.state/submitted})
 ;; TODO deleted state?
 
+(defn draft? [application]
+  (= :application.state/draft (:application/state application)))
+
 (defn accepted-licenses? [application userid]
   (let [application-licenses (map :license/id (:application/licenses application))
         user-accepted-licenses (get (:application/accepted-licenses application) userid)]

--- a/test/clj/rems/api/test_applications.clj
+++ b/test/clj/rems/api/test_applications.clj
@@ -815,14 +815,14 @@
                               :type :application.command/submit
                               :actor applicant})
       (testing "can't delete submitted application"
-        (is (= {:errors [{:type "forbidden"}] :success false}
+        (is (= {:errors [{:type "only-draft-may-be-deleted"}] :success false}
                (api-call :post "/api/applications/delete" {:application-id app-id}
                          api-key applicant))))
       (test-helpers/command! {:application-id app-id
                               :type :application.command/return
                               :actor handler-id})
       (testing "can't delete returned application"
-        (is (= {:errors [{:type "forbidden"}] :success false}
+        (is (= {:errors [{:type "only-draft-may-be-deleted"}] :success false}
                (api-call :post "/api/applications/delete" {:application-id app-id}
                          api-key applicant)))))))
 

--- a/test/clj/rems/application/test_eraser.clj
+++ b/test/clj/rems/application/test_eraser.clj
@@ -16,16 +16,8 @@
             [rems.testing-util :refer [with-fixed-time]]
             [clojure.string :as str]))
 
-(defn- email-footer-and-signature [f]
-  (with-redefs [translations (update-in translations [:en :t :email]
-                                        assoc :footer "" :regards "")]
-    (f)))
-
 (use-fixtures :once test-db-fixture)
-(use-fixtures
-  :each
-  email-footer-and-signature
-  rollback-db-fixture)
+(use-fixtures :each rollback-db-fixture)
 
 (def test-time (time/date-time 2023))
 
@@ -59,7 +51,7 @@
                                         :time date-time}))
     app-id))
 
-(defn- get-application-events [app-id]
+(defn- get-events [app-id]
   (:application/events (applications/get-application-internal app-id)))
 
 (defn expiration-notifications-sent [event]
@@ -70,8 +62,8 @@
        (map :application/id)))
 
 (deftest test-expire-application
-  (test-helpers/create-user! {:userid "alice"})
-  (let [draft (create-application! {:draft? true
+  (let [_ (test-helpers/create-user! {:userid "alice"})
+        draft (create-application! {:draft? true
                                     :date-time test-time
                                     :actor "alice"})
         old-submitted (create-application! {:date-time (time/minus test-time (time/days 120))
@@ -79,100 +71,115 @@
         expired-draft (create-application! {:draft? true
                                             :date-time (time/minus test-time (time/days 90) (time/seconds 1))
                                             :actor "alice"})
-        outbox-emails (atom [])
-        config {:application-expiration {:application.state/draft {:delete-after "P90D"}}}]
-    (with-redefs [outbox/put! (fn [email] (swap! outbox-emails conj email))
-                  env config]
+        outbox-emails (atom [])]
 
-      (testing "does not process applications when expirer-bot user does not exist"
+    (testing "does not process applications when expirer-bot user does not exist"
+      (with-redefs [outbox/put! (fn [email] (swap! outbox-emails conj email))
+                    env {:application-expiration {:application.state/draft {:delete-after "P90D"}}}]
         (log-test/with-log
-          (is (= #{draft old-submitted expired-draft} (set (get-all-application-ids "alice"))))
-          (eraser/process-applications!)
-
-          (is (log-test/logged? "rems.application.eraser" :warn "Cannot process applications, because user expirer-bot does not exist"))
-          (is (empty? (log-test/matches "rems.application.eraser" :info #"application.command/send-expiration-notifications")))
-          (is (empty? @outbox-emails))
-          (is (empty? (log-test/matches "rems.application.eraser" :info #"application.command/delete")))
-          (is (not (log-test/logged? "rems.db.applications" :info #"Finished deleting application")))
-
-          (is (= #{draft old-submitted expired-draft} (set (get-all-application-ids "alice")))
-              "Applications should not have been deleted")))
-
-      (testing "does not delete applications when configuration is not valid"
-        (log-test/with-log
-          (with-redefs [env {}]
-            (test-helpers/create-user! {:userid expirer-bot/bot-userid})
-            (roles/add-role! expirer-bot/bot-userid :expirer)
-
+          (testing "processing applications does not delete applications"
             (is (= #{draft old-submitted expired-draft} (set (get-all-application-ids "alice"))))
             (eraser/process-applications!)
+            (is (= #{draft old-submitted expired-draft} (set (get-all-application-ids "alice"))))
+            (is (empty? (log-test/matches "rems.application.eraser" :info #"application.command/delete"))))
 
-            (is (not (log-test/logged? "rems.application.eraser" :warn "Cannot process applications, because user expirer-bot does not exist")))
+          (testing "expiration notification events are not created and emails are not sent"
+            (is (empty? (filter expiration-notifications-sent (get-events draft))))
+            (is (empty? (filter expiration-notifications-sent (get-events old-submitted))))
+            (is (empty? (filter expiration-notifications-sent (get-events expired-draft))))
             (is (empty? (log-test/matches "rems.application.eraser" :info #"application.command/send-expiration-notifications")))
-            (is (empty? @outbox-emails))
-            (is (empty? (log-test/matches "rems.application.eraser" :info #"application.command/delete")))
-            (is (not (log-test/logged? "rems.db.applications" :info #"Finished deleting application")))
+            (is (empty? @outbox-emails)))
 
-            (is (= #{draft old-submitted expired-draft} (set (get-all-application-ids "alice")))
-                "applications should not have been deleted"))))
+          (is (log-test/logged? "rems.application.eraser" :warn "Cannot process applications, because user expirer-bot does not exist")))))
 
-      (testing "cannot remove other than draft applications"
+    (testing "does not delete applications when configuration is not valid"
+      (with-redefs [outbox/put! (fn [email] (swap! outbox-emails conj email))
+                    env {}]
+        (test-helpers/create-user! {:userid expirer-bot/bot-userid})
+        (roles/add-role! expirer-bot/bot-userid :expirer)
+
         (log-test/with-log
-          (with-redefs [env {:application-expiration {:application.state/submitted {:delete-after "P90D"}}}]
+          (testing "processing applications does not delete applications"
             (is (= #{draft old-submitted expired-draft} (set (get-all-application-ids "alice"))))
             (eraser/process-applications!)
+            (is (= #{draft old-submitted expired-draft} (set (get-all-application-ids "alice"))))
+            (is (empty? (log-test/matches "rems.application.eraser" :info #"application.command/delete"))))
+
+          (testing "expiration notification events are not created and emails are not sent"
+            (is (empty? (filter expiration-notifications-sent (get-events draft))))
+            (is (empty? (filter expiration-notifications-sent (get-events old-submitted))))
+            (is (empty? (filter expiration-notifications-sent (get-events expired-draft))))
             (is (empty? (log-test/matches "rems.application.eraser" :info #"application.command/send-expiration-notifications")))
-            (is (empty? @outbox-emails))
-            (is (not (log-test/logged? "rems.db.applications" :info #"Finished deleting application")))
+            (is (empty? @outbox-emails)))
 
-            (testing "delete command start is logged"
-              (let [cmds (log-test/matches "rems.application.eraser" :info #"application.command/delete")
-                    msg (:message (first cmds))]
-                (is (= 1 (count cmds)))
-                (is (str/includes? msg (str ":application-id " old-submitted)))))
+          (is (not (log-test/logged? "rems.application.eraser" :warn "Cannot process applications, because user expirer-bot does not exist")))
+          (is (log-test/logged? "rems.application.eraser" :info "No applications to process")))))
 
-            (testing "delete command validation failure is logged"
-              (let [warnings (log-test/matches "rems.application.eraser" :warn #"Command validation failed")
-                    msg (:message (first warnings))]
-                (is (= 1 (count warnings)))
-                (is (str/includes? msg ":application.command/delete"))
-                (is (str/includes? msg (str ":application-id " old-submitted)))))
-
-            (is (= #{draft old-submitted expired-draft} (set (get-all-application-ids "alice")))
-                "applications should not have been deleted"))))
-
-      (testing "removes expired applications"
+    (testing "cannot remove other than draft applications"
+      (with-redefs [outbox/put! (fn [email] (swap! outbox-emails conj email))
+                    env {:application-expiration {:application.state/submitted {:delete-after "P90D"}}}]
         (log-test/with-log
-          (is (= #{draft old-submitted expired-draft} (set (get-all-application-ids "alice"))))
-          (with-fixed-time test-time
-            (eraser/process-applications!))
+          (testing "processing applications does not delete applications"
+            (is (= #{draft old-submitted expired-draft} (set (get-all-application-ids "alice"))))
+            (eraser/process-applications!)
+            (is (= #{draft old-submitted expired-draft} (set (get-all-application-ids "alice")))))
 
-          (is (empty? (log-test/matches "rems.application.eraser" :info #"application.command/send-expiration-notifications")))
-          (is (empty? @outbox-emails))
+          (testing "expiration notification events are not created and emails are not sent"
+            (is (empty? (filter expiration-notifications-sent (get-events draft))))
+            (is (empty? (filter expiration-notifications-sent (get-events old-submitted))))
+            (is (empty? (filter expiration-notifications-sent (get-events expired-draft))))
+            (is (empty? (log-test/matches "rems.application.eraser" :info #"application.command/send-expiration-notifications")))
+            (is (empty? @outbox-emails)))
 
-          (testing "delete command start is logged"
+          (testing "attempt to delete submitted application is logged"
             (let [cmds (log-test/matches "rems.application.eraser" :info #"application.command/delete")
                   msg (:message (first cmds))]
               (is (= 1 (count cmds)))
-              (is (str/includes? msg (str ":application-id " expired-draft)))))
+              (is (str/includes? msg (str ":application-id " old-submitted))))
 
-          (is (not (log-test/logged? "rems.application.eraser" :warn #"Command validation failed")))
+            (let [warnings (log-test/matches "rems.application.eraser" :warn #"Command validation failed")
+                  msg (:message (first warnings))]
+              (is (= 1 (count warnings)))
+              (is (str/includes? msg ":application.command/delete"))
+              (is (str/includes? msg (str ":application-id " old-submitted))))
 
-          (testing "delete success is logged"
-            (let [deletes (log-test/matches "rems.db.applications" :info #"Finished deleting application")
-                  msg (:message (first deletes))]
-              (is (= 1 (count deletes)))
-              (is (= (str "Finished deleting application " expired-draft) msg))))
+            (is (not (log-test/logged? "rems.db.applications" :info #"Finished deleting application")))))))
 
-          (is (= #{draft old-submitted} (set (get-all-application-ids "alice")))
-              "expired draft application is deleted"))))))
+    (testing "deletes expired draft application"
+      (with-redefs [outbox/put! (fn [email] (swap! outbox-emails conj email))
+                    env {:application-expiration {:application.state/draft {:delete-after "P90D"}}}]
+        (with-fixed-time test-time
+          (log-test/with-log
+            (testing "processing applications deletes expired draft"
+              (is (= #{draft old-submitted expired-draft} (set (get-all-application-ids "alice"))))
+              (eraser/process-applications!)
+              (is (= #{draft old-submitted} (set (get-all-application-ids "alice")))))
+
+            (testing "expiration notification events are not created and emails are not sent"
+              (is (empty? (filter expiration-notifications-sent (get-events draft))))
+              (is (empty? (filter expiration-notifications-sent (get-events old-submitted))))
+              (is (empty? (filter expiration-notifications-sent (get-events expired-draft))))
+              (is (empty? (log-test/matches "rems.application.eraser" :info #"application.command/send-expiration-notifications")))
+              (is (empty? @outbox-emails)))
+
+            (testing "application delete is logged"
+              (let [cmds (log-test/matches "rems.application.eraser" :info #"application.command/delete")
+                    msg (:message (first cmds))]
+                (is (= 1 (count cmds)))
+                (is (str/includes? msg (str ":application-id " expired-draft))))
+
+              (let [deletes (log-test/matches "rems.db.applications" :info #"Finished deleting application")
+                    msg (:message (first deletes))]
+                (is (= 1 (count deletes)))
+                (is (= (str "Finished deleting application " expired-draft) msg))))))))))
 
 (deftest test-send-reminder-email
-  (test-helpers/create-user! {:userid "alice"})
-  (test-helpers/create-user! {:userid "member"})
-  (test-helpers/create-user! {:userid expirer-bot/bot-userid})
-  (roles/add-role! expirer-bot/bot-userid :expirer)
-  (let [draft-expires-in-6d (create-application! {:draft? true
+  (let [_ (test-helpers/create-user! {:userid "alice"})
+        _ (test-helpers/create-user! {:userid "member"})
+        _ (test-helpers/create-user! {:userid "expirer-bot"} :expirer)
+        expiration-config {:application.state/draft {:delete-after "P90D"
+                                                     :reminder-before "P7D"}}
+        draft-expires-in-6d (create-application! {:draft? true
                                                   :date-time (time/minus test-time (time/days 84))
                                                   :actor "alice"
                                                   :members [{:userid "member"
@@ -184,94 +191,144 @@
         submitted (create-application! {:date-time (time/minus test-time (time/days 84))
                                         :actor "alice"})
         outbox-emails (atom [])
-        config {:application-id-column :id
-                :public-url "localhost/"
-                :application-expiration {:application.state/draft {:delete-after "P90D"
-                                                                   :reminder-before "P7D"}}}]
-    (with-redefs [outbox/put! (fn [email] (swap! outbox-emails conj email))
-                  user-settings/get-user-settings (constantly {:language :en})
-                  env config]
+        test-time-plus-one-hour (time/plus test-time (time/hours 1))
+        test-time-plus-ten-days (time/plus test-time (time/days 10))]
 
-      (testing "should not send reminder because config is missing or partially correct"
+    (testing "should not send reminder because config is missing or partially correct,"
+      (doseq [expiration [{:application.state/draft {:delete-after "P90D"}}
+                          {:application.state/draft {:reminder-before "P7D"}}
+                          nil]]
+        (with-redefs [outbox/put! (fn [email] (swap! outbox-emails conj email))
+                      env {:application-id-column :id
+                           :public-url "localhost/"
+                           :application-expiration expiration}]
+          (with-fixed-time test-time
+            (log-test/with-log
+              (testing "processing applications does not delete applications"
+                (is (= #{draft-expires-in-6d draft-expires-in-8d submitted} (set (get-all-application-ids "alice"))))
+                (eraser/process-applications!)
+                (is (= #{draft-expires-in-6d draft-expires-in-8d submitted} (set (get-all-application-ids "alice"))))
+                (is (empty? (log-test/matches "rems.application.eraser" :info #"application.command/delete"))))
+
+              (testing "expiration notification events are not created and emails are not sent"
+                (is (empty? (filter expiration-notifications-sent (get-events draft-expires-in-6d))))
+                (is (empty? (filter expiration-notifications-sent (get-events draft-expires-in-8d))))
+                (is (empty? (filter expiration-notifications-sent (get-events submitted))))
+                (is (empty? (log-test/matches "rems.application.eraser" :info #"application.command/send-expiration-notifications")))
+                (is (empty? @outbox-emails))))))))
+
+    (testing "send expiration notifications"
+      (with-redefs [outbox/put! (fn [email] (swap! outbox-emails conj email))
+                    user-settings/get-user-settings (constantly {:language :en})
+                    env {:application-id-column :id
+                         :public-url "localhost/"
+                         :application-expiration expiration-config}
+                    translations (-> translations
+                                     (assoc-in [:en :t :email :footer] "")
+                                     (assoc-in [:en :t :email :regards] ""))]
         (with-fixed-time test-time
-          (doseq [expiration [{:application.state/draft {:delete-after "P90D"}}
-                              {:application.state/draft {:reminder-before "P7D"}}
-                              nil]]
-            (with-redefs [env (assoc config :application-expiration expiration)]
+          (log-test/with-log
+            (reset! outbox-emails [])
+
+            (testing "processing applications does not delete applications"
+              (is (= #{draft-expires-in-6d draft-expires-in-8d submitted} (set (get-all-application-ids "alice"))))
               (eraser/process-applications!)
               (is (= #{draft-expires-in-6d draft-expires-in-8d submitted} (set (get-all-application-ids "alice"))))
-              (is (empty? @outbox-emails))
-              (is (empty? (filter expiration-notifications-sent (get-application-events draft-expires-in-6d))))
-              (is (empty? (filter expiration-notifications-sent (get-application-events draft-expires-in-8d))))
-              (is (empty? (filter expiration-notifications-sent (get-application-events submitted))))))))
+              (is (empty? (log-test/matches "rems.application.eraser" :info #"application.command/delete"))))
 
-      (testing "send expiration notifications"
-        (with-fixed-time test-time
-          (eraser/process-applications!)
-          (is (= #{draft-expires-in-6d draft-expires-in-8d submitted} (set (get-all-application-ids "alice")))
-              "no applications have been deleted")
-          (is (empty? (filter expiration-notifications-sent (get-application-events draft-expires-in-8d))))
-          (is (empty? (filter expiration-notifications-sent (get-application-events submitted))))
+            (testing "expiration notification events are not created for non-expiring applications"
+              (is (empty? (filter expiration-notifications-sent (get-events draft-expires-in-8d))))
+              (is (empty? (filter expiration-notifications-sent (get-events submitted)))))
 
-          (testing "expiration notifications sent event was created for draft expiring in 6 days"
-            (let [events (filter expiration-notifications-sent (get-application-events draft-expires-in-6d))]
-              (is (= 1 (count events)))
-              (is (time/equal? (time/plus test-time (time/days 6)) (:application/expires-on (first events))))
-              (is (time/equal? test-time (:event-time (first events))))))
+            (testing "expiration notification event is created for draft expiring in 6 days"
+              (let [events (filter expiration-notifications-sent (get-events draft-expires-in-6d))
+                    notification (first events)]
+                (is (= 1 (count events)))
+                (is (time/equal? (time/plus test-time (time/days 7)) (:application/expires-on notification)))
+                (is (time/equal? test-time (:event/time notification))))
 
-          (is (= [{:outbox/deadline test-time
-                   :outbox/email {:subject (str "Your unsubmitted application " draft-expires-in-6d " will be deleted soon")
-                                  :body (str "Dear alice,\n\n"
-                                             "Your unsubmitted application has been inactive since 2022-10-09 and it will be deleted after 2023-01-07, if it is not edited.\n\n"
-                                             "You can view and edit the application at localhost/application/" draft-expires-in-6d)
-                                  :to-user "alice"}
-                   :outbox/type :email}
-                  {:outbox/deadline test-time
-                   :outbox/email {:subject (str "Your unsubmitted application " draft-expires-in-6d " will be deleted soon")
-                                  :body (str "Dear member,\n\n"
-                                             "Your unsubmitted application has been inactive since 2022-10-09 and it will be deleted after 2023-01-07, if it is not edited.\n\n"
-                                             "You can view and edit the application at localhost/application/" draft-expires-in-6d)
-                                  :to-user "member"}
-                   :outbox/type :email}]
-                 @outbox-emails))
+              (testing "emails are sent to applicants"
+                (is (= [{:outbox/deadline test-time
+                         :outbox/email {:subject (str "Your unsubmitted application " draft-expires-in-6d " will be deleted soon")
+                                        :body (str "Dear alice,"
+                                                   "\n\nYour unsubmitted application has been inactive since 2022-10-09 and it will be deleted after 2023-01-08, if it is not edited."
+                                                   "\n\nYou can view and edit the application at localhost/application/" draft-expires-in-6d)
+                                        :to-user "alice"}
+                         :outbox/type :email}
+                        {:outbox/deadline test-time
+                         :outbox/email {:subject (str "Your unsubmitted application " draft-expires-in-6d " will be deleted soon")
+                                        :body (str "Dear member,"
+                                                   "\n\nYour unsubmitted application has been inactive since 2022-10-09 and it will be deleted after 2023-01-08, if it is not edited."
+                                                   "\n\nYou can view and edit the application at localhost/application/" draft-expires-in-6d)
+                                        :to-user "member"}
+                         :outbox/type :email}]
+                       @outbox-emails))))))
 
-          (testing "processing applications again should not send new notifications"
+        (with-fixed-time test-time-plus-one-hour
+          (log-test/with-log
             (reset! outbox-emails [])
-            (eraser/process-applications!)
 
-            (is (= #{draft-expires-in-6d draft-expires-in-8d submitted} (set (get-all-application-ids "alice")))
-                "no applications have been deleted")
-            (is (empty? (filter expiration-notifications-sent (get-application-events draft-expires-in-8d))))
-            (is (empty? (filter expiration-notifications-sent (get-application-events submitted))))
-            (is (empty? @outbox-emails))
+            (testing "processing applications again after one hour does not delete applications"
+              (is (= #{draft-expires-in-6d draft-expires-in-8d submitted} (set (get-all-application-ids "alice"))))
+              (eraser/process-applications!)
+              (is (= #{draft-expires-in-6d draft-expires-in-8d submitted} (set (get-all-application-ids "alice"))))
+              (is (empty? (log-test/matches "rems.application.eraser" :info #"application.command/delete"))))
+
+            (testing "expiration notification events are not created for non-expiring applications"
+              (is (empty? (filter expiration-notifications-sent (get-events draft-expires-in-8d))))
+              (is (empty? (filter expiration-notifications-sent (get-events submitted)))))
 
             (testing "expiration notifications events have not changed for draft expiring in 6 days"
-              (let [events (filter expiration-notifications-sent (get-application-events draft-expires-in-6d))]
+              (let [events (filter expiration-notifications-sent (get-events draft-expires-in-6d))
+                    notification (first events)]
                 (is (= 1 (count events)))
-                (is (time/equal? (time/plus test-time (time/days 6)) (:application/expires-on (first events))))
-                (is (time/equal? test-time (:event-time (first events)))))))))
+                (is (time/equal? (time/plus test-time (time/days 7)) (:application/expires-on notification)))
+                (is (time/equal? test-time (:event/time notification)))))
 
-      (testing "draft is expired after extended reminder period"
-        (with-fixed-time (-> test-time
-                             (time/plus (time/days 7))
-                             (time/plus (time/seconds 1)))
+            (testing "email is not sent"
+              (is (empty? @outbox-emails)))))
+
+        ;; NB: gap between previous run simulates enabling eraser without previous notification messages.
+        ;; some applications may already have expired, but without notification event, and when notifications
+        ;; are enabled, those applications are expired only after "notification window".
+        (with-fixed-time test-time-plus-ten-days
           (log-test/with-log
-            (is (= #{draft-expires-in-6d draft-expires-in-8d submitted} (set (get-all-application-ids "alice"))))
-            (eraser/process-applications!)
+            (reset! outbox-emails [])
 
-            (testing "delete command start is logged"
+            (testing "processing applications again after ten days deletes expired draft application"
+              (is (= #{draft-expires-in-6d draft-expires-in-8d submitted} (set (get-all-application-ids "alice"))))
+              (eraser/process-applications!)
+              (is (= #{draft-expires-in-8d submitted} (set (get-all-application-ids "alice")))))
+
+            (testing "application delete is logged"
               (let [cmds (log-test/matches "rems.application.eraser" :info #"application.command/delete")
                     msg (:message (first cmds))]
                 (is (= 1 (count cmds)))
-                (is (str/includes? msg (str ":application-id " draft-expires-in-6d)))))
+                (is (str/includes? msg (str ":application-id " draft-expires-in-6d))))
 
-            (is (not (log-test/logged? "rems.application.eraser" :warn #"Command validation failed")))
+              (is (not (log-test/logged? "rems.application.eraser" :warn #"Command validation failed")))
 
-            (testing "delete success is logged"
               (let [deletes (log-test/matches "rems.db.applications" :info #"Finished deleting application")
                     msg (:message (first deletes))]
                 (is (= 1 (count deletes)))
                 (is (= (str "Finished deleting application " draft-expires-in-6d) msg))))
 
-            (is (= #{draft-expires-in-8d submitted} (set (get-all-application-ids "alice")))
-                "draft application is deleted")))))))
+            (testing "notifications are not created for non-expiring application"
+              (is (empty? (filter expiration-notifications-sent (get-events submitted)))))
+
+            (testing "notification is created for expiring draft"
+              (let [events (filter expiration-notifications-sent (get-events draft-expires-in-8d))
+                    notification (first events)]
+                (is (= 1 (count events)))
+                (is (time/equal? (time/plus test-time-plus-ten-days (time/days 7)) (:application/expires-on notification)))
+                (is (time/equal? test-time-plus-ten-days (:event/time notification)))))
+
+            (testing "email is sent to applicant for expiring draft"
+              (is (= [{:outbox/deadline test-time-plus-ten-days
+                       :outbox/email {:subject (str "Your unsubmitted application " draft-expires-in-8d " will be deleted soon")
+                                      :body (str "Dear alice,\n\n"
+                                                 "Your unsubmitted application has been inactive since 2022-10-11 and it will be deleted after 2023-01-18, if it is not edited.\n\n"
+                                                 "You can view and edit the application at localhost/application/" draft-expires-in-8d)
+                                      :to-user "alice"}
+                       :outbox/type :email}]
+                     @outbox-emails)))))))))


### PR DESCRIPTION
implements #3225 

Fixes
- Expiration notification command uses `now` for calculating `:expires-on`
  - Previously it used last applying user event for calculations, which could set the date in emails in the past.
- Send expiration notifications no longer validates invalid expiration
  - `:last-activity` was no longer returned by command, so validation always failed
  - In addition, validation returned faulty key `:error` which was ignored by (command!), see detailed description below

Feature additions/changes
- NB: (time-before-or-equal?) is used in both (expire-application) and (should-send-notification-email?)
  - Combines (time/before?) and (time/equal?) using logical-or
- NB: both `:application.command/delete` and `:application.command/send-expiration-notifications` command handlers validate that application state is draft
- (rems.application.eraser/process-applications!) now logs more:
  - **info** on startup,
  - **warning** when expirer-bot does not exist,
  - **info** when it has nothing to execute,
  - **info** before running each command, and
  - **warning** when command validation fails.
- (rems.db.applications/delete-application!) logs info after it is finished deleting application.
- Delete command now includes optional `:expires-on` similar to send expiration notifications.
  - It is for logging purposes, not used in event generation, and as optional key it can be passed from API, but has no effect.
- New config option `:application-expiration-process-limit`:
  - Limits how many commands (rems.application.eraser/process-applications!) can pull for execution.
  - Default value `nil` (hard-coded to 50)

Test additions/changes
- rems.application.expirer-bot
  - unit tests have more (testing) blocks
  - use (exactly-90d-ago) format over (over-90d-ago) due to change in date time checking, which should be more intuitive
- rems.application.test-eraser
  - all tests generally run (process-applications!) and check following:
    1. any applications removed?
    2. any notification events created?
    3. any emails sent? 
  - use clojure.tools.logging.test instead of atom + with-redefs over log function. with-log automatically handles log collection start/end
  - (testing) blocks handle as much config as possible, e.g. with-redefs, with-log and with-fixed-time
    - Due to progressive time in notification tests, fixed time needs to be redefined. also with-log needs to used for each (process-applications!), so there is already some unavoidable nesting

Send expiration notifications command had interesting bug:
1. A validation function generated error due to non-existing attribute, but it was malformed due to typo (`:error` should've been `:errors`).
4. `rems.application.commands/handle-command` ignores this because command results are not validated.
5. Now `:events` is not in cmd result, but because `:errors` is neither, `rems.service.command/command!` assumes it is valid.
6. `command!` calls `mapv` on nil, which returns empty vector, so no events are added or validated.

# Checklist for author

Remove items that aren't applicable, check items that are done.

## Reviewability
- [x] Link to issue

## Documentation
- [x] Update changelog if necessary

## Testing
- [x] Complex logic is unit tested
- [x] Valuable features are integration tested automatically

## Follow-up
- [ ] New tasks are created for pending or remaining tasks

---
## Example runtime log
Some Logback MDC parts omitted for brevity:
```log
INFO  rems.application.eraser - :start #'rems.application.eraser/process-applications!
INFO  rems.application.eraser - Total of 4 applications due for processing (4 expired, 0 to send expiration notifications for). Processing is limited to 3 applications at a time.
INFO  rems.application.eraser - :application.command/delete {:application-id 16, :expires-on #clj-time/date-time "2023-08-15T19:10:28.985Z"}
INFO  rems.db.applications - Finished deleting application 16
INFO  rems.application.eraser - :application.command/delete {:application-id 10, :expires-on #clj-time/date-time "2023-08-21T19:10:28.424Z"}
INFO  rems.db.applications - Finished deleting application 10
INFO  rems.application.eraser - :application.command/delete {:application-id 18, :expires-on #clj-time/date-time "2023-08-13T19:10:29.166Z"}
INFO  rems.db.applications - Finished deleting application 18
INFO  rems.db.applications - Start rems.db.applications/reload-cache!
INFO  rems.db.applications - Finished rems.db.applications/reload-cache!
INFO  rems.application.eraser - :finish #'rems.application.eraser/process-applications!
```

Command validation failure (e.g. configured expire for non-draft):
```log
INFO  rems.application.eraser - :start #'rems.application.eraser/process-applications!
INFO  rems.application.eraser - Total of 1 applications due for processing (1 expired, 0 to send expiration notifications for). Processing is limited to 3 applications at a time.
INFO  rems.application.eraser - :application.command/delete {:application-id 24, :expires-on #clj-time/date-time "2023-11-10T19:10:29.809Z"}
WARN  rems.application.eraser - Command validation failed: :application.command/delete {:application-id 24} {:errors [{:type :only-draft-may-be-deleted}]}
INFO  rems.db.applications - Start rems.db.applications/reload-cache!
INFO  rems.db.applications - Finished rems.db.applications/reload-cache!
INFO  rems.application.eraser - :finish #'rems.application.eraser/process-applications!
```

Nothing to process, no cache reload:
```log
INFO  rems.application.eraser - :start #'rems.application.eraser/process-applications!
INFO  rems.application.eraser - No applications to process
INFO  rems.application.eraser - :finish #'rems.application.eraser/process-applications!
```