### PR TITLE
Optimize more

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Changes since v2.34.2
 - Catalogue page has been sped up with optimizations. The API supports not joining organization data if not required (`join-organization=false`).
 - Adding a user to blacklist does not reload the full cache anymore. This should make it faster. Also the user is directed to Applications page after delete, not to Catalogue.
 - Deleting a (draft) application is now faster because it does not reload the full cache, only update it.
+- Editing workflows (e.g. handlers) should now be faster because it does not reload the full cache, only update it.
 
 ### Fixes
 - Big improvements in performance from small improvements in how applications and events are processed and cached. REMS should be able to handle a 100k event DB without breaking a sweat. (#2783)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ Changes since v2.34.2
 
 **NB: This release removes the experimental application PDF export API. The non-experimental PDF export API is preferred instead. (#3098)**
 
+### Changes
+- Catalogue page has been sped up with optimizations. The API supports not joining organization data if not required (`join-organization=false`).
+- Adding a user to blacklist does not reload the full cache anymore. This should make it faster. Also the user is directed to Applications page after delete, not to Catalogue.
+- Deleting a (draft) application is now faster because it does not reload the full cache, only update it.
+
 ### Fixes
 - Big improvements in performance from small improvements in how applications and events are processed and cached. REMS should be able to handle a 100k event DB without breaking a sweat. (#2783)
 - Administration dropdown buttons should now respond to clicks more widely, and not only by directly clicking text. (#3167)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,8 +19,6 @@ Changes since v2.34.2
 
 ### Changes
 - Application expiration now logs more, and more often. (#3225)
-
-### Changes
 - Catalogue page has been sped up with optimizations. The API supports not joining organization data if not required (`join-organization=false`).
 - Adding a user to blacklist does not reload the full cache anymore. This should make it faster. Also the user is directed to Applications page after delete, not to Catalogue.
 - Deleting a (draft) application is now faster because it does not reload the full cache, only update it.

--- a/src/clj/rems/api/catalogue.clj
+++ b/src/clj/rems/api/catalogue.clj
@@ -21,12 +21,14 @@
     :tags ["catalogue"]
     (GET "/" []
       :summary "Get the catalogue of items for the UI (does not include archived items)"
+      :query-params [{join-organization :- (describe s/Bool "Should organizations be returned for each item?") true}]
       :return GetCatalogueResponse
       (cond
         (or (:catalogue-is-public env)
             (roles/has-roles? :logged-in))
-        (ok (catalogue/get-catalogue-table (when-not (apply roles/has-roles? roles/+admin-read-roles+)  ; only admins get enabled and disabled items
-                                             {:enabled true})))
+        (ok (catalogue/get-catalogue-table (merge {:join-organization? join-organization}
+                                                  (when-not (apply roles/has-roles? roles/+admin-read-roles+)  ; only admins get enabled and disabled items
+                                                    {:enabled true}))))
 
         (not (roles/has-roles? :logged-in))
         (throw-unauthorized)
@@ -36,12 +38,14 @@
 
     (GET "/tree" []
       :summary "Get the catalogue of items in a tree for the UI (does not include archived items) (EXPERIMENTAL)"
+      :query-params [{join-organization :- (describe s/Bool "Should organizations be returned for each item?") true}]
       :return GetCatalogueTreeResponse
       (cond
         (or (:catalogue-is-public env)
             (roles/has-roles? :logged-in))
         (ok (catalogue/get-catalogue-tree (merge {:archived false
                                                   :expand-catalogue-data? true
+                                                  :join-organization? join-organization
                                                   :empty false}
                                                  (when-not (apply roles/has-roles? roles/+admin-read-roles+)  ; only admins get enabled and disabled items
                                                    {:enabled true}))))

--- a/src/clj/rems/api/schema.clj
+++ b/src/clj/rems/api/schema.clj
@@ -25,7 +25,7 @@
    (s/optional-key :form-name) (s/maybe s/Str)
    :resid s/Str
    :resource-id s/Int
-   :organization schema-base/OrganizationOverview
+   :organization (s/either schema-base/OrganizationId schema-base/OrganizationOverview)
    (s/optional-key :resource-name) s/Str
    :start DateTime
    :end (s/maybe DateTime)

--- a/src/clj/rems/application/eraser.clj
+++ b/src/clj/rems/application/eraser.clj
@@ -18,7 +18,6 @@
         (command/command! cmd)))
     (log/warnf "Cannot process applications, because user %s does not exist"
                expirer-bot/bot-userid))
-  (applications/reload-cache!)
   (log/info :finish #'process-applications!))
 
 (mount/defstate expired-application-poller

--- a/src/clj/rems/application/eraser.clj
+++ b/src/clj/rems/application/eraser.clj
@@ -11,7 +11,7 @@
 
 (defn process-applications! []
   (log/info :start #'process-applications!)
-  ; check that bot user exists, else log missing
+  ;; check that bot user exists, else log missing
   (if (users/user-exists? expirer-bot/bot-userid)
     (doseq [application (applications/get-all-unrestricted-applications)]
       (when-some [cmd (expirer-bot/run-expirer-bot application)]

--- a/src/clj/rems/application/events_cache.clj
+++ b/src/clj/rems/application/events_cache.clj
@@ -35,6 +35,21 @@
       (compare-and-set! cache cached updated))
     (:state updated)))
 
+(defn update-cache!
+  "Updates the cache with any update.
+   `update-fn` should be a function which takes as parameters the previously
+   cached state and a list of new events, and returns the updated state."
+  [cache update-fn]
+  (let [cache-enabled? (atom? cache)
+        cached (if cache-enabled? @cache empty-cache)
+        updated {:state (update-fn (:state cached))
+                 :last-processed-event-id (:last-processed-event-id cached)}]
+    (when (and cache-enabled?
+               (not (identical? cached updated)))
+      ;; with concurrent requests, only one of them will update the cache
+      (compare-and-set! cache cached updated))
+    (:state updated)))
+
 (defn empty! [cache]
   (when (atom? cache)
     (reset! cache empty-cache)))

--- a/src/clj/rems/application/process_managers.clj
+++ b/src/clj/rems/application/process_managers.clj
@@ -28,9 +28,7 @@
   [new-events]
   (doseq [event new-events]
     (when (= :application.event/deleted (:event/type event))
-      (if (= expirer-bot/bot-userid (:event/actor event)) ; will reload in the end
-        (applications/delete-application! (:application/id event))
-        (applications/delete-application-and-reload-cache! (:application/id event))))))
+      (applications/delete-application! (:application/id event)))))
 
 (defn delete-orphan-attachments [application-id]
   (let [application (applications/get-application-internal application-id)

--- a/src/clj/rems/db/applications.clj
+++ b/src/clj/rems/db/applications.clj
@@ -291,7 +291,7 @@
                                ;; remove users updated in this round
                                (map-vals (fn [users] (apply disj users updated-users)))
                                ;; add users back to correct groups
-                               (merge-with set/union (group-users-by-role (vals new-updated-raw-apps)))
+                               (merge-with set/union (group-users-by-role (vals new-updated-enriched-apps)))
                                doall)]
 
     {::raw-apps new-raw-apps

--- a/src/clj/rems/db/applications.clj
+++ b/src/clj/rems/db/applications.clj
@@ -380,6 +380,7 @@
 
 (defn delete-application!
   [app-id]
+  (refresh-all-applications-cache!) ; NB: try make sure the cache is up to date so we have any new applications present
   (let [application (get-application app-id)]
     (assert (= :application.state/draft (:application/state application))
             (str "Tried to delete application " app-id " which is not a draft!"))

--- a/src/clj/rems/db/organizations.clj
+++ b/src/clj/rems/db/organizations.clj
@@ -72,7 +72,6 @@
                                   getx-organization-by-id
                                   (select-keys [:organization/id :organization/name :organization/short-name]))]
     (-> x
-        (update-existing :organization (fn [_] organization-overview))
         (update-existing :organization (fn [_] organization-overview)))))
 
 (defn set-organization! [organization]

--- a/src/clj/rems/service/blacklist.clj
+++ b/src/clj/rems/service/blacklist.clj
@@ -12,14 +12,18 @@
    :event/comment (:comment command)})
 
 (defn add-user-to-blacklist! [actor command]
-  (blacklist/add-event! (-> (command->event command actor)
-                            (assoc :event/type :blacklist.event/add)))
-  (applications/reload-cache!))
+  (let [event (-> (command->event command actor)
+                  (assoc :event/type :blacklist.event/add))]
+    (blacklist/add-event! event)
+    (applications/empty-injection-cache! :blacklisted?)
+    (applications/reload-applications! {:by-userid (get-in command [:blacklist/user :userid])})))
 
 (defn remove-user-from-blacklist! [actor command]
-  (blacklist/add-event! (-> (command->event command actor)
-                            (assoc :event/type :blacklist.event/remove)))
-  (applications/reload-cache!))
+  (let [event (-> (command->event command actor)
+                  (assoc :event/type :blacklist.event/remove))]
+    (blacklist/add-event! event)
+    (applications/empty-injection-cache! :blacklisted?)
+    (applications/reload-applications! {:by-userid (get-in command [:blacklist/user :userid])})))
 
 (defn- format-blacklist-entry [entry]
   {:blacklist/resource {:resource/ext-id (:resource/ext-id entry)}

--- a/src/clj/rems/service/blacklist.clj
+++ b/src/clj/rems/service/blacklist.clj
@@ -16,14 +16,14 @@
                   (assoc :event/type :blacklist.event/add))]
     (blacklist/add-event! event)
     (applications/empty-injection-cache! :blacklisted?)
-    (applications/reload-applications! {:by-userid (get-in command [:blacklist/user :userid])})))
+    (applications/reload-applications! {:by-userids [(get-in command [:blacklist/user :userid])]})))
 
 (defn remove-user-from-blacklist! [actor command]
   (let [event (-> (command->event command actor)
                   (assoc :event/type :blacklist.event/remove))]
     (blacklist/add-event! event)
     (applications/empty-injection-cache! :blacklisted?)
-    (applications/reload-applications! {:by-userid (get-in command [:blacklist/user :userid])})))
+    (applications/reload-applications! {:by-userids [(get-in command [:blacklist/user :userid])]})))
 
 (defn- format-blacklist-entry [entry]
   {:blacklist/resource {:resource/ext-id (:resource/ext-id entry)}

--- a/src/cljs/rems/application.cljs
+++ b/src/cljs/rems/application.cljs
@@ -1020,8 +1020,8 @@
         show-comment-field? (is-handling-user? application)
         actions (action-buttons application config)
         reload (r/partial reload! app-id)
-        go-to-catalogue #(do (flash-message/show-default-success! :top [text :t.actions/delete])
-                             (navigate! "/catalogue"))]
+        go-to-applications #(do (flash-message/show-default-success! :top [text :t.actions/delete])
+                                (navigate! "/applications"))]
     (when (seq actions)
       [collapsible/component
        {:id "actions-collapse"
@@ -1044,7 +1044,7 @@
                   [return-form app-id reload]
                   [approve-reject-form app-id reload]
                   [assign-external-id-form app-id reload]
-                  [delete-form app-id go-to-catalogue]
+                  [delete-form app-id go-to-applications]
                   [vote-form app-id application reload]]]}])))
 
 (defn- render-resource [resource language]

--- a/src/cljs/rems/catalogue.cljs
+++ b/src/cljs/rems/catalogue.cljs
@@ -17,12 +17,12 @@
  ::enter-page
  (fn [{:keys [db]} _]
    {:db (dissoc db ::catalogue ::draft-applications)
-    :dispatch-n [(when (:enable-catalogue-table (:config db))
-                   [::full-catalogue])
+    :dispatch-n [[:rems.table/reset]
+                 (when (roles/is-logged-in? (get-in db [:identity :roles])) [::draft-applications])
                  (when (:enable-catalogue-tree (:config db))
                    [::full-catalogue-tree])
-                 (when (roles/is-logged-in? (get-in db [:identity :roles])) [::draft-applications])
-                 [:rems.table/reset]]}))
+                 (when (:enable-catalogue-table (:config db))
+                   [::full-catalogue])]}))
 
 (fetcher/reg-fetcher ::full-catalogue "/api/catalogue?join-organization=false")
 (fetcher/reg-fetcher ::full-catalogue-tree "/api/catalogue/tree?join-organization=false" {:result :roots})
@@ -166,18 +166,24 @@
      [document-title (text :t.catalogue/catalogue)]
      [flash-message/component :top]
      (text :t.catalogue/intro)
-     (if (or @(rf/subscribe [::full-catalogue :fetching?])
-             @(rf/subscribe [::full-catalogue-tree :fetching?])
-             @(rf/subscribe [::draft-applications :fetching?]))
-       [spinner/big]
-       [:div
-        (when @(rf/subscribe [:logged-in])
-          [:<>
-           [draft-application-list]
-           (when (:enable-cart config)
-             [cart/cart-list-container])
-           [:h2 (text :t.catalogue/apply-resources)]])
-        (when (:enable-catalogue-tree config)
-          [catalogue-tree])
-        (when (:enable-catalogue-table config)
-          [catalogue-table])])]))
+     [:div
+      (when @(rf/subscribe [:logged-in])
+        [:<>
+         [draft-application-list]
+
+         (when (:enable-cart config)
+           (when-not (or @(rf/subscribe [::full-catalogue :fetching?])
+                         @(rf/subscribe [::full-catalogue-tree :fetching?]))
+             [cart/cart-list-container]))
+
+         [:h2 (text :t.catalogue/apply-resources)]])
+
+      (when (:enable-catalogue-tree config)
+        (if @(rf/subscribe [::full-catalogue :fetching?])
+          [spinner/big]
+          [catalogue-tree]))
+
+      (when (:enable-catalogue-table config)
+        (if @(rf/subscribe [::full-catalogue-tree :fetching?])
+          [spinner/big]
+          [catalogue-table]))]]))

--- a/src/cljs/rems/catalogue.cljs
+++ b/src/cljs/rems/catalogue.cljs
@@ -24,8 +24,8 @@
                  (when (roles/is-logged-in? (get-in db [:identity :roles])) [::draft-applications])
                  [:rems.table/reset]]}))
 
-(fetcher/reg-fetcher ::full-catalogue "/api/catalogue")
-(fetcher/reg-fetcher ::full-catalogue-tree "/api/catalogue/tree" {:result :roots})
+(fetcher/reg-fetcher ::full-catalogue "/api/catalogue?join-organization=false")
+(fetcher/reg-fetcher ::full-catalogue-tree "/api/catalogue/tree?join-organization=false" {:result :roots})
 
 (rf/reg-sub
  ::catalogue

--- a/test/clj/rems/application/test_eraser.clj
+++ b/test/clj/rems/application/test_eraser.clj
@@ -61,13 +61,6 @@
   (->> (applications/get-all-applications user-id)
        (map :application/id)))
 
-(def original-log* log/log*)
-
-(defn- log*-mock [coll-atom]
-  (fn [logger level throwable message]
-    (original-log* logger level throwable message)
-    (swap! coll-atom conj {:logger logger :level level :throwable throwable :message message})))
-
 (deftest test-expire-application
   (let [_ (test-helpers/create-user! {:userid "alice"})
         draft (create-application! {:draft? true

--- a/test/clj/rems/application/test_eraser.clj
+++ b/test/clj/rems/application/test_eraser.clj
@@ -104,6 +104,7 @@
 
         (test-helpers/create-user! {:userid expirer-bot/bot-userid})
         (roles/add-role! expirer-bot/bot-userid :expirer)
+        (applications/reload-cache!) ; we change roles which affect applications
 
         (testing "does not delete applications when configuration is not valid"
           (reset! log-messages [])

--- a/test/clj/rems/application/test_eraser.clj
+++ b/test/clj/rems/application/test_eraser.clj
@@ -67,8 +67,11 @@
   (->> (applications/get-all-applications user-id)
        (map :application/id)))
 
+(def original-log* log/log*)
+
 (defn- log*-mock [coll-atom]
   (fn [logger level throwable message]
+    (original-log* logger level throwable message)
     (swap! coll-atom conj {:logger logger :level level :throwable throwable :message message})))
 
 (deftest test-expire-application

--- a/test/clj/rems/application/test_rejecter_bot.clj
+++ b/test/clj/rems/application/test_rejecter_bot.clj
@@ -5,10 +5,10 @@
             [rems.application.rejecter-bot :as rejecter-bot]
             [rems.db.applications :as applications]
             [rems.db.test-data-helpers :as test-helpers]
-            [rems.db.testing :refer [test-db-fixture rollback-db-fixture]]))
+            [rems.db.testing :refer [test-db-fixture reset-caches-fixture rollback-db-fixture]]))
 
 (use-fixtures :once test-db-fixture)
-(use-fixtures :each rollback-db-fixture)
+(use-fixtures :each rollback-db-fixture reset-caches-fixture)
 
 ;; These tests are integration tests via rems.service.command
 ;; since we'd need to mock get-application to unit-test

--- a/test/clj/rems/db/test_applications.clj
+++ b/test/clj/rems/db/test_applications.clj
@@ -91,7 +91,7 @@
     (is (= "1980/2" (application-external-id! (DateTime. #inst "1980-12-12"))))
     (is (= "1981/4" (application-external-id! (DateTime. #inst "1981-04-01"))))))
 
-(deftest test-delete-application-and-reload-cache!
+(deftest test-delete-application!
   (let [_ (test-helpers/create-user! {:userid "applicant1"})
         _ (test-helpers/create-user! {:userid "applicant2"})
         _ (test-helpers/create-user! {:userid "unrelated"})
@@ -102,7 +102,7 @@
     (is (= #{:applicant} (applications/get-all-application-roles "applicant1")))
     (is (= #{"applicant1" "applicant2"} (applications/get-users-with-role :applicant)))
 
-    (applications/delete-application-and-reload-cache! app-id1)
+    (applications/delete-application! app-id1)
 
     (testing "application disappears from my applications"
       (is (= [] (applications/get-my-applications "applicant1"))))
@@ -126,12 +126,12 @@
                             :type :application.command/submit
                             :actor "applicant1"})
     (testing "can't delete submitted application"
-      (is (thrown? AssertionError (applications/delete-application-and-reload-cache! app-id1))))
+      (is (thrown? AssertionError (applications/delete-application! app-id1))))
     (test-helpers/command! {:application-id app-id1
                             :type :application.command/return
                             :actor "developer"})
     (testing "can't delete returned application"
-      (is (thrown? AssertionError (applications/delete-application-and-reload-cache! app-id1))))))
+      (is (thrown? AssertionError (applications/delete-application! app-id1))))))
 
 (deftest test-cache-reload
   (let [_ (test-helpers/create-user! {:userid "applicant1"})

--- a/test/clj/rems/db/test_applications.clj
+++ b/test/clj/rems/db/test_applications.clj
@@ -146,6 +146,7 @@
     (is (= [app-id1] (map :application/id (applications/get-my-applications "applicant1"))))
     (is (= #{:applicant} (applications/get-all-application-roles "applicant1")))
     (is (= #{"applicant1"} (applications/get-users-with-role :applicant)))
+    (is (= #{"handler"} (applications/get-users-with-role :handler)))
 
     (test-helpers/command! {:type :application.command/add-member
                             :application-id app-id1
@@ -154,6 +155,7 @@
 
     (is (= #{"applicant1"} (applications/get-users-with-role :applicant)))
     (is (= #{"applicant2"} (applications/get-users-with-role :member)))
+    (is (= #{"handler"} (applications/get-users-with-role :handler)))
 
     (test-helpers/command! {:type :application.command/change-applicant
                             :application-id app-id1
@@ -162,6 +164,7 @@
 
     (is (= #{"applicant2"} (applications/get-users-with-role :applicant)))
     (is (= #{"applicant1"} (applications/get-users-with-role :member)))
+    (is (= #{"handler"} (applications/get-users-with-role :handler)))
 
     (test-helpers/command! {:type :application.command/remove-member
                             :application-id app-id1
@@ -170,6 +173,7 @@
 
     (is (= #{"applicant2"} (applications/get-users-with-role :applicant)))
     (is (= #{} (applications/get-users-with-role :member)))
+    (is (= #{"handler"} (applications/get-users-with-role :handler)))
 
     (testing "application disappears from my applications"
       (is (= [] (applications/get-my-applications "applicant1"))))


### PR DESCRIPTION
- Catalogue page has been sped up with optimizations. The API supports not joining organization data if not required (`join-organization=false`).
- Adding a user to blacklist does not reload the full cache anymore. This should make it faster. Also the user is directed to Applications page after delete, not to Catalogue.
- Deleting a (draft) application is now faster because it does not reload the full cache, only update it.
- Editing workflows (e.g. handlers) should now be faster because it does not reload the full cache, only update it.

# Checklist for author

Remove items that aren't applicable, check items that are done.

## Reviewability
- [ ] Link to issue

## Backwards compatibility
- [x] API is backwards compatible or completely new

## Documentation
- [x] Update changelog if necessary
