### PR TITLE
Small fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ Changes since v2.34.2
 - Administration dropdown buttons should now respond to clicks more widely, and not only by directly clicking text. (#3167)
 - Catalogue item unarchive should no longer fail when form does not exist. (#3217)
 - Current page updates correctly. (#3218)
+- Show organization in create workflow Forms dropdown (#3230)
+- When copying an item, reset the organization, if it's not owned by the user. (#2880)
 
 ## v2.34.2 "Santakatu +2" 2023-11-03
 

--- a/src/cljs/rems/administration/create_catalogue_item.cljs
+++ b/src/cljs/rems/administration/create_catalogue_item.cljs
@@ -183,7 +183,7 @@
          :items (->> workflows (filter :enabled) (remove :archived))
          :item-key :id
          :item-label #(str (:title %)
-                           " (org: "
+                           " (" (text :t.administration/org) ": "
                            (get-in % [:organization :organization/short-name language])
                            ")")
          :item-selected? item-selected?
@@ -240,7 +240,7 @@
          :items (->> forms (filter :enabled) (remove :archived))
          :item-key :form/id
          :item-label #(str (:form/internal-name %)
-                           " (org: "
+                           " (" (text :t.administration/org) ": "
                            (get-in % [:organization :organization/short-name language])
                            ")")
          :item-selected? item-selected?

--- a/src/cljs/rems/administration/create_resource.cljs
+++ b/src/cljs/rems/administration/create_resource.cljs
@@ -117,7 +117,7 @@
        :items licenses
        :item-key :id
        :item-label #(str (get-localized-title % language)
-                         " (org: "
+                         " (" (text :t.administration/org) ": "
                          (get-in % [:organization :organization/short-name language])
                          ")")
        :item-selected? #(contains? (set selected-licenses) %)

--- a/src/cljs/rems/administration/create_workflow.cljs
+++ b/src/cljs/rems/administration/create_workflow.cljs
@@ -407,7 +407,11 @@
         {:id id
          :items (->> all-forms (filter :enabled) (remove :archived))
          :item-key :form/id
-         :item-label :form/internal-name
+         :item-label (fn [form]
+                       (let [title (:form/internal-name form)
+                             organization (localized (get-in form [:organization
+                                                                   :organization/short-name]))]
+                         (str title " (org: " organization ")")))
          :item-selected? #(contains? selected-form-ids (:form/id %))
          ;; TODO support ordering multiple forms
          :multi? true

--- a/src/cljs/rems/administration/create_workflow.cljs
+++ b/src/cljs/rems/administration/create_workflow.cljs
@@ -202,7 +202,7 @@
                        (let [title (:title (localized (:localizations license)))
                              organization (localized (get-in license [:organization
                                                                       :organization/short-name]))]
-                         (str title " (org: " organization ")"))) ; XXX: workaround for get-localized-title
+                         (str title " (" (text :t.administration/org) ": " organization ")"))) ; XXX: workaround for get-localized-title
          :item-selected? #(contains? (set selected-licenses) %)
          :multi? true
          :on-change #(rf/dispatch [::set-licenses %])}])]))
@@ -411,7 +411,7 @@
                        (let [title (:form/internal-name form)
                              organization (localized (get-in form [:organization
                                                                    :organization/short-name]))]
-                         (str title " (org: " organization ")")))
+                         (str title " (" (text :t.administration/org) ": " organization ")")))
          :item-selected? #(contains? selected-form-ids (:form/id %))
          ;; TODO support ordering multiple forms
          :multi? true

--- a/src/cljs/rems/administration/form.cljs
+++ b/src/cljs/rems/administration/form.cljs
@@ -73,10 +73,11 @@
      :always [:div
               [inline-info-field (text :t.administration/organization) (get-in form [:organization :organization/name language])]
               [inline-info-field (text :t.administration/internal-name) (get-in form [:form/internal-name])]
-              (for [[langcode title] (:form/external-title form)]
-                [inline-info-field (str (text :t.administration/external-title)
-                                        " (" (str/upper-case (name langcode)) ")")
-                 title])
+              (doall (for [[langcode title] (:form/external-title form)]
+                       ^{:key langcode}
+                       [inline-info-field (str (text :t.administration/external-title)
+                                               " (" (str/upper-case (name langcode)) ")")
+                        title]))
               [inline-info-field (text :t.administration/active) [readonly-checkbox {:value (status-flags/active? form)}]]]}]
    (let [id (:form/id form)]
      [:div.col.commands

--- a/src/cljs/rems/atoms.cljs
+++ b/src/cljs/rems/atoms.cljs
@@ -305,7 +305,9 @@
    * `:wait` interval in milliseconds"
   [{:keys [disabled wait] :or {wait 2000} :as props}]
   [button (-> props
-              (dissoc :wait (when disabled :on-click))
+              (dissoc :wait
+                      :loading?
+                      (when disabled :on-click))
               (update-existing :on-click wrap-rate-limit wait))])
 
 (defn action-button

--- a/test/clj/rems/api/test_forms.clj
+++ b/test/clj/rems/api/test_forms.clj
@@ -4,10 +4,9 @@
             [rems.api.schema :as schema]
             [rems.api.testing :refer :all]
             [rems.handler :refer [handler]]
-            [rems.db.api-key :as api-key]
             [rems.db.core :as db]
             [rems.db.test-data-helpers :as test-helpers]
-            [rems.db.testing :refer [owners-fixture +test-api-key+]]
+            [rems.db.testing :refer [owners-fixture]]
             [ring.mock.request :refer :all])
   (:import (java.util UUID)))
 


### PR DESCRIPTION
Close #2880 
Close #3230 

- Show organization in create workflow forms dropdown (was shown everwhere else)
- Use localized "org" text. Could be further improved by localizing `:` and parens too.
- Fixes warning in license view about lazy deref and missing key prop.
- Fixes warning from `:loading?` attribute being passed to HTML where it has invalid meaning.

![image](https://github.com/CSCfi/rems/assets/823661/66eb0d86-567e-423b-b245-69bc1ee22f12)

# Checklist for author

Remove items that aren't applicable, check items that are done.

## Reviewability
- [x] Link to issue
- [x] Consider adding screenshots for ease of review

## Documentation
- [x] Update changelog if necessary

## Testing
- [ ] Complex logic is unit tested
- [ ] Valuable features are integration / browser / acceptance tested automatically

## Follow-up
- [ ] New tasks are created for pending or remaining tasks
