### PR TITLE
Remove unsupported JVM flag --illegal-access

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -30,7 +30,7 @@ for cmd in "${cmd_array[@]}"
 do
     [ "${cmd}" = "run" ] && cmd_prefix="exec"
 
-    FULL_COMMAND="${cmd_prefix} java --illegal-access=deny -Drems.config=config/config.edn -jar rems.jar ${cmd}"
+    FULL_COMMAND="${cmd_prefix} java -Drems.config=config/config.edn -jar rems.jar ${cmd}"
     echo "####################"
     echo "########## RUNNING COMMAND: ${FULL_COMMAND}"
     echo "####################"


### PR DESCRIPTION
closes #2934 

I think `docker-entrypoint.sh` was the only place using this flag, based on grepping.

# Checklist for author

Remove items that aren't applicable, check items that are done.

## Reviewability
- [x] Link to issue
- [ ] Note if related change in rems-deploy repo

## Follow-up
- [ ] New tasks are created for pending or remaining tasks
