### PR TITLE
Own organization only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ Changes since v2.34.2
 
 **NB: This release removes the experimental application PDF export API. The non-experimental PDF export API is preferred instead. (#3098)**
 
+### Additions
+- By default administration pages show only "own organization" items. (#2046)
+
 ### Fixes
 - Administration dropdown buttons should now respond to clicks more widely, and not only by directly clicking text. (#3167)
 - Catalogue item unarchive should no longer fail when form does not exist. (#3217)

--- a/resources/translations/da.edn
+++ b/resources/translations/da.edn
@@ -111,6 +111,8 @@
                    :disabled-and-archived-explanation "Deaktivering skjuler en post fra ansøgere. Arkivering skjuler den også i administrationsgrænsefladen."
                    :display-archived "Vis arkiverede"
                    :display-order "Visningsrækkefølge"
+                   :display-own-organization-only-explanation nil
+                   :display-own-organization-only nil
                    :edit "Rediger"
                    :edit-catalogue-item "Rediger katalogpost"
                    :edit-category "Rediger kategori"

--- a/resources/translations/en.edn
+++ b/resources/translations/en.edn
@@ -111,6 +111,8 @@
                    :disabled-and-archived-explanation "Disabling hides an item from applicants. Archiving also hides it in the administration view."
                    :display-archived "Display archived"
                    :display-order "Display order"
+                   :display-own-organization-only-explanation "Should only own organization items be shown?"
+                   :display-own-organization-only "Own organization only"
                    :edit "Edit"
                    :edit-catalogue-item "Edit catalogue item"
                    :edit-category "Edit category"

--- a/resources/translations/fi.edn
+++ b/resources/translations/fi.edn
@@ -109,6 +109,8 @@
                    :disabled-and-archived-explanation "Käytöstä poistaminen piilottaa asian käyttäjiltä. Arkistoiminen piilottaa sen myös ylläpitonäkymästä."
                    :display-archived "Näytä arkistoidut"
                    :display-order "Näyttöjärjestys"
+                   :display-own-organization-only-explanation "Näytetäänkö vain oma organisaatio?"
+                   :display-own-organization-only "Vain oma organisaatio"
                    :edit "Muokkaa"
                    :edit-catalogue-item "Muokkaa aineistoa"
                    :edit-category "Muokkaa kategoriaa"

--- a/resources/translations/sv.edn
+++ b/resources/translations/sv.edn
@@ -109,6 +109,8 @@
                    :disabled-commands "Avaktiverade funktioner"
                    :display-archived "Visa arkiverade"
                    :display-order "Visningsordning"
+                   :display-own-organization-only-explanation "Visa endast egen organisation?"
+                   :display-own-organization-only "Endast egen organisation"
                    :edit "Ändra"
                    :edit-catalogue-item "Ändra katalogpost"
                    :edit-category "Ändra kategori"

--- a/src/clj/rems/layout.clj
+++ b/src/clj/rems/layout.clj
@@ -5,7 +5,7 @@
             [rems.common.git :as git]
             [rems.config :refer [env]]
             [rems.context :as context]
-            [rems.json :as json]
+            [rems.service.organizations :as organizations]
             [cognitect.transit]
             [rems.text :refer [text with-language]]
             [ring.middleware.anti-forgery :refer [*anti-forgery-token*]]
@@ -126,6 +126,8 @@
     (inline-value "rems.app.setConfig" (public/get-config))
     (inline-value "rems.app.setTranslations" (public/get-translations))
     (inline-value "rems.app.setTheme" (public/get-theme))
+    (when (contains? context/*roles* :handler)
+      (inline-value "rems.app.setHandledOrganizations" (organizations/get-handled-organizations (select-keys context/*user* [:userid]))))
     [:script {:type "text/javascript"} "rems.spa.mount();"])))
 
 (defn- error-content

--- a/src/clj/rems/service/organizations.clj
+++ b/src/clj/rems/service/organizations.clj
@@ -7,6 +7,7 @@
             [rems.db.organizations :as organizations]
             [rems.db.roles :as roles]
             [rems.db.users :as users]
+            [rems.db.workflow :as workflow]
             [rems.service.dependencies :as dependencies]
             [rems.service.util]))
 
@@ -75,3 +76,10 @@
           {:success true}))))
 
 (defn get-available-owners [] (users/get-users))
+
+(defn get-handled-organizations [{:keys [userid]}]
+  (for [workflow (workflow/get-workflows nil)
+        :let [handlers (set (mapv :userid (get-in workflow [:workflow :handlers])))]
+        :when (contains? handlers userid)
+        :let [organization (organizations/getx-organization-by-id (get-in workflow [:organization :organization/id]))]]
+    organization))

--- a/src/cljc/rems/common/roles.cljc
+++ b/src/cljc/rems/common/roles.cljc
@@ -34,6 +34,10 @@
    (defn show-when [roles & body]
      (clojure.core/when (apply has-roles? roles)
        (into [:<>] body))))
+#?(:cljs
+   (defn show-when-not [roles & body]
+     (clojure.core/when-not (apply has-roles? roles)
+       (into [:<>] body))))
 
 #?(:cljs
    (defn can-modify-organization-item? [item]

--- a/src/cljs/rems/administration/administration.cljs
+++ b/src/cljs/rems/administration/administration.cljs
@@ -39,6 +39,30 @@
 
 (rf/reg-sub ::display-own-organization-only (fn [db _] (::display-own-organization-only db true)))
 
+(rf/reg-sub
+ ::personal-organizations
+ (fn [_ _]
+   [(rf/subscribe [:owned-organizations])
+    (rf/subscribe [:handled-organizations])])
+ (fn [[owned-organizations handled-organizations] _]
+   (concat owned-organizations handled-organizations)))
+
+(rf/reg-sub
+ ::displayed-organization-ids
+ (fn [_ _]
+   [(rf/subscribe [::display-own-organization-only])
+    (rf/subscribe [:organizations])
+    (rf/subscribe [::personal-organizations])])
+ (fn [[display-own-organization-only? all-organizations personal-organizations] _]
+   (if (or (not display-own-organization-only?)
+           (roles/has-roles? :owner :reporter))
+     (set (map :organization/id all-organizations))
+     (set (map :organization/id personal-organizations)))))
+
+(defn filter-by-displayed-organization [displayed-organization-ids f coll]
+  (filter (fn [x] (contains? displayed-organization-ids (f x)))
+          coll))
+
 (defn display-own-organization-only []
   (let [display-own-organization-only? @(rf/subscribe [::display-own-organization-only])
         on-change (fn [] (rf/dispatch [::set-display-own-organization-only (not display-own-organization-only?)]))]
@@ -52,9 +76,11 @@
 
 (defn own-organization-selection []
   [roles/show-when-not #{:owner :reporter}
-   [:div.mt-1.d-flex.flex-row.align-items-start.justify-content-between {:style {:gap "2rem"}}
-    [:p (text :t.administration/display-own-organization-only-explanation)]
-    [display-own-organization-only]]])
+   (let [organizations @(rf/subscribe [::personal-organizations])]
+     (when (> (count organizations) 1) ; don't bother showing if there is only 1
+       [:div.mt-1.d-flex.flex-row.align-items-start.justify-content-between {:style {:gap "2rem"}}
+        [:p (text :t.administration/display-own-organization-only-explanation)]
+        [display-own-organization-only]]))])
 
 (defn guide []
   [:div

--- a/src/cljs/rems/administration/administration.cljs
+++ b/src/cljs/rems/administration/administration.cljs
@@ -67,11 +67,11 @@
   (let [display-own-organization-only? @(rf/subscribe [::display-own-organization-only])
         on-change (fn [] (rf/dispatch [::set-display-own-organization-only (not display-own-organization-only?)]))]
     [:div.form-check.form-check-inline.pointer
-     [atoms/checkbox {:id :display-archived
+     [atoms/checkbox {:id :display-own-organization-only
                       :class :form-check-input
                       :value display-own-organization-only?
                       :on-change on-change}]
-     [:label.form-check-label {:for :display-archived :on-click on-change}
+     [:label.form-check-label {:for :display-own-organization-only :on-click on-change}
       (text :t.administration/display-own-organization-only)]]))
 
 (defn own-organization-selection []

--- a/src/cljs/rems/administration/administration.cljs
+++ b/src/cljs/rems/administration/administration.cljs
@@ -32,6 +32,30 @@
    [roles/show-when #{:owner :reporter}
     [navbar/nav-link "/administration/reports" (text :t.administration/reports)]]])
 
+(rf/reg-event-fx
+ ::set-display-own-organization-only
+ (fn [{:keys [db]} [_ display-own-organization-only?]]
+   {:db (assoc db ::display-own-organization-only display-own-organization-only?)}))
+
+(rf/reg-sub ::display-own-organization-only (fn [db _] (::display-own-organization-only db true)))
+
+(defn display-own-organization-only []
+  (let [display-own-organization-only? @(rf/subscribe [::display-own-organization-only])
+        on-change (fn [] (rf/dispatch [::set-display-own-organization-only (not display-own-organization-only?)]))]
+    [:div.form-check.form-check-inline.pointer
+     [atoms/checkbox {:id :display-archived
+                      :class :form-check-input
+                      :value display-own-organization-only?
+                      :on-change on-change}]
+     [:label.form-check-label {:for :display-archived :on-click on-change}
+      (text :t.administration/display-own-organization-only)]]))
+
+(defn own-organization-selection []
+  [roles/show-when-not #{:owner :reporter}
+   [:div.mt-1.d-flex.flex-row.align-items-start.justify-content-between {:style {:gap "2rem"}}
+    [:p (text :t.administration/display-own-organization-only-explanation)]
+    [display-own-organization-only]]])
+
 (defn guide []
   [:div
    (component-info navigator)

--- a/src/cljs/rems/administration/administration.cljs
+++ b/src/cljs/rems/administration/administration.cljs
@@ -76,11 +76,9 @@
 
 (defn own-organization-selection []
   [roles/show-when-not #{:owner :reporter}
-   (let [organizations @(rf/subscribe [::personal-organizations])]
-     (when (> (count organizations) 1) ; don't bother showing if there is only 1
-       [:div.mt-1.d-flex.flex-row.align-items-start.justify-content-between {:style {:gap "2rem"}}
-        [:p (text :t.administration/display-own-organization-only-explanation)]
-        [display-own-organization-only]]))])
+   [:div.mt-1.d-flex.flex-row.align-items-start.justify-content-between {:style {:gap "2rem"}}
+    [:p (text :t.administration/display-own-organization-only-explanation)]
+    [display-own-organization-only]]])
 
 (defn guide []
   [:div

--- a/src/cljs/rems/app.cljs
+++ b/src/cljs/rems/app.cljs
@@ -24,3 +24,5 @@
 (defn ^:export setTheme [theme]
   (rf/dispatch-sync [:loaded-theme (read-transit theme)]))
 
+(defn ^:export setHandledOrganizations [organizations]
+  (rf/dispatch-sync [:loaded-handled-organizations (read-transit organizations)]))

--- a/src/cljs/rems/config.cljs
+++ b/src/cljs/rems/config.cljs
@@ -70,3 +70,18 @@
          {:params {:disabled true :archived true}
           :handler #(rf/dispatch-sync [:loaded-organizations %])
           :error-handler (flash-message/default-error-handler :top "Fetch organizations")}))
+
+(rf/reg-sub
+ :handled-organizations
+ (fn [db _]
+   (:handled-organizations db)))
+
+(rf/reg-event-db
+ :loaded-handled-organizations
+ (fn [db [_ organizations]]
+   (assoc db :handled-organizations organizations)))
+
+(defn fetch-handled-organizations! []
+  (fetch "/api/organizations/handled"
+         {:handler #(rf/dispatch-sync [:loaded-handled-organizations %])
+          :error-handler (flash-message/default-error-handler :top "Fetch handled organizations")}))

--- a/test/clj/rems/test_browser.clj
+++ b/test/clj/rems/test_browser.clj
@@ -1016,6 +1016,7 @@
         (btu/scroll-and-click [:handled-applications-collapse {:fn/text "Show all rows"}])
         (btu/wait-for-animation)
         (btu/scroll-and-click [:handled-applications-paging-pages {:fn/text "10"}])
+        (btu/wait-visible {:fn/text "test-processed-applications-10"}) ; wait for at least one to appear before checking all
         (is (= (for [i (range 10 0 -1)]
                  (str "test-processed-applications-" i))
                (mapv #(get % "description") (slurp-rows :handled-applications))))
@@ -2816,6 +2817,7 @@
             (is (not (btu/visible? {:css ".edit-organization"})))
 
             (go-to-admin "Organizations")
+            (btu/scroll-and-click {:fn/text "Own organization only"}) ; not part of it anymore
             (is (= "View"
                    (->> (slurp-table :organizations)
                         (some #(when (= "SNEN" (get % "short-name"))

--- a/test/clj/rems/test_browser.clj
+++ b/test/clj/rems/test_browser.clj
@@ -2816,13 +2816,23 @@
                    (slurp-fields :organization)))
             (is (not (btu/visible? {:css ".edit-organization"})))
 
-            (go-to-admin "Organizations")
-            (btu/scroll-and-click {:fn/text "Own organization only"}) ; not part of it anymore
-            (is (= "View"
-                   (->> (slurp-table :organizations)
-                        (some #(when (= "SNEN" (get % "short-name"))
-                                 (get % "commands")))))
-                "organization actions should not be visible for non organization owner")))))))
+            (testing "organization list and own organizations"
+              (go-to-admin "Organizations")
+
+              (is (= nil
+                     (->> (slurp-table :organizations)
+                          (some #(when (= "SNEN" (get % "short-name"))
+                                   (get % "commands")))))
+                  "by default you can see only own organization and this is not anymore")
+
+              ;; toggle other organizations to view
+              (btu/scroll-and-click {:fn/text "Own organization only"})
+
+              (is (= "View"
+                     (->> (slurp-table :organizations)
+                          (some #(when (= "SNEN" (get % "short-name"))
+                                   (get % "commands")))))
+                  "organization actions should not be visible for non organization owner"))))))))
 
 (deftest test-small-navbar
   (testing "create a test application with the API to have another page to navigate to"

--- a/test/clj/rems/test_browser.clj
+++ b/test/clj/rems/test_browser.clj
@@ -2828,6 +2828,8 @@
               ;; toggle other organizations to view
               (btu/scroll-and-click {:fn/text "Own organization only"})
 
+              (btu/wait-visible [:organizations {:fn/text "SNEN"}])
+
               (is (= "View"
                      (->> (slurp-table :organizations)
                           (some #(when (= "SNEN" (get % "short-name"))


### PR DESCRIPTION
Close #2046

- Owners and reporters are shown everything, and no "own organization only" checkbox is shown
- Organization owners are shown only those organizations they own
- Handlers are shown those organizations that they are workflow handlers in

### Handler (shown by default only organizations where they are handlers)
![image](https://github.com/CSCfi/rems/assets/823661/39ea89ae-0211-451d-8b47-10a0018cb0ae)

### Handler looking at all
![image](https://github.com/CSCfi/rems/assets/823661/262e8348-44b6-4339-8053-2e601f302dec)

# Checklist for author

Remove items that aren't applicable, check items that are done.

## Reviewability
- [x] Link to issue
- [x] Consider adding screenshots for ease of review

## Documentation
- [x] Update changelog if necessary
- [ ] Update manual/ (if applicable) (delegated to #3197)

## Testing
- [x] Valuable features are integration / browser / acceptance tested automatically

## Follow-up
- [x] New tasks are created for pending or remaining tasks
