### PR TITLE
Add optional text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ have notable changes.
 
 Changes since v2.35
 
+### Fixes
+- Mark form as optional in catalogue item creation. Also consider categories optional unless the catalogue tree is enabled. (#3244)
+
 ## v2.35 "Selkämerenkatu" 2023-12-13
 
 **NB: This release removes the experimental application PDF export API. The non-experimental PDF export API is preferred instead. (#3098)**

--- a/src/cljs/rems/administration/create_catalogue_item.cljs
+++ b/src/cljs/rems/administration/create_catalogue_item.cljs
@@ -230,7 +230,10 @@
         item-selected? #(= (:form/id %) (:form/id selected-form))
         language @(rf/subscribe [:language])]
     [:div.form-group
-     [:label.administration-field-label {:for form-dropdown-id} (text :t.administration/form)]
+     [:label.administration-field-label {:for form-dropdown-id}
+      (text :t.administration/form)
+      " "
+      (text :t.administration/optional)]
      (if editing?
        (let [form (item-by-id forms :form/id (:form/id selected-form))]
          [fields/readonly-field {:id form-dropdown-id
@@ -251,9 +254,13 @@
 (defn- catalogue-item-categories-field []
   (let [categories @(rf/subscribe [::categories])
         selected-categories @(rf/subscribe [::selected-categories])
-        item-selected? (set selected-categories)]
+        item-selected? (set selected-categories)
+        config @(rf/subscribe [:rems.config/config])]
     [:div.form-group
-     [:label.administration-field-label {:for categories-dropdown-id} (text :t.administration/categories)]
+     [:label.administration-field-label {:for categories-dropdown-id}
+      (text :t.administration/categories)
+      (when-not (:enable-catalogue-tree config)
+        (str " " (text :t.administration/optional)))]
      [dropdown/dropdown
       {:id categories-dropdown-id
        :items categories

--- a/test/clj/rems/test_browser.clj
+++ b/test/clj/rems/test_browser.clj
@@ -1614,7 +1614,7 @@
             "More info URL (optional) (EN)" ""
             "More info URL (optional) (FI)" ""
             "More info URL (optional) (SV)" ""
-            "Form" "test-edit-catalogue-item form"
+            "Form (optional)" "test-edit-catalogue-item form"
             "Categories" "No categories"
             "Workflow" "test-edit-catalogue-item workflow"
             "Resource" "test-edit-catalogue-item resource"}
@@ -1655,7 +1655,7 @@
                 "More info URL (optional) (EN)" "http://google.com"
                 "More info URL (optional) (FI)" ""
                 "More info URL (optional) (SV)" ""
-                "Form" "test-edit-catalogue-item form"
+                "Form (optional)" "test-edit-catalogue-item form"
                 "Categories" "No categories"
                 "Workflow" "test-edit-catalogue-item workflow"
                 "Resource" "test-edit-catalogue-item resource"}


### PR DESCRIPTION
Fix #3244

- Forms are always optional
- Categories are optional when there is no catalogue tree (in screenshot)

![image](https://github.com/CSCfi/rems/assets/823661/3a05f77e-c63b-4e8b-9980-158b8cfdc604)

# Checklist for author

Remove items that aren't applicable, check items that are done.

## Reviewability
- [x] Link to issue
- [x] Consider adding screenshots for ease of review

## Documentation
- [x] Update changelog if necessary
