### PR TITLE
Refactor uses of getx/getx-in helper

### DIFF
--- a/src/clj/rems/api/blacklist.clj
+++ b/src/clj/rems/api/blacklist.clj
@@ -7,11 +7,12 @@
             [rems.api.util :refer [extended-logging unprocessable-entity-json-response]] ; required for route :roles
             [rems.application.rejecter-bot :as rejecter-bot]
             [rems.common.roles :refer [+admin-read-roles+]]
+            [rems.common.util :refer [getx-in]]
             [rems.db.resource :as resource]
             [rems.db.users :as users]
             [rems.db.user-mappings :as user-mappings]
             [rems.schema-base :as schema-base]
-            [rems.util :refer [getx-in getx-user-id]]
+            [rems.util :refer [getx-user-id]]
             [ring.util.http-response :refer [ok]]
             [schema.core :as s])
   (:import [org.joda.time DateTime]))

--- a/src/clj/rems/application/commands.clj
+++ b/src/clj/rems/application/commands.clj
@@ -4,11 +4,11 @@
             [medley.core :refer [assoc-some distinct-by update-existing]]
             [rems.common.application-util :as application-util]
             [rems.common.form :as form]
-            [rems.common.util :refer [build-index]]
+            [rems.common.util :refer [getx getx-in build-index]]
             [rems.form-validation :as form-validation]
             [rems.permissions :as permissions]
             [rems.schema-base :as schema-base]
-            [rems.util :refer [assert-ex getx getx-in try-catch-ex]]
+            [rems.util :refer [assert-ex try-catch-ex]]
             [schema-refined.core :as r]
             [schema.core :as s]
             [clj-time.core :as time])

--- a/src/clj/rems/auth/oidc.clj
+++ b/src/clj/rems/auth/oidc.clj
@@ -5,6 +5,7 @@
             [clojure.tools.logging :as log]
             [compojure.core :refer [GET defroutes]]
             [medley.core :refer [find-first]]
+            [rems.common.util :refer [getx]]
             [rems.config :refer [env oidc-configuration]]
             [rems.db.user-mappings :as user-mappings]
             [rems.db.users :as users]
@@ -12,7 +13,6 @@
             [rems.json :as json]
             [rems.jwt :as jwt]
             [rems.plugins :as plugins]
-            [rems.util :refer [getx]]
             [ring.util.response :refer [redirect]])
   (:import [java.time Instant]))
 

--- a/src/clj/rems/db/outbox.clj
+++ b/src/clj/rems/db/outbox.clj
@@ -1,10 +1,10 @@
 (ns rems.db.outbox
   (:require [clj-time.core :as time]
             [clojure.test :refer [deftest is testing]]
+            [rems.common.util :refer [getx]]
             [rems.db.core :as db]
             [rems.db.pg-util :refer [pg-interval->joda-duration joda-duration->pg-interval]]
             [rems.json :as json]
-            [rems.util :refer [getx]]
             [schema.coerce :as coerce]
             [schema.core :as s])
   (:import [org.joda.time Duration DateTime]))

--- a/src/clj/rems/email/template.clj
+++ b/src/clj/rems/email/template.clj
@@ -2,12 +2,12 @@
   (:require [clojure.string :as str]
             [rems.application.model :as model]
             [rems.common.application-util :as application-util]
+            [rems.common.util :refer [getx]]
             [rems.config :refer [env]]
             [rems.context :as context]
             [rems.db.user-settings :as user-settings]
             [rems.permissions :as permissions]
-            [rems.text :refer [localize-user localize-utc-date text text-no-fallback text-format-map with-language]]
-            [rems.util :as util]))
+            [rems.text :refer [localize-user localize-utc-date text text-no-fallback text-format-map with-language]]))
 
 ;;; Mapping events to emails
 
@@ -23,7 +23,7 @@
 
 (defn- format-application-for-email [application]
   (str
-   (case (util/getx env :application-id-column)
+   (case (getx env :application-id-column)
      :generated-and-assigned-external-id (:application/external-id application)
      :external-id (:application/external-id application)
      :id (:application/id application))

--- a/src/clj/rems/event_notification.clj
+++ b/src/clj/rems/event_notification.clj
@@ -5,12 +5,12 @@
             [clojure.tools.logging :as log]
             [mount.core :as mount]
             [rems.api.schema :as schema]
+            [rems.common.util :refer [getx]]
             [rems.config]
             [rems.db.applications :as applications]
             [rems.db.outbox :as outbox]
             [rems.json :as json]
-            [rems.scheduler :as scheduler]
-            [rems.util :refer [getx]]))
+            [rems.scheduler :as scheduler]))
 
 (def ^:private default-timeout 60)
 

--- a/src/clj/rems/migrations/multiple_forms.clj
+++ b/src/clj/rems/migrations/multiple_forms.clj
@@ -1,7 +1,7 @@
 (ns rems.migrations.multiple-forms
   (:require [hugsql.core :as hugsql]
-            [rems.json :as json]
-            [rems.util :refer [getx]]))
+            [rems.common.util :refer [getx]]
+            [rems.json :as json]))
 
 (hugsql/def-db-fns-from-string
   "

--- a/src/clj/rems/pdf.clj
+++ b/src/clj/rems/pdf.clj
@@ -5,11 +5,10 @@
             [clojure.string :as str]
             [rems.common.application-util :as application-util]
             [rems.common.form :as form]
-            [rems.common.util :refer [build-index index-by]]
+            [rems.common.util :refer [getx build-index index-by]]
             [rems.config :refer [env]]
             [rems.context :as context]
-            [rems.text :refer [localized localize-decision localize-event localize-attachment localize-state localize-time text text-format with-language]]
-            [rems.util :refer [getx]])
+            [rems.text :refer [localized localize-decision localize-event localize-attachment localize-state localize-time text text-format with-language]])
   (:import [java.io ByteArrayOutputStream]))
 
 (def heading-style {:spacing-before 20})

--- a/src/clj/rems/service/attachment.clj
+++ b/src/clj/rems/service/attachment.clj
@@ -6,9 +6,9 @@
             [rems.application.model :as model]
             [rems.auth.util :refer [throw-forbidden]]
             [rems.common.attachment-util :refer [getx-filename]]
+            [rems.common.util :refer [getx]]
             [rems.db.applications :as applications]
             [rems.db.attachments :as attachments]
-            [rems.util :refer [getx]]
             [ring.util.http-response :refer [ok content-type header]])
   (:import [java.io ByteArrayInputStream ByteArrayOutputStream]
            [java.util.zip ZipOutputStream ZipEntry ZipException]))

--- a/src/clj/rems/service/permissions.clj
+++ b/src/clj/rems/service/permissions.clj
@@ -4,9 +4,10 @@
             [rems.auth.util :refer [throw-forbidden]]
             [rems.db.core :as db]
             [rems.common.roles :refer [has-roles?]]
+            [rems.common.util :refer [getx]]
             [rems.config :refer [env]]
             [rems.ga4gh :as ga4gh]
-            [rems.util :refer [getx getx-user-id]]))
+            [rems.util :refer [getx-user-id]]))
 
 (defn get-jwks []
   (let [jwk (getx env :ga4gh-visa-public-key)]

--- a/src/clj/rems/util.clj
+++ b/src/clj/rems/util.clj
@@ -2,6 +2,7 @@
   (:require [clojure.java.io :as io]
             [buddy.core.nonce :as buddy-nonce]
             [buddy.core.codecs :as buddy-codecs]
+            [rems.common.util :refer [getx]]
             [rems.context :as context])
   (:import [clojure.lang Atom]
            [java.io ByteArrayOutputStream FileInputStream]))
@@ -10,19 +11,6 @@
   "Throw a RuntimeException, args passed to `clojure.core/format`."
   [& fmt-args]
   (throw (RuntimeException. (apply format fmt-args))))
-
-(defn getx
-  "Like `get` but throws an exception if the key is not found."
-  [m k]
-  (let [e (get m k ::sentinel)]
-    (if-not (= e ::sentinel)
-      e
-      (throw (ex-info "Missing required key" {:map m :key k})))))
-
-(defn getx-in
-  "Like `get-in` but throws an exception if the key is not found."
-  [m ks]
-  (reduce getx m ks))
 
 (def never-match-route
   (constantly nil))
@@ -83,7 +71,6 @@
                                 :bytes (.toByteArray baos)})))
           (recur files))
         files))))
-
 
 (defn delete-directory-contents-recursively
   "Deletes `dir` contents recursively, if the `dir` exists.

--- a/src/cljc/rems/common/util.cljc
+++ b/src/cljc/rems/common/util.cljc
@@ -180,7 +180,6 @@
   (is (= "fdce:de09:d25d:b23e:de8:d0e8:de8:de8"
          (first (re-matches +reserved-ipv6-range-regex+ "fdce:de09:d25d:b23e:de8:d0e8:de8:de8")))))
 
-;; TODO remove separate clj and cljs implementations of getx and getx-in
 (defn getx
   "Like `get` but throws an exception if the key is not found."
   [m k]

--- a/src/cljs/rems/util.cljs
+++ b/src/cljs/rems/util.cljs
@@ -6,20 +6,6 @@
             [goog.string :refer [format]]
             [re-frame.core :as rf]))
 
-;; TODO move to cljc
-(defn getx
-  "Like `get` but throws an exception if the key is not found."
-  [m k]
-  (let [e (get m k ::sentinel)]
-    (if-not (= e ::sentinel)
-      e
-      (throw (ex-info "Missing required key" {:map m :key k})))))
-
-(defn getx-in
-  "Like `get-in` but throws an exception if the key is not found."
-  [m ks]
-  (reduce getx m ks))
-
 (defn replace-url!
   "Navigates to the given URL without adding a browser history entry."
   [url]

--- a/test/clj/rems/application/test_commands.clj
+++ b/test/clj/rems/application/test_commands.clj
@@ -3,8 +3,9 @@
             [rems.application.commands :as commands]
             [rems.application.events :as events]
             [rems.application.model :as model]
+            [rems.common.util :refer [getx]]
             [rems.permissions :as permissions]
-            [rems.util :refer [assert-ex getx]]
+            [rems.util :refer [assert-ex]]
             [rems.testing-util :refer [with-fixed-time]]
             [clj-time.core :as time])
   (:import [clojure.lang ExceptionInfo]

--- a/test/clj/rems/browser_test_util.clj
+++ b/test/clj/rems/browser_test_util.clj
@@ -6,7 +6,7 @@
             [clojure.java.io :as io]
             [clojure.stacktrace]
             [clojure.string :as str]
-            [clojure.test :refer :all]
+            [clojure.test :refer [compose-fixtures]]
             [clojure.tools.logging :as log]
             [com.rpl.specter :refer [ALL select]]
             [etaoin.api :as et]
@@ -330,7 +330,6 @@
   [filename q]
   (screenshot-element filename [q {:xpath "./../../.."}]))
 
-
 (defn dump-content [content filename]
   (when (seq content)
     (let [full-filename (format "%03d-%s-%s%s"
@@ -387,7 +386,6 @@
 (def accept-alert (wrap-etaoin et/accept-alert))
 (def reload (wrap-etaoin et/reload))
 ;; TODO add more of etaoin here
-
 
 ;;; etaoin extensions
 
@@ -475,7 +473,6 @@
 
 (defn wait-page-loaded []
   (wait-invisible {:css ".fa-spinner"}))
-
 
 (defn field-visible? [label]
   (or (visible? [{:css ".fields"}
@@ -660,7 +657,6 @@
      (catch Exception e#
        (rems.browser-test-util/postmortem-handler e#)
        (throw e#))))
-
 
 (defn wait-for-animation
   "Waits for a short while for animations to finish.

--- a/test/clj/rems/test_browser.clj
+++ b/test/clj/rems/test_browser.clj
@@ -11,7 +11,7 @@
   (:require [clj-http.client :as http]
             [clojure.string :as str]
             [clojure.set :refer [intersection]]
-            [clojure.test :refer :all]
+            [clojure.test :refer [deftest is testing use-fixtures]]
             [com.rpl.specter :refer [select ALL]]
             [etaoin.keys]
             [medley.core :refer [find-first]]

--- a/test/clj/rems/test_locales.clj
+++ b/test/clj/rems/test_locales.clj
@@ -6,11 +6,11 @@
             [clojure.test :refer [deftest is testing]]
             [clojure.tools.logging]
             [clojure.tools.logging.test :as log-test]
-            [rems.common.util :refer [recursive-keys]]
+            [rems.common.util :refer [getx-in recursive-keys]]
             [rems.locales :as locales]
             [rems.tempura]
             [rems.testing-util :refer [create-temp-dir]]
-            [rems.util :refer [getx-in delete-directory-recursively]]
+            [rems.util :refer [delete-directory-recursively]]
             [taoensso.tempura.impl])
   (:import (java.io FileNotFoundException)))
 

--- a/test/cljs/rems/administration/test_create_form.cljs
+++ b/test/cljs/rems/administration/test_create_form.cljs
@@ -2,9 +2,9 @@
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [rems.administration.create-form :refer [build-request build-request-field build-localized-string]]
+            [rems.common.util :refer [getx-in]]
             [rems.identity] ; XXX: initializes missing event handlers like :set-roles
-            [rems.testing :refer [init-spa-fixture]]
-            [rems.util :refer [getx-in]]))
+            [rems.testing :refer [init-spa-fixture]]))
 
 (use-fixtures :each init-spa-fixture)
 


### PR DESCRIPTION
Changed all uses of `getx` and `getx-in` to use cljc instead of clj/cljs, and removed clj/cljs implementations (as they are identical).