### PR TITLE
Faster events

### DIFF
--- a/src/clj/rems/db/applications.clj
+++ b/src/clj/rems/db/applications.clj
@@ -295,7 +295,7 @@
     (assert (= :application.state/draft (:application/state application))
             (str "Tried to delete application " app-id " which is not a draft!")))
   (db/delete-application-attachments! {:application app-id})
-  (db/delete-application-events! {:application app-id})
+  (events/delete-application-events! app-id)
   (db/delete-application! {:application app-id}))
 
 (defn delete-application-and-reload-cache! [app-id]

--- a/src/clj/rems/db/events.clj
+++ b/src/clj/rems/db/events.clj
@@ -93,3 +93,11 @@
       (replace-event! (merge event
                              (select-keys last-event [:event/id])))
       (add-event! event))))
+
+(defn delete-application-events! [app-id]
+  (let [events (get-application-events app-id)]
+    (db/delete-application-events! {:application app-id})
+    (swap! event-cache (fn [cached]
+                         (reduce (fn [cached id]
+                                   (dissoc cached id))
+                                 cached (map :event/id events))))))

--- a/src/clj/rems/email/core.clj
+++ b/src/clj/rems/email/core.clj
@@ -15,7 +15,8 @@
             [rems.db.user-settings :as user-settings]
             [rems.db.users :as users]
             [rems.email.template :as template]
-            [rems.scheduler :as scheduler])
+            [rems.scheduler :as scheduler]
+            [clojure.string :as str])
   (:import [javax.mail.internet InternetAddress]
            [org.joda.time Duration Period]))
 
@@ -109,7 +110,9 @@
                      "Auto-Submitted" "auto-generated")
         to-error (validate-address (:to email))]
     (when (and (:body email) (:to email))
-      (log/info "sending email:" (pr-str email))
+      (when (or (not (:dev env))
+                (not (str/includes? (:to email "") "perftester")))
+        (log/info "sending email:" (pr-str email)))
       (cond
         to-error
         (do
@@ -118,7 +121,9 @@
 
         (not (and (:host smtp) (:port smtp)))
         (do
-          (log/info "no smtp server configured, only pretending to send email")
+          (when (or (not (:dev env))
+                    (not (str/includes? (:to email "") "perftester")))
+            (log/info "no smtp server configured, only pretending to send email"))
           nil)
 
         :else

--- a/src/clj/rems/json.clj
+++ b/src/clj/rems/json.clj
@@ -80,7 +80,7 @@
 
 ;;; Utils for schema-based coercion
 
-(defn- datestring->datetime [s]
+(defn datestring->datetime [s]
   (if (string? s)
     (time-format/parse (clj-time.format/formatters :date-time) s)
     s))

--- a/src/clj/rems/json.clj
+++ b/src/clj/rems/json.clj
@@ -82,7 +82,7 @@
 
 (defn- datestring->datetime [s]
   (if (string? s)
-    (time-format/parse s)
+    (time-format/parse (clj-time.format/formatters :date-time) s)
     s))
 
 (def datestring-coercion-matcher

--- a/src/clj/rems/service/test_data.clj
+++ b/src/clj/rems/service/test_data.clj
@@ -619,39 +619,40 @@
                                                            :email (str user-id "@example.com")
                                                            :name (str "Performance Tester " n)})
                              user-id)))))]
-    (in-parallel
-     (for [n (range-1 application-count)]
-       (fn []
-         (log/info "Creating performance test application" n "/" application-count)
-         (let [cat-item-id (rand-nth cat-item-ids)
-               user-id (rand-nth user-ids)
-               handler (rand-nth handlers)
-               app-id (test-helpers/create-application! {:catalogue-item-ids [cat-item-id]
-                                                         :actor user-id})
-               long-answer (random-long-string)]
-           (dotimes [i 20] ; user saves ~ 20 times while writing an application
-             (test-helpers/command! {:type :application.command/save-draft
+    (with-redefs [rems.config/env (assoc rems.config/env :enable-save-compaction false)] ; generate more events without compaction
+      (in-parallel
+       (for [n (range-1 application-count)]
+         (fn []
+           (log/info "Creating performance test application" n "/" application-count)
+           (let [cat-item-id (rand-nth cat-item-ids)
+                 user-id (rand-nth user-ids)
+                 handler (rand-nth handlers)
+                 app-id (test-helpers/create-application! {:catalogue-item-ids [cat-item-id]
+                                                           :actor user-id})
+                 long-answer (random-long-string)]
+             (dotimes [i 20] ; user saves ~ 20 times while writing an application
+               (test-helpers/command! {:type :application.command/save-draft
+                                       :application-id app-id
+                                       :actor user-id
+                                       :field-values [{:form form-id
+                                                       :field (:field/id (first (:form/fields form)))
+                                                       :value (str "Performance test application " (UUID/randomUUID))}
+                                                      {:form form-id
+                                                       :field (:field/id (second (:form/fields form)))
+                                                       ;; 1000 words of lorem ipsum samples from a text from www.lipsum.com
+                                                       ;; to increase the memory requirements of an application
+                                                       :value (subs long-answer 0 (int (/ (* (inc i) (count long-answer)) (inc i))))}]}))
+             (test-helpers/command! {:type :application.command/accept-licenses
                                      :application-id app-id
                                      :actor user-id
-                                     :field-values [{:form form-id
-                                                     :field (:field/id (first (:form/fields form)))
-                                                     :value (str "Performance test application " (UUID/randomUUID))}
-                                                    {:form form-id
-                                                     :field (:field/id (second (:form/fields form)))
-                                        ;; 1000 words of lorem ipsum samples from a text from www.lipsum.com
-                                        ;; to increase the memory requirements of an application
-                                                     :value (subs long-answer 0 (int (/ (* (inc i) (count long-answer)) (inc i))))}]}))
-           (test-helpers/command! {:type :application.command/accept-licenses
-                                   :application-id app-id
-                                   :actor user-id
-                                   :accepted-licenses [license-id]})
-           (test-helpers/command! {:type :application.command/submit
-                                   :application-id app-id
-                                   :actor user-id})
-           (test-helpers/command! {:type :application.command/approve
-                                   :application-id app-id
-                                   :actor handler
-                                   :comment ""})))))
+                                     :accepted-licenses [license-id]})
+             (test-helpers/command! {:type :application.command/submit
+                                     :application-id app-id
+                                     :actor user-id})
+             (test-helpers/command! {:type :application.command/approve
+                                     :application-id app-id
+                                     :actor handler
+                                     :comment ""}))))))
     (log/info "Performance test applications created")))
 
 (defn- create-items! [users users-data]

--- a/test/clj/rems/db/testing.clj
+++ b/test/clj/rems/db/testing.clj
@@ -11,10 +11,10 @@
             [rems.db.catalogue :as catalogue]
             [rems.db.category :as category]
             [rems.db.core :as db]
+            [rems.db.events :as events]
             [rems.service.test-data :as test-data]
             [rems.db.user-mappings :as user-mappings]
-            [rems.locales])
-  (:import [org.joda.time Duration ReadableInstant]))
+            [rems.locales]))
 
 (defn reset-db-fixture [f]
   (try
@@ -48,7 +48,8 @@
       (catalogue/reset-cache!)
       (category/reset-cache!)
       (dependencies/reset-cache!)
-      (user-mappings/reset-cache!))))
+      (user-mappings/reset-cache!)
+      (events/reset-event-cache!))))
 
 (def +test-api-key+ test-data/+test-api-key+) ;; re-exported for convenience
 
@@ -59,4 +60,5 @@
 (defn rollback-db-fixture [f]
   (conman/with-transaction [db/*db* {:isolation :serializable}]
     (jdbc/db-set-rollback-only! db/*db*)
+    (events/reset-event-cache!) ; NB can't rollback this cache so reset
     (f)))


### PR DESCRIPTION
Speeds up low level event handling.

Particularly:
- `rems.json` parses dates with a specified format (instead of trying several)
- Event coercion is done manually (with Specter) because it's much faster than Schema
- Low level coerced events are cached (separately from events cache, application cache). Querying events from DB takes a while, and coercion takes another while. This ends up speeding also full cache reloads. The cache is maintained in all CRUD functions.

# Checklist for author

Remove items that aren't applicable, check items that are done.

## Reviewability
- [ ] Link to issue

## Backwards compatibility
- [x] API is backwards compatible or completely new
- [x] Events are backwards compatible _or_ have migrations

## Documentation
- [ ] Update changelog if necessary
- [ ] ADR for major architectural decisions or experiments

## Testing
- [ ] Complex logic is unit tested
- [ ] Valuable features are integration / browser / acceptance tested automatically

## Follow-up
- [ ] New tasks are created for pending or remaining tasks
