### PR TITLE
Form editor perf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,11 @@ Changes since v2.37
 ### Changes
 - The performance has been improved when there are many handlers. (#3283)
 - The error message "shake" animation has been removed. (#3298)
+- The collapsible component no longer animates on open/close.
 - If REMS is trying to send email, and if the address has an obvious problem,
   REMS will not try sending it again, but gives up immediately. This should
   avoid having many hopeless retries, if there is a typo in an email address.
+- Form editor performance has been significantly improved. To give rough numbers, the editor now works smoothly with 200 form fields in test data. (#3105)
 
 ## v2.37 "Laivapojankatu" 2024-05-16
 

--- a/project.clj
+++ b/project.clj
@@ -116,7 +116,7 @@
                                 [com.clojure-goes-fast/clj-async-profiler "1.2.0"] ; also check extra :jvm-opts https://github.com/clojure-goes-fast/clj-async-profiler?tab=readme-ov-file#tuning-for-better-accuracy
                                 [com.clojure-goes-fast/clj-memory-meter "0.3.0"]
                                 [criterium "0.4.6"]
-                                [lambdaisland/kaocha "1.87.1366"]
+                                [lambdaisland/kaocha "1.91.1392"]
                                 [lambdaisland/kaocha-junit-xml "1.17.101"]
                                 [etaoin "1.0.40"]
                                 [ring/ring-mock "0.4.0" :exclusions [cheshire]]

--- a/resources/translations/da.edn
+++ b/resources/translations/da.edn
@@ -316,10 +316,8 @@
               :continue-existing-application "Genoptag ansøgning"
               :continue-existing-application-intro ""
               :apply-resources "Ansøg om ressourcer"}
-  :collapse {:hide "Skjul"
-             :show "Vis"
-             :show-less "Vis mindre"
-             :show-more "Vis mere"}
+  :collapse {:hide "Vis mindre"
+             :show "Vis mere"}
   :update-catalogue-item {:update-catalogue-item-intro "Du er ved at opdatera nedenstående ressourcer. Ændringerne foretages en ad gangen, så hver gammel ressource tages væk og en ny kopi vil benytte den valgte blanket og arbejdsgang."
                           :form-selection "Blanket"
                           :workflow-selection "Arbejdsgang"}

--- a/resources/translations/en.edn
+++ b/resources/translations/en.edn
@@ -341,10 +341,8 @@
               :continue-existing-application "Continue application"
               :continue-existing-application-intro ""
               :apply-resources "Apply for access"}
-  :collapse {:hide "Hide"
-             :show "Show"
-             :show-less "Show less"
-             :show-more "Show more"}
+  :collapse {:hide "Show less"
+             :show "Show more"}
   :update-catalogue-item {:update-catalogue-item-intro "You are about to update the following catalogue items. The changes will be made one at a time, so that each old item is terminated and a new copy will use the chosen form and workflow."
                           :form-selection "Form"
                           :workflow-selection "Workflow"}

--- a/resources/translations/fi.edn
+++ b/resources/translations/fi.edn
@@ -295,10 +295,8 @@
               :continue-existing-application "Jatka hakemusta"
               :continue-existing-application-intro ""
               :apply-resources "Hae uusia käyttöoikeuksia"}
-  :collapse {:hide "Piilota"
-             :show "Näytä"
-             :show-less "Näytä vähemmän"
-             :show-more "Näytä lisää"}
+  :collapse {:hide "Näytä vähemmän"
+             :show "Näytä lisää"}
   :update-catalogue-item {:update-catalogue-item-intro "Olet muuttamassa seuraavia aineistoja. Muutokset tehdään yksi kerrallaan siten, että vanha aineisto poistetaan käytöstä ja uusi kopio käyttää valitsemaasi lomaketta ja työvuota."
                           :form-selection "Lomake"
                           :workflow-selection "Workflow"}

--- a/resources/translations/sv.edn
+++ b/resources/translations/sv.edn
@@ -295,10 +295,8 @@
               :continue-existing-application "Återuppta ansökan"
               :continue-existing-application-intro ""
               :apply-resources "Ansök om resurser"}
-  :collapse {:hide "Dölj"
-             :show "Visa"
-             :show-less "Visa mindre"
-             :show-more "Visa mer"}
+  :collapse {:hide "Visa mindre"
+             :show "Visa mer"}
   :update-catalogue-item {:update-catalogue-item-intro "Du uppdaterar katalogposterna nedan. Förändringarna görs en åt gången genom att den gamla katalogposten tas ur bruk och ersätts av en kopia som använder blanketten och arbetsflöden du väljer nedan."
                           :form-selection "Blankett"
                           :workflow-selection "Arbetsflöde"}

--- a/src/clj/rems/service/test_data.clj
+++ b/src/clj/rems/service/test_data.clj
@@ -236,6 +236,25 @@
          (set (map :field/type all-field-types-example)))
       "a new field has been added to schema but not to this test data"))
 
+(defn generate-form-fields [n]
+  (->> (concat [description-field
+                label-field
+                header-field]
+               (take n (cycle (list text-field
+                                    texta-field
+                                    date-field
+                                    email-field
+                                    attachment-field
+                                    multiselect-field
+                                    table-field
+                                    phone-number-field
+                                    ip-address-field))))
+       (map-indexed (fn [idx item]
+                      (-> item ; index in title makes it easier to track fields in long form list
+                          (update-in [:field/title :en] str " " (inc idx))
+                          (update-in [:field/title :fi] str " " (inc idx))
+                          (update-in [:field/title :sv] str " " (inc idx)))))))
+
 (defn create-all-field-types-example-form!
   "Creates a multilingual form with all supported field types. Returns the form ID."
   [actor organization internal-name external-title]
@@ -859,6 +878,13 @@
                                                                       {:en "Owned by organization owner"
                                                                        :fi "Omistaja organization owner"
                                                                        :sv "Ägare organization owner"})
+        _performance-test-form (test-helpers/create-form! {:actor owner
+                                                           :organization {:organization/id "default"}
+                                                           :form/internal-name "Performance test form"
+                                                           :form/external-title {:en "Performance test form"
+                                                                                 :fi "Suorituskykytestilomake"
+                                                                                 :sv "Blankett för prestand"}
+                                                           :form/fields (generate-form-fields 200)})
 
         ;; Create categories
         ordinary-category {:category/id (test-helpers/create-category! {:actor owner

--- a/src/cljs/rems/actions.cljs
+++ b/src/cljs/rems/actions.cljs
@@ -39,7 +39,7 @@
      [flash-message/component :top]
      [:div.spaced-sections
       [collapsible/component
-       {:id "todo-applications-collapse"
+       {:id "todo-applications-collapsible"
         :open? true
         :title (text :t.actions/todo-applications)
         :bottom-less-button? false
@@ -53,7 +53,7 @@
                                                 :default-sort-column :last-activity
                                                 :default-sort-order :desc}]]}]
       [collapsible/component
-       {:id "handled-applications-collapse"
+       {:id "handled-applications-collapsible"
         :title (text :t.actions/handled-applications)
         :on-open #(do (rf/dispatch [::handled-applications {:limit 51}])
                       (rf/dispatch [::handled-applications-count]))

--- a/src/cljs/rems/actions/components.cljs
+++ b/src/cljs/rems/actions/components.cljs
@@ -7,7 +7,7 @@
             [rems.fields :as fields]
             [rems.flash-message :as flash-message]
             [rems.text :refer [text text-format]]
-            [rems.util :refer [post!]]))
+            [rems.util :refer [event-value post!]]))
 
 (defn- action-collapse-id [action-id]
   (str "actions-" action-id))
@@ -76,9 +76,7 @@
                 :max-rows 4
                 :name id
                 :value @(rf/subscribe [::comment field-key])
-                :on-change (fn [event]
-                             (let [value (.. event -target -value)]
-                               (rf/dispatch [::set-comment field-key value])))}]]))
+                :on-change #(rf/dispatch [::set-comment field-key (event-value %)])}]]))
 
 (rf/reg-sub ::event-public (fn [db [_ field-key]] (get-in db [::event-public field-key] false)))
 (rf/reg-event-db ::set-event-public (fn [db [_ field-key value]] (assoc-in db [::event-public field-key] value)))

--- a/src/cljs/rems/administration/components.cljs
+++ b/src/cljs/rems/administration/components.cljs
@@ -193,13 +193,12 @@
                          :normalizer normalizer
                          :on-change on-change}]))]
     (if collapse?
-      [:div.form-group.localized-field.mb-1
-       [:label.administration-field-label
+      [:div.form-group.field.localized-field
+       [:label.administration-field-label.d-flex.align-items-center
         label
-        " "
-        [collapsible/controls id (text :t.collapse/show) (text :t.collapse/hide)]]
-       [:div.collapse {:id id}
-        fields]]
+        [collapsible/toggle-control id]]
+       [collapsible/minimal {:id id
+                             :collapse fields}]]
       [:div.form-group.localized-field
        [:label.administration-field-label label]
        fields])))

--- a/src/cljs/rems/administration/components.cljs
+++ b/src/cljs/rems/administration/components.cljs
@@ -14,39 +14,55 @@
               analogous to the `get-in` and `assoc-in` parameters.
     :label  - String, shown to the user as-is."
   (:require [clojure.string :as str]
+            [medley.core :refer [assoc-some]]
             [re-frame.core :as rf]
             [rems.atoms :as atoms :refer [info-field textarea]]
             [rems.collapsible :as collapsible]
+            [rems.config]
             [rems.dropdown :as dropdown]
             [rems.fields :as fields]
             [rems.globals]
             [rems.common.roles :as roles]
             [rems.common.util :refer [clamp parse-int]]
-            [rems.config]
-            [rems.text :refer [localized text text-format]]))
+            [rems.text :refer [localized text text-format]]
+            [rems.util :refer [event-checked event-value]]))
 
 (defn- key-to-id [key]
   (if (number? key)
     (str key)
     (name key)))
 
-(defn- keys-to-id [keys]
-  (->> keys
+(defn keys-to-id [key-path]
+  (->> key-path
        (map key-to-id)
        (str/join "-")))
 
-(defn- field-validation-message [error label]
-  [:div {:class "invalid-feedback"}
-   (when error (text-format error label))])
+(defn field-validation-message [error label]
+  (when error
+    [:div.invalid-feedback (text-format error label)]))
 
-(defn input-field [{:keys [keys label placeholder context type normalizer readonly inline? input-style on-change] :as opts}]
-  (let [form @(rf/subscribe [(:get-form context)])
-        form-errors (when (:get-form-errors context)
-                      @(rf/subscribe [(:get-form-errors context)]))
-        id (keys-to-id keys)
+(defn update-form [context key-path value]
+  (rf/dispatch-sync [(:update-form context) key-path value])
+  value)
+
+(defn get-form-value [context key-path]
+  (if (contains? context :get-in-form)
+    @(rf/subscribe [(:get-in-form context) key-path])
+    (get-in @(rf/subscribe [(:get-form context)]) key-path)))
+
+(defn get-form-error [context key-path]
+  (when (contains? context :get-form-error)
+    @(rf/subscribe [(:get-form-error context) key-path])))
+
+(defn input-field [{:keys [context inline? input-style label normalizer on-change placeholder readonly field-type]
+                    key-path :keys
+                    min-value :min
+                    max-value :max}]
+  (let [id (keys-to-id key-path)
+        value (get-form-value context key-path)
+        error (get-form-error context key-path)
         normalizer (or normalizer identity)
-        on-change (or on-change (fn [_]))
-        error (get-in form-errors keys)]
+        on-change (or on-change identity)]
     [:div.form-group.field {:class (when inline? "row")}
      [:label {:for id
               :class (if inline?
@@ -54,61 +70,62 @@
                        "administration-field-label")}
       label]
      [:div {:class (when inline? "col")}
-      [:input.form-control (merge {:type type
-                                   :id id
-                                   :style input-style
-                                   :disabled readonly
-                                   :placeholder placeholder
-                                   :class (when error "is-invalid")
-                                   :value (get-in form keys)
-                                   :on-change #(let [new-value (normalizer (.. % -target -value))]
-                                                 (rf/dispatch [(:update-form context)
-                                                               keys
-                                                               new-value])
-                                                 (on-change new-value))}
-                                  (select-keys opts [:min :max]))]
+      [:input.form-control (-> {:type field-type
+                                :id id
+                                :style input-style
+                                :disabled readonly
+                                :placeholder placeholder
+                                :value value
+                                :on-change #(->> (event-value %)
+                                                 normalizer
+                                                 (update-form context key-path)
+                                                 on-change)}
+                               (assoc-some :class (when error "is-invalid")
+                                           :min min-value
+                                           :max max-value))]
       [field-validation-message error label]]]))
 
 (defn text-field
   "A basic text field, full page width."
-  [context keys]
-  (input-field (merge keys {:context context :type "text"})))
+  [context opts]
+  [input-field (merge opts {:context context :type "text"})])
 
 (defn text-field-inline
   "A basic text field, label next to field"
-  [context keys]
-  (input-field (merge keys {:context context :type "text" :inline? true})))
+  [context opts]
+  [input-field (merge opts {:context context :type "text" :inline? true})])
 
 (defn number-field
   "A basic number field, full page width."
-  [context keys]
-  (input-field (merge keys {:context context
+  [context {min-value :min
+            max-value :max
+            :or {min-value 0 max-value 1000000}
+            :as opts}]
+  [input-field (merge opts {:context context
                             :type "number"
-                            :normalizer #(some-> % parse-int (clamp (:min keys 0) (:max keys 1000000)))
-                            :min 0
-                            :max 1000000})))
+                            :normalizer #(some-> % parse-int (clamp min-value max-value))
+                            :min min-value
+                            :max max-value})])
 
 (defn textarea-autosize
   "A basic textarea, full page width."
-  [context {:keys [keys label placeholder normalizer on-change]}]
-  (let [form @(rf/subscribe [(:get-form context)])
-        form-errors (when (:get-form-errors context)
-                      @(rf/subscribe [(:get-form-errors context)]))
+  [context {:keys [label normalizer placeholder on-change]
+            key-path :keys}]
+  (let [value (get-form-value context key-path)
+        error (get-form-error context key-path)
+        id (keys-to-id key-path)
         normalizer (or normalizer identity)
-        on-change (or on-change (fn [_]))
-        id (keys-to-id keys)
-        error (get-in form-errors keys)]
+        on-change (or on-change identity)]
     [:div.form-group.field
      [:label.administration-field-label {:for id} label]
      [textarea {:id id
                 :placeholder placeholder
-                :value (get-in form keys)
+                :value value
                 :class (when error "is-invalid")
-                :on-change #(let [new-value (normalizer (.. % -target -value))]
-                              (rf/dispatch [(:update-form context)
-                                            keys
-                                            new-value])
-                              (on-change new-value))}]
+                :on-change #(->> (event-value %)
+                                 normalizer
+                                 (update-form context key-path)
+                                 on-change)}]
      [field-validation-message error label]]))
 
 (defn localized-textarea-autosize
@@ -117,61 +134,56 @@
   in the form as a map of language to text. If `:localizations-key` is
   provided in opts, languages are mapped from `[:localizations lang localizations-key]`
   path."
-  [context {:keys [keys localizations-key label placeholder normalizer on-change]}]
+  [context {:keys [localizations-key label normalizer on-change placeholder]
+            key-path :keys}]
   (let [normalizer (or normalizer identity)
-        on-change (or on-change (fn [_]))]
+        on-change (or on-change identity)]
     (into [:div.form-group.localized-field
            [:label.administration-field-label label]]
           (for [language @rems.config/languages
-                :let [form @(rf/subscribe [(:get-form context)])
-                      form-errors (when (:get-form-errors context)
-                                    @(rf/subscribe [(:get-form-errors context)]))
-                      keys (if (some? localizations-key)
-                             [:localizations language localizations-key]
-                             (conj keys language))
+                :let [sub-key-path (if (some? localizations-key)
+                                     [:localizations language localizations-key]
+                                     (conj key-path language))
+                      value (get-form-value context sub-key-path)
+                      error (get-form-error context sub-key-path)
                       id (keys-to-id (if (some? localizations-key)
                                        [:localizations language localizations-key]
-                                       keys))
-                      error (get-in form-errors keys)]]
+                                       sub-key-path))]]
             [:div.row.mb-0
              [:label.col-sm-1.col-form-label {:for id}
               (str/upper-case (name language))]
              [:div.col-sm-11
               [textarea {:id id
                          :placeholder placeholder
-                         :value (get-in form keys)
+                         :value value
                          :class (when error "is-invalid")
-                         :on-change #(let [new-value (normalizer (.. % -target -value))]
-                                       (rf/dispatch [(:update-form context)
-                                                     keys
-                                                     new-value])
-                                       (on-change new-value))}]
+                         :on-change #(->> (event-value %)
+                                          normalizer
+                                          (update-form context sub-key-path)
+                                          on-change)}]
               [field-validation-message error label]]]))))
 
 (defn- localized-text-field-lang [context {:keys [keys-prefix label lang localizations-key normalizer on-change]}]
-  (let [form @(rf/subscribe [(:get-form context)])
-        form-errors (when (:get-form-errors context)
-                      @(rf/subscribe [(:get-form-errors context)]))
-        keys (if localizations-key
-               [:localizations lang localizations-key]
-               (conj (vec keys-prefix) lang))
+  (let [key-path (if localizations-key
+                   [:localizations lang localizations-key]
+                   (conj (vec keys-prefix) lang))
+        value (get-form-value context key-path)
+        error (get-form-error context key-path)
+        id (keys-to-id key-path)
         normalizer (or normalizer identity)
-        on-change (or on-change (fn [_]))
-        id (keys-to-id keys)
-        error (get-in form-errors keys)]
+        on-change (or on-change identity)]
     [:div.row.mb-0
      [:label.col-sm-1.col-form-label {:for id}
       (str/upper-case (name lang))]
      [:div.col-sm-11
       [textarea {:id id
                  :min-rows 1
-                 :value (get-in form keys)
+                 :value value
                  :class (when error "is-invalid")
-                 :on-change #(let [new-value (normalizer (.. % -target -value))]
-                               (rf/dispatch [(:update-form context)
-                                             keys
-                                             new-value])
-                               (on-change new-value))}]
+                 :on-change #(->> (event-value %)
+                                  normalizer
+                                  (update-form context key-path)
+                                  on-change)}]
       [field-validation-message error label]]]))
 
 (defn localized-text-field
@@ -180,13 +192,15 @@
   in the form as a map of language to text. If `:localizations-key` is
   provided in opts, languages are mapped from `[:localizations lang localizations-key]`
   path."
-  [context {:keys [keys label localizations-key collapse? normalizer on-change]}]
-  (let [languages @rems.config/languages
-        id (keys-to-id (if (some? localizations-key) [localizations-key] keys))
-        fields (into [:<>]
-                     (for [lang languages]
+  [context {:keys [collapse? label localizations-key normalizer on-change]
+            key-path :keys}]
+  (let [id (keys-to-id (if (some? localizations-key)
+                         [localizations-key]
+                         key-path))
+        fields (into [:div.spaced-vertically]
+                     (for [lang @rems.config/languages]
                        [localized-text-field-lang context
-                        {:keys-prefix keys
+                        {:keys-prefix key-path
                          :label label
                          :lang lang
                          :localizations-key localizations-key
@@ -205,70 +219,71 @@
 
 (defn checkbox
   "A single checkbox, on its own line."
-  [context {:keys [keys label negate? on-change]}]
-  (let [form @(rf/subscribe [(:get-form context)])
+  [context {:keys [label negate? on-change]
+            key-path :keys}]
+  (let [id (keys-to-id key-path)
+        value (get-form-value context key-path)
         val-fn (if negate?
                  (comp not boolean)
                  boolean)
-        on-change (or on-change (fn [_]))
-        id (keys-to-id keys)]
+        on-change (or on-change identity)]
     [:div.form-group.field
      [:div.form-check
       [:input.form-check-input {:id id
                                 :type "checkbox"
-                                :checked (val-fn (get-in form keys))
-                                :on-change #(let [new-value (val-fn (.. % -target -checked))]
-                                              (rf/dispatch [(:update-form context)
-                                                            keys
-                                                            new-value])
-                                              (on-change new-value))}]
+                                :checked (val-fn value)
+                                :on-change #(->> (event-checked %)
+                                                 val-fn
+                                                 (update-form context key-path)
+                                                 on-change)}]
       [:label.form-check-label {:for id}
        label]]]))
 
-(defn- radio-button [context {:keys [keys value label orientation readonly on-change]}]
-  (let [form @(rf/subscribe [(:get-form context)])
-        form-errors (when (:get-form-errors context)
-                      @(rf/subscribe [(:get-form-errors context)]))
-        on-change (or on-change (fn [_]))
-        name (keys-to-id keys)
-        id (keys-to-id (conj keys value))
-        error (get-in form-errors keys)]
-    [(case orientation
-       :vertical :div.form-check
-       :horizontal :div.form-check.form-check-inline)
+(defn- radio-button [context {:keys [key-path label on-change orientation readonly value]}]
+  (let [name (keys-to-id key-path)
+        id (keys-to-id (conj key-path value))
+        form-value (get-form-value context key-path)
+        error (get-form-error context key-path)
+        on-change (or on-change identity)]
+    [:div.form-check {:class (when (= :horizontal orientation)
+                               "form-check-inline")}
      [:input.form-check-input {:id id
                                :type "radio"
                                :disabled readonly
                                :class (when error "is-invalid")
                                :name name
                                :value value
-                               :checked (= value (get-in form keys))
-                               :on-change #(when (.. % -target -checked)
-                                             (rf/dispatch [(:update-form context) keys value])
-                                             (on-change value))}]
+                               :checked (= value form-value)
+                               :on-change #(when (event-checked %)
+                                             (->> value
+                                                  (update-form context key-path)
+                                                  on-change))}]
      [:label.form-check-label {:for id}
       label]]))
 
 (defn radio-button-group
   "A list of radio buttons.
   `id`           - the id of the group
-  `orientation`  - `:horizontal` or `:vertical`
   `keys`         - keys for options
-  `label`        - optional label text for group
+  `label`        - (optional) label text for group
+  `on-change`    - (optional) callback
+  `orientation`  - `:horizontal` or `:vertical`
   `options`      - list of `{:value \"...\", :label \"...\"}`
   `readonly`     - boolean"
-  [context {:keys [id keys label orientation options readonly on-change]}]
+  [context {:keys [id label orientation options readonly on-change]
+            key-path :keys}]
   [:div.form-group.field {:id id}
-   (when label [:label.administration-field-label {:for id} label])
+   (when label
+     [:label.administration-field-label {:for id} label])
    (into [:div.form-control]
-         (map (fn [{:keys [value label]}]
-                [radio-button context {:keys keys
-                                       :value value
-                                       :label label
-                                       :readonly readonly
-                                       :orientation orientation
-                                       :on-change on-change}])
-              options))])
+         (for [{:keys [value label]} options]
+           ^{:key (str id "-" (name value))}
+           [radio-button context {:key-path key-path
+                                  :label label
+                                  :on-change on-change
+                                  :orientation orientation
+                                  :readonly readonly
+                                  :value value}]))])
 
 (defn inline-info-field [text value & [opts]]
   [info-field text value (merge {:inline? true} opts)])
@@ -278,29 +293,28 @@
   The data is passed in as a map of language to text.
   If :localizations-key is passed in opts, language to text is
   mapped from `[:localizations lang localizations-key]` instead."
-  [m {:keys [label localizations-key]}]
-  (let [languages @rems.config/languages
-        to-label #(str label " (" (str/upper-case (name %)) ")")]
-    (into [:<>]
-          (for [lang languages
-                :let [value (if (some? localizations-key)
-                              (get-in m [:localizations lang localizations-key])
-                              (get m lang))]]
-            [inline-info-field (to-label lang) value]))))
+  [m {label :label
+      localizations-key :localizations-key}]
+  (into [:<>]
+        (for [lang @rems.config/languages]
+          [inline-info-field (text-format :t.label/parens label (str/upper-case (name lang)))
+           (if (some? localizations-key)
+             (get-in m [:localizations lang localizations-key])
+             (get m lang))])))
 
-(defn organization-field [context {:keys [keys readonly on-change]}]
-  (let [id (keys-to-id keys)
-        label (text :t.administration/organization)
+(defn organization-field [context {:keys [readonly on-change]
+                                   key-path :keys}]
+  (let [on-change (or on-change identity)
+        on-update #(->> %
+                        (update-form context key-path)
+                        on-change)
+        id (keys-to-id key-path)
+        potential-value (get-form-value context key-path)
+        error (get-form-error context key-path)
         owned-organizations @(rf/subscribe [:owned-organizations])
-        valid-organizations (->> owned-organizations (filter :enabled) (remove :archived))
+        valid-organizations (->> owned-organizations
+                                 (into [] (comp (filter :enabled) (remove :archived))))
         disallowed (roles/disallow-setting-organization? @rems.globals/roles)
-        form @(rf/subscribe [(:get-form context)])
-        potential-value (get-in form keys)
-        on-change (or on-change (fn [_]))
-        wrapped-on-change #(let [new-value %]
-                             (rf/dispatch [(:update-form context) keys new-value])
-                             (on-change new-value))
-
         ;; if item was copied then this org could be something old
         ;; where we have no access to so reset here
         value (if (or readonly
@@ -309,35 +323,35 @@
                                  (:organization/id potential-value)))
                 potential-value
 
-                ;; not accessible, reset
-                (wrapped-on-change nil))
+                  ;; not accessible, reset
+                (on-update nil))
 
-        form-errors (when (:get-form-errors context)
-                      @(rf/subscribe [(:get-form-errors context)]))
         item-selected? #(= (:organization/id %) (:organization/id value))]
     [:div.form-group.field
-     [:label.administration-field-label {:for id} label]
+     [:label.administration-field-label {:for id}
+      (text :t.administration/organization)]
      (if (or readonly disallowed)
        [fields/readonly-field {:id id
                                :value (localized (:organization/name value))}]
        [dropdown/dropdown
         {:id id
-         :items valid-organizations
+         :items (->> valid-organizations
+                     (mapv #(assoc % ::label (localized (:organization/name %)))))
          :item-key :organization/id
-         :item-label (comp localized :organization/name)
+         :item-label ::label
          :item-selected? item-selected?
-         :on-change wrapped-on-change}])
-     [field-validation-message (get-in form-errors keys) label]]))
+         :on-change on-update}])
+     [field-validation-message error (text :t.administration/organization)]]))
 
-(defn date-field
-  [context {:keys [label keys min max validation optional normalizer on-change]}]
-  (let [form @(rf/subscribe [(:get-form context)])
-        value (get-in form keys)
+(defn date-field [context {:keys [label normalizer on-change optional validation]
+                           key-path :keys
+                           max-value :max
+                           min-value :min}]
+  (let [id (keys-to-id key-path)
+        value (get-form-value context key-path)
+        error (get-form-error context key-path)
         normalizer (or normalizer identity)
-        on-change (or on-change (fn [_]))
-        form-errors (when (:get-form-errors context)
-                      @(rf/subscribe [(:get-form-errors context)]))
-        id (keys-to-id keys)]
+        on-change (or on-change identity)]
     ;; TODO: format readonly value in user locale (give field-wrapper a formatted :value and :previous-value in opts)
     [:div.form-group.field
      [:label.administration-field-label {:for id} label]
@@ -351,14 +365,13 @@
                            :aria-invalid (when validation true)
                            :aria-describedby (when validation
                                                (str id "-error"))
-                           :min min
-                           :max max
-                           :on-change #(let [new-value (normalizer (.. % -target -value))]
-                                         (rf/dispatch [(:update-form context)
-                                                       keys
-                                                       new-value])
-                                         (on-change new-value))}]
-     [field-validation-message (get-in form-errors keys) label]]))
+                           :min min-value
+                           :max max-value
+                           :on-change #(->> (event-value %)
+                                            normalizer
+                                            (update-form context key-path)
+                                            on-change)}]
+     [field-validation-message error label]]))
 
 (defn perform-action-button [{:keys [loading?] :as props}]
   [atoms/rate-limited-button

--- a/src/cljs/rems/administration/create_form.cljs
+++ b/src/cljs/rems/administration/create_form.cljs
@@ -11,17 +11,21 @@
   `data-field-index` property for this. When a field is e.g. moved, it takes a while for
   React to re-render it. So we want to wait until the element is rendered to the new place
   with the new index before we can scroll to the new position."
-  (:require [clojure.string :as str]
-            [medley.core :refer [find-first]]
+  (:require [better-cond.core :as b]
+            [clojure.string :as str]
+            [medley.core :refer [find-first indexed]]
             [re-frame.core :as rf]
+            [reagent.core :as r]
+            [reagent.format :as rfmt]
+            [reagent.ratom :as ra]
             [rems.administration.administration :as administration]
-            [rems.administration.components :refer [checkbox localized-text-field organization-field radio-button-group text-field text-field-inline]]
+            [rems.administration.components :refer [checkbox field-validation-message keys-to-id localized-text-field organization-field radio-button-group text-field text-field-inline update-form]]
             [rems.administration.items :as items]
             [rems.atoms :as atoms :refer [document-title]]
             [rems.collapsible :as collapsible]
             [rems.common.form :refer [field-visible? generate-field-id validate-form-template] :as common-form]
-            [rems.common.util :refer [parse-int]]
-            [rems.config :as config]
+            [rems.common.util :refer [andstr not-blank parse-int]]
+            [rems.config]
             [rems.dropdown :as dropdown]
             [rems.fetcher :as fetcher]
             [rems.fields :as fields]
@@ -29,7 +33,7 @@
             [rems.focus :as focus]
             [rems.spinner :as spinner]
             [rems.text :refer [localized text text-format]]
-            [rems.util :refer [navigate! put! post! trim-when-string visibility-ratio focus-input-field]]))
+            [rems.util :refer [event-value focus-input-field navigate! on-element-appear on-element-appear-async post! put! trim-when-string visibility-ratio]]))
 
 (rf/reg-event-fx
  ::enter-page
@@ -41,232 +45,248 @@
                ::edit-form? edit-form?)
     :dispatch-n [(when form-id [::form])]}))
 
+(rf/reg-sub ::form-id (fn [db] (::form-id db)))
+
 (fetcher/reg-fetcher ::form "/api/forms/:id" {:path-params (fn [db] {:id (::form-id db)})})
 
 ;;;; form state
 
-(defn- field-editor-id [id]
-  (str "field-editor-" id))
+(def ^:private preview-fields (r/atom nil))
 
-(defn- field-editor-selector [id index]
-  (str "#" (field-editor-id id) "[data-field-index='" index "']"))
-
-(defn- track-moved-field-editor! [id index button-selector]
-  (when-some [element (js/document.getElementById (field-editor-id id))]
-    (let [before (.getBoundingClientRect element)]
-      ;; NB: the element exists already but we wait for it to reappear with the new index
-      (focus/on-element-appear (field-editor-selector id index)
-                               (fn [element]
-                                 (let [after (.getBoundingClientRect element)]
-                                   (focus/scroll-offset before after)
-                                   (focus/focus-without-scroll (.querySelector element button-selector))))))))
-
-(defn- focus-field-editor! [id]
-  (let [selector "textarea"] ;; focus first title field
-    (focus/on-element-appear (str "#" (field-editor-id id))
-                             (fn [element]
-                               (focus/scroll-to-top element)
-                               (collapsible/open-component (field-editor-id id))
-                               (.focus (.querySelector element selector))))))
-
-(defn- assign-field-index [form]
-  (update form :form/fields #(vec (map-indexed (fn [i field] (assoc field :field/index i)) %))))
-
-(rf/reg-sub ::form-data (fn [db] (assign-field-index (get-in db [::form :data]))))
-(rf/reg-sub ::form-errors (fn [db _] (::form-errors db)))
 (rf/reg-sub ::edit-form? (fn [db _] (::edit-form? db)))
-(rf/reg-event-db ::set-form-field (fn [db [_ keys value]] (assoc-in db (concat [::form :data] keys) value)))
+(rf/reg-sub ::form-errors (fn [db _] (::form-errors db)))
+(rf/reg-sub ::form-data (fn [db] (get-in db [::form :data])))
+(rf/reg-sub ::fields (fn [db] (vec (get-in db [::form :data :form/fields] []))))
+(rf/reg-sub ::field
+            :<- [::fields]
+            (fn [form-fields [_ field-id]]
+              (find-first (comp #{field-id} :field/id) form-fields)))
 
-(rf/reg-event-db
+(defn- field-collapsible-id [id] (str "field-collapsible-" id))
+
+(defn- data-field-id [^js elem] (.. elem -dataset -fieldId))
+(defn- data-field-index [^js elem] (.. elem -dataset -fieldIndex))
+
+(defn- field-selector [id & [idx]]
+  (cond-> ".form-field"
+    :always (str (rfmt/format "[data-field-id='%s']" id))
+    idx (str (rfmt/format "[data-field-index='%s']" idx))))
+
+(defn- preview-selector [id & [idx]]
+  (cond-> ".field-preview"
+    :always (str (rfmt/format "[data-field-id='%s']" id))
+    idx (str (rfmt/format "[data-field-index='%s']" idx))))
+
+(rf/reg-fx
+ ::focus-field-editor
+ (fn [field-id]
+   (-> (on-element-appear-async {:selector (field-selector field-id)})
+       (.then (fn [element]
+                (rf/dispatch [:rems.collapsible/set-expanded (field-collapsible-id field-id) true])
+                (on-element-appear-async {:selector "textarea"
+                                          :target element})))
+       (.then focus/focus-without-scroll))))
+
+(rf/reg-event-fx
  ::add-form-field
- (fn [db [_ & [index]]]
-   (let [new-item (merge (generate-field-id (get-in db [::form :data :form/fields]))
-                         {:field/type :text})]
-     (focus-field-editor! (:field/id new-item))
-     (update-in db [::form :data :form/fields] items/add new-item index))))
+ (fn [{:keys [db]} [_ & [index]]]
+   (let [new-item (-> db
+                      (get-in [::form :data :form/fields])
+                      generate-field-id
+                      (merge {:field/type :text}))]
+     {:db (update-in db [::form :data :form/fields] items/add new-item index)
+      ::focus-field-editor (:field/id new-item)})))
 
 (rf/reg-event-db
  ::remove-form-field
  (fn [db [_ field-index]]
    (update-in db [::form :data :form/fields] items/remove field-index)))
 
-(rf/reg-event-db
+(defn- track-moved-field-editor [field-id field-index button-selector]
+  (when-some [before (some-> js/document
+                             (.querySelector (field-selector field-id))
+                             (.getBoundingClientRect))]
+    (on-element-appear {:selector (field-selector field-id field-index)
+                        :on-resolve (fn [element]
+                                      (let [after (.getBoundingClientRect element)]
+                                        (focus/scroll-offset before after)
+                                        (focus/focus-without-scroll (.querySelector element button-selector))))})))
+
+(rf/reg-event-fx
  ::move-form-field-up
- (fn [db [_ field-index]]
-   (track-moved-field-editor! (get-in db [::form :data :form/fields field-index :field/id])
-                              (dec field-index)
-                              ".move-up")
-   (update-in db [::form :data :form/fields] items/move-up field-index)))
+ (fn [{:keys [db]} [_ field-index]]
+   (let [field-id (get-in db [::form :data :form/fields field-index :field/id])]
+     (track-moved-field-editor field-id (dec field-index) ".move-up")
+     {:db (update-in db
+                     [::form :data :form/fields]
+                     items/move-up
+                     field-index)})))
 
-(rf/reg-event-db
+(rf/reg-event-fx
  ::move-form-field-down
- (fn [db [_ field-index]]
-   (track-moved-field-editor! (get-in db [::form :data :form/fields field-index :field/id])
-                              (inc field-index)
-                              ".move-down")
-   (update-in db [::form :data :form/fields] items/move-down field-index)))
+ (fn [{:keys [db]} [_ field-index]]
+   (let [field-id (get-in db [::form :data :form/fields field-index :field/id])]
+     (track-moved-field-editor field-id (inc field-index) ".move-down")
+     {:db (update-in db
+                     [::form :data :form/fields]
+                     items/move-down
+                     field-index)})))
 
-(rf/reg-event-db
- ::add-form-field-option
- (fn [db [_ field-index]]
-   (update-in db [::form :data :form/fields field-index :field/options] items/add {})))
+(defn- add-item [k db [_ field-index]]
+  (update-in db [::form :data :form/fields field-index k] items/add {}))
 
-(rf/reg-event-db
- ::remove-form-field-option
- (fn [db [_ field-index option-index]]
-   (update-in db [::form :data :form/fields field-index :field/options] items/remove option-index)))
+(defn- remove-item [k db [_ field-index item-index]]
+  (update-in db [::form :data :form/fields field-index k] items/remove item-index))
 
-(rf/reg-event-db
- ::move-form-field-option-up
- (fn [db [_ field-index option-index]]
-   (update-in db [::form :data :form/fields field-index :field/options] items/move-up option-index)))
+(defn- move-item [k direction db [_ field-index item-index]]
+  (case direction
+    :up (update-in db [::form :data :form/fields field-index k] items/move-up item-index)
+    :down (update-in db [::form :data :form/fields field-index k] items/move-down item-index)))
 
-(rf/reg-event-db
- ::move-form-field-option-down
- (fn [db [_ field-index option-index]]
-   (update-in db [::form :data :form/fields field-index :field/options] items/move-down option-index)))
+(rf/reg-event-db ::add-option (partial add-item :field/options))
+(rf/reg-event-db ::remove-option (partial remove-item :field/options))
+(rf/reg-event-db ::move-option-up (partial move-item :field/options :up))
+(rf/reg-event-db ::move-option-down (partial move-item :field/options :down))
 
-;; TODO column code is an exact duplication of option code
-
-(rf/reg-event-db
- ::add-form-field-column
- (fn [db [_ field-index]]
-   (update-in db [::form :data :form/fields field-index :field/columns] items/add {})))
-
-(rf/reg-event-db
- ::remove-form-field-column
- (fn [db [_ field-index column-index]]
-   (update-in db [::form :data :form/fields field-index :field/columns] items/remove column-index)))
-
-(rf/reg-event-db
- ::move-form-field-column-up
- (fn [db [_ field-index column-index]]
-   (update-in db [::form :data :form/fields field-index :field/columns] items/move-up column-index)))
-
-(rf/reg-event-db
- ::move-form-field-column-down
- (fn [db [_ field-index column-index]]
-   (update-in db [::form :data :form/fields field-index :field/columns] items/move-down column-index)))
+(rf/reg-event-db ::add-column (partial add-item :field/columns))
+(rf/reg-event-db ::remove-column (partial remove-item :field/columns))
+(rf/reg-event-db ::move-column-up (partial move-item :field/columns :up))
+(rf/reg-event-db ::move-column-down (partial move-item :field/columns :down))
 
 ;;;; form submit
 
-(defn build-localized-string [lstr languages]
-  (let [v (into {} (for [language languages]
+(defn build-localized-string [lstr]
+  (let [v (into {} (for [language @rems.config/languages]
                      [language (trim-when-string (get lstr language ""))]))]
     (when-not (every? str/blank? (vals v))
       v)))
 
-(defn build-request-field [field languages]
-  (merge {:field/id (:field/id field)
-          :field/title (build-localized-string (:field/title field) languages)
-          :field/type (:field/type field)
-          :field/optional (if (common-form/supports-optional? field)
-                            (boolean (:field/optional field))
-                            false)}
-         (when (common-form/supports-info-text? field)
-           (when-let [v (build-localized-string (:field/info-text field) languages)]
-             {:field/info-text v}))
-         (when (common-form/supports-placeholder? field)
-           (when-let [v (build-localized-string (:field/placeholder field) languages)]
-             {:field/placeholder v}))
-         (when (common-form/supports-max-length? field)
-           {:field/max-length (parse-int (:field/max-length field))})
-         (when (common-form/supports-options? field)
-           {:field/options (for [{:keys [key label]} (:field/options field)]
-                             {:key key
-                              :label (build-localized-string label languages)})})
-         (when (common-form/supports-columns? field)
-           {:field/columns (for [{:keys [key label]} (:field/columns field)]
-                             {:key key
-                              :label (build-localized-string label languages)})})
-         (when (common-form/supports-privacy? field)
-           (when (= :private (get-in field [:field/privacy]))
-             {:field/privacy (:field/privacy field)}))
-         (when (common-form/supports-visibility? field)
-           (when (= :only-if (get-in field [:field/visibility :visibility/type]))
-             {:field/visibility (select-keys (:field/visibility field)
-                                             [:visibility/type :visibility/field :visibility/values])}))))
+(defn build-request-field [field]
+  (let [columns? (common-form/supports-columns? field)
+        info-text? (common-form/supports-info-text? field)
+        max-length? (common-form/supports-max-length? field)
+        optional? (common-form/supports-optional? field)
+        options? (common-form/supports-options? field)
+        placeholder? (common-form/supports-placeholder? field)
+        privacy? (common-form/supports-privacy? field)
+        visibility? (common-form/supports-visibility? field)]
+    (merge {:field/id (:field/id field)
+            :field/title (build-localized-string (:field/title field))
+            :field/type (:field/type field)
+            :field/optional (if optional?
+                              (boolean (:field/optional field))
+                              false)}
+           (when info-text?
+             (when-let [v (build-localized-string (:field/info-text field))]
+               {:field/info-text v}))
+           (when placeholder?
+             (when-let [v (build-localized-string (:field/placeholder field))]
+               {:field/placeholder v}))
+           (when max-length?
+             {:field/max-length (parse-int (:field/max-length field))})
+           (when options?
+             {:field/options (for [{:keys [key label]} (:field/options field)]
+                               {:key key
+                                :label (build-localized-string label)})})
+           (when columns?
+             {:field/columns (for [{:keys [key label]} (:field/columns field)]
+                               {:key key
+                                :label (build-localized-string label)})})
+           (when privacy?
+             (when (= :private (get-in field [:field/privacy]))
+               {:field/privacy (:field/privacy field)}))
+           (when visibility?
+             (when (= :only-if (get-in field [:field/visibility :visibility/type]))
+               {:field/visibility (select-keys (:field/visibility field)
+                                               [:visibility/type :visibility/field :visibility/values])})))))
 
-(defn build-request [form languages]
+(defn build-request [form]
   {:organization {:organization/id (get-in form [:organization :organization/id])}
    :form/internal-name (trim-when-string (:form/internal-name form))
-   :form/external-title (build-localized-string (:form/external-title form) languages)
-   :form/fields (mapv #(build-request-field % languages) (:form/fields form))})
+   :form/external-title (build-localized-string (:form/external-title form))
+   :form/fields (mapv build-request-field (:form/fields form))})
 
 ;;;; form validation
 
-(defn- page-title [edit-form?]
-  (if edit-form?
-    (text :t.administration/edit-form)
-    (text :t.administration/create-form)))
+(rf/reg-event-fx
+ ::create-form
+ (fn [{:keys [db]} _]
+   (let [request (build-request (get-in db [::form :data]))
+         form-errors (validate-form-template request @rems.config/languages)]
+     (when-not form-errors
+       (post! "/api/forms/create"
+              {:params request
+               :handler (flash-message/default-success-handler :top
+                                                               [text :t.administration/create-form]
+                                                               #(navigate! (str "/administration/forms/" (:id %))))
+               :error-handler (flash-message/default-error-handler :top
+                                                                   [text :t.administration/create-form])}))
+     {:db (assoc db ::form-errors form-errors)})))
 
 (rf/reg-event-fx
- ::send-form
- (fn [{:keys [db]} [_]]
-   (let [edit? (::edit-form? db)
-         request (build-request (get-in db [::form :data]) @rems.config/languages)
-         form-errors (validate-form-template request @rems.config/languages)
-         send-verb (if edit? put! post!)
-         send-url (str "/api/forms/" (if edit?
-                                       "edit"
-                                       "create"))
-         description [page-title edit?]
-         request (merge request
-                        (when edit?
-                          {:form/id (::form-id db)}))]
+ ::edit-form
+ (fn [{:keys [db]} _]
+   (let [request (build-request (get-in db [::form :data]))
+         form-errors (validate-form-template request @rems.config/languages)]
      (when-not form-errors
-       (send-verb send-url
-                  {:params request
-                   :handler (flash-message/default-success-handler
-                             :top
-                             description
-                             (fn [response]
-                               (navigate! (str "/administration/forms/"
-                                               (if edit?
-                                                 (::form-id db)
-                                                 (response :id))))))
-                   :error-handler (flash-message/default-error-handler :top description)}))
+       (put! "/api/forms/edit"
+             {:params (assoc request :form/id (::form-id db))
+              :handler (flash-message/default-success-handler :top
+                                                              [text :t.administration/edit-form]
+                                                              #(navigate! (str "/administration/forms/" (::form-id db))))
+              :error-handler (flash-message/default-error-handler :top
+                                                                  [text :t.administration/edit-form])}))
      {:db (assoc db ::form-errors form-errors)})))
 
 ;;;; preview auto-scrolling
 
-(defn true-height [element]
+(defn- true-height [element]
   (let [style (.getComputedStyle js/window element)]
     (+ (.-offsetHeight element)
-       (js/parseInt (.-marginTop style))
-       (js/parseInt (.-marginBottom style)))))
+       (parse-int (.-marginTop style))
+       (parse-int (.-marginBottom style)))))
 
-(defn set-visibility-ratio [frame element ratio]
+(defn- set-visibility-ratio [frame element ratio]
   (when (and frame element)
     (let [element-top (- (.-offsetTop element) (.-offsetTop frame))
           element-height (true-height element)
           top-margin (/ (.-offsetHeight frame) 4)
-          position (+ element-top element-height (* -1 ratio element-height) (- top-margin))]
-      (.scrollTo frame 0 position))))
+          position (+ element-top
+                      element-height
+                      (* -1 ratio element-height)
+                      (- top-margin))]
+      (-> frame
+          (.scrollTo 0 position)))))
 
-(defn first-partially-visible-edit-field []
-  (let [fields (array-seq (.querySelectorAll js/document "#create-form .form-field:not(.new-form-field)"))
-        visibility? #(<= 0 (-> % .getBoundingClientRect .-bottom))]
-    (first (filter visibility? fields))))
+(defn- partially-visible? [^js elem] (<= 0 (-> elem .getBoundingClientRect .-bottom)))
 
-(defn autoscroll []
-  (when-let [edit-field (first-partially-visible-edit-field)]
-    (let [id (last (str/split (.-id edit-field) #"-"))
-          preview-frame (.querySelector js/document "#preview-form-contents")
-          preview-field (-> js/document
-                            (.getElementById (str "field-preview-" id)))
-          ratio (visibility-ratio edit-field)]
-      (set-visibility-ratio preview-frame preview-field ratio))))
+(defn- autoscroll []
+  (b/when-some [edit-field (->> (.querySelectorAll js/document "#create-form .form-field:not(.new-form-field)")
+                                array-seq
+                                (find-first partially-visible?))
+                id (data-field-id edit-field)
+                preview-frame (.querySelector js/document "#preview-form-contents")
+                preview-field (.querySelector js/document (preview-selector id))
+                ratio (visibility-ratio edit-field)]
+    (r/after-render
+     #(set-visibility-ratio preview-frame preview-field ratio))))
 
-(defn enable-autoscroll! []
-  (set! (.-onscroll js/window) autoscroll))
+(def ^:private use-autoscroll
+  "Hook-like helper that attaches autoscroll event listener on component mount,
+   and removes it on unmount."
+  (ra/make-reaction #(.addEventListener js/window "scroll" autoscroll)
+                    {:on-dispose #(.removeEventListener js/window "scroll" autoscroll)}))
 
 ;;;; UI
 
+(rf/reg-sub ::get-in-form :<- [::form-data] (fn [form [_ key-path]] (get-in form key-path)))
+(rf/reg-sub ::get-form-error :<- [::form-errors] (fn [errors [_ key-path]] (get-in errors key-path)))
+(rf/reg-event-db ::update-form (fn [db [_ keys value]] (assoc-in db (concat [::form :data] keys) value)))
+
 (def ^:private context
-  {:get-form ::form-data
-   :get-form-errors ::form-errors
-   :update-form ::set-form-field})
+  {:get-in-form ::get-in-form
+   :get-form-error ::get-form-error
+   :update-form ::update-form})
 
 (defn- form-organization-field []
   [organization-field context {:keys [:organization]}])
@@ -301,48 +321,43 @@
   [text-field-inline context {:keys [:form/fields field-index :field/max-length]
                               :label (text :t.create-form/maxlength)}])
 
-(defn- add-form-field-option-button [field-index]
-  [:a.add-option {:href "#"
-                  :id (str "fields-" field-index "-add-option")
-                  :on-click (fn [event]
-                              (.preventDefault event)
-                              (rf/dispatch [::add-form-field-option field-index]))}
-   [atoms/add-symbol] " " (text :t.create-form/add-option)])
 
-(defn- remove-form-field-option-button [field-index option-index]
-  [items/remove-button #(rf/dispatch [::remove-form-field-option field-index option-index])])
 
-(defn- move-form-field-option-up-button [field-index option-index]
-  [items/move-up-button
-   {:on-click #(rf/dispatch [::move-form-field-option-up field-index option-index])
-    :class (str "fields-" field-index "-option-" option-index)}])
-
-(defn- move-form-field-option-down-button [field-index option-index]
-  [items/move-down-button
-   {:on-click #(rf/dispatch [::move-form-field-option-down field-index option-index])
-    :class (str "fields-" field-index "-option-" option-index)}])
+;;; option fields
 
 (defn- form-field-option-field [field-index option-index]
   [:div.form-field-option
    [:div.form-field-header
     [:h4 (text-format :t.create-form/option-n (inc option-index))]
     [:div.form-field-controls
-     [move-form-field-option-up-button field-index option-index]
-     [move-form-field-option-down-button field-index option-index]
-     [remove-form-field-option-button field-index option-index]]]
+     [items/move-up-button {:on-click #(rf/dispatch [::move-option-up field-index option-index])
+                            :data-index option-index}]
+     [items/move-down-button {:on-click #(rf/dispatch [::move-option-down field-index option-index])
+                              :data-index option-index}]
+     [items/remove-button {:on-click #(rf/dispatch [::remove-option field-index option-index])
+                           :data-index option-index}]]]
+
    [text-field-inline context {:keys [:form/fields field-index :field/options option-index :key]
-                               :label (text :t.create-form/option-key)
+                               :label [text :t.create-form/option-key]
                                :normalizer common-form/normalize-option-key}]
    [localized-text-field context {:keys [:form/fields field-index :field/options option-index :label]
-                                  :label (text :t.create-form/option-label)}]])
+                                  :label [text :t.create-form/option-label]}]])
 
 (defn- form-field-option-fields [field-index]
-  (let [form @(rf/subscribe [::form-data])]
-    (into (into [:div]
-                (for [option-index (range (count (get-in form [:form/fields field-index :field/options])))]
-                  [form-field-option-field field-index option-index]))
-          [[:div.form-field-option.new-form-field-option
-            [add-form-field-option-button field-index]]])))
+  (let [options @(rf/subscribe [::get-in-form [:form/fields field-index :field/options]])]
+    [:div
+     (into [:<>] (for [option-index (range (count options))]
+                   [form-field-option-field field-index option-index]))
+     [:div.form-field-option.new-form-field-option
+      [atoms/action-link {:class "add-option"
+                          :id (str "fields-" field-index "-add-option")
+                          :label [:<>
+                                  [atoms/add-symbol] " " [text :t.create-form/add-option]]
+                          :on-click #(rf/dispatch [::add-option field-index])}]]]))
+
+
+
+;;; column fields
 
 ;; TODO column code is an exact duplication of option code
 ;; TODO column code reuses some option styles
@@ -352,28 +367,20 @@
                   :id (str "fields-" field-index "-add-column")
                   :on-click (fn [event]
                               (.preventDefault event)
-                              (rf/dispatch [::add-form-field-column field-index]))}
-   (text :t.create-form/add-column)])
-
-(defn- remove-form-field-column-button [field-index column-index]
-  [items/remove-button #(rf/dispatch [::remove-form-field-column field-index column-index])])
-
-(defn- move-form-field-column-up-button [field-index column-index]
-  [items/move-up-button
-   {:on-click #(rf/dispatch [::move-form-field-column-up field-index column-index])}])
-
-(defn- move-form-field-column-down-button [field-index column-index]
-  [items/move-down-button
-   {:on-click #(rf/dispatch [::move-form-field-column-down field-index column-index])}])
+                              (rf/dispatch [::add-column field-index]))}
+   [text :t.create-form/add-column]])
 
 (defn- form-field-column-field [field-index column-index]
   [:div.form-field-option
    [:div.form-field-header
     [:h4 (text-format :t.create-form/column-n (inc column-index))]
     [:div.form-field-controls
-     [move-form-field-column-up-button field-index column-index]
-     [move-form-field-column-down-button field-index column-index]
-     [remove-form-field-column-button field-index column-index]]]
+     [items/move-up-button {:on-click #(rf/dispatch [::move-column-up field-index column-index])
+                            :data-index column-index}]
+     [items/move-down-button {:on-click #(rf/dispatch [::move-column-down field-index column-index])
+                              :data-index column-index}]
+     [items/remove-button {:on-click #(rf/dispatch [::remove-column field-index column-index])
+                           :data-index column-index}]]]
    [text-field-inline context {:keys [:form/fields field-index :field/columns column-index :key]
                                :label (text :t.create-form/column-key)
                                :normalizer common-form/normalize-option-key}]
@@ -381,134 +388,114 @@
                                   :label (text :t.create-form/column-label)}]])
 
 (defn- form-field-column-fields [field-index]
-  (let [form @(rf/subscribe [::form-data])]
-    (into [:div {:id (str "fields-" field-index "-columns")}]
-          (concat
-           (for [column-index (range (count (get-in form [:form/fields field-index :field/columns])))]
-             [form-field-column-field field-index column-index])
-           [[:div.form-field-option.new-form-field-option
-             [add-form-field-column-button field-index]]]))))
+  (let [columns @(rf/subscribe [::get-in-form [:form/fields field-index :field/columns]])]
+    [:div {:id (str "fields-" field-index "-columns")}
+     (into [:<>]
+           (for [column-index (range (count columns))]
+             [form-field-column-field field-index column-index]))
+     [:div.form-field-option.new-form-field-option
+      [add-form-field-column-button field-index]]]))
 
-(defn- form-fields-that-can-be-used-in-visibility [form]
-  (filter #(contains? #{:option :multiselect} (:field/type %))
-          (:form/fields form)))
 
-(defn- form-field-values [form field-id]
-  (let [field (find-first (comp #{field-id} :field/id) (:form/fields form))]
-    (case (:field/type field)
-      (:option :multiselect)
-      (let [options (:field/options field)]
-        (map (fn [o] {:value (:key o)
-                      :title (:label o)})
-             options))
-      [])))
 
-(rf/reg-event-db
- ::form-field-visibility-type
- (fn [db [_ field-index visibility-type]]
-   (assoc-in db [::form :data :form/fields field-index :field/visibility :visibility/type] visibility-type)))
+;;; field visibility
 
-(rf/reg-event-db
- ::form-field-visibility-field
- (fn [db [_ field-index visibility-field]]
-   (assoc-in db [::form :data :form/fields field-index :field/visibility :visibility/field] visibility-field)))
+(defn- select-visibility-type [context {:keys [id key-path]}]
+  (let [value @(rf/subscribe [(:get-in-form context) key-path])
+        error @(rf/subscribe [(:get-form-error context) key-path])]
+    [:div.form-group.field.row
+     [:label.col-sm-3.col-form-label {:for id} (text :t.create-form/type-visibility)]
+     [:div.col-sm-9
+      [:select.form-control
+       {:id id
+        :class (when error "is-invalid")
+        :on-change #(->> (event-value %)
+                         keyword
+                         (update-form context key-path))
+        :value (or value "")}
+       [:option {:value "always"} (text :t.create-form.visibility/always)]
+       [:option {:value "only-if"} (text :t.create-form.visibility/only-if)]]
+      [field-validation-message error (text :t.create-form/type-visibility)]]]))
 
-(rf/reg-event-db
- ::form-field-visibility-values
- (fn [db [_ field-index visibility-value]]
-   (assoc-in db [::form :data :form/fields field-index :field/visibility :visibility/values] visibility-value)))
+(defn- select-visibility-field [context {:keys [id key-path]}]
+  (let [value @(rf/subscribe [(:get-in-form context) key-path])
+        error @(rf/subscribe [(:get-form-error context) key-path])
+        can-select-visibility? #(contains? #{:option :multiselect} (:field/type %))]
+    [:div.form-group.field.row
+     [:label.col-sm-3.col-form-label {:for id} (text :t.create-form.visibility/field)]
+     [:div.col-sm-9
+      (into [:select.form-control {:id id
+                                   :class (when error "is-invalid")
+                                   :on-change #(->> (event-value %)
+                                                    (assoc {} :field/id)
+                                                    (update-form context key-path))
+                                   :value (or (:field/id value) "")}
+             [:option ""]] ; not selected
+            (for [[idx field] (indexed @(rf/subscribe [::fields]))
+                  :when (can-select-visibility? field)
+                  :let [option-label (text-format :t.create-form/field-n (inc idx) (localized (:field/title field)))]]
+              [:option {:value (:field/id field)}
+               option-label]))
+      [field-validation-message error (text :t.create-form.visibility/field)]]]))
+
+(defn- select-visibility-values [context {:keys [id key-path visibility-field-id]}]
+  (let [values (set @(rf/subscribe [(:get-in-form context) key-path]))
+        error @(rf/subscribe [(:get-form-error context) key-path])
+        visibility-field @(rf/subscribe [::field visibility-field-id])]
+    [:div.form-group.field.row
+     [:label.col-sm-3.col-form-label {:for id} (text :t.create-form.visibility/has-value)]
+     [:div.col-sm-9
+      [dropdown/dropdown
+       {:id id
+        :items (->> (:field/options visibility-field)
+                    (mapv #(assoc % ::label (localized (:label %)))))
+        :item-key :key
+        :item-label ::label
+        :item-selected? #(contains? values (:key %))
+        :multi? true
+        :clearable? true
+        :on-change #(->> (mapv :key %)
+                         (update-form context key-path))}]
+      [field-validation-message error (text :t.create-form.visibility/has-value)]]]))
 
 (defn- form-field-visibility
   "Component for specifying form field visibility rules"
   [field-index]
-  (let [form @(rf/subscribe [::form-data])
-        form-errors @(rf/subscribe [::form-errors])
-        error-type (get-in form-errors [:form/fields field-index :field/visibility :visibility/type])
-        error-field (get-in form-errors [:form/fields field-index :field/visibility :visibility/field])
-        error-value (get-in form-errors [:form/fields field-index :field/visibility :visibility/values])
-        id-type (str "fields-" field-index "-visibility-type")
-        id-field (str "fields-" field-index "-visibility-field")
-        id-value (str "fields-" field-index "-visibility-value")
-        label-type (text :t.create-form/type-visibility)
-        label-field (text :t.create-form.visibility/field)
-        label-value (text :t.create-form.visibility/has-value)
-        visibility (get-in form [:form/fields field-index :field/visibility])
-        visibility-type (:visibility/type visibility)
-        visibility-field (:visibility/field visibility)
-        visibility-value (:visibility/values visibility)]
-    [:div {:class (when (= :only-if visibility-type) "form-field-visibility")}
-     [:div.form-group.field.row {:id (str "container-field" field-index)}
-      [:label.col-sm-3.col-form-label {:for id-type} label-type]
-      [:div.col-sm-9
-       [:select.form-control
-        {:id id-type
-         :class (when error-type "is-invalid")
-         :on-change #(rf/dispatch [::form-field-visibility-type field-index (keyword (.. % -target -value))])
-         :value (or visibility-type "")}
-        [:option {:value "always"} (text :t.create-form.visibility/always)]
-        [:option {:value "only-if"} (text :t.create-form.visibility/only-if)]]
-       [:div.invalid-feedback
-        (when error-type (text-format error-type label-type))]]]
-     (when (= :only-if visibility-type)
+  (let [key-path [:form/fields field-index :field/visibility]
+        value @(rf/subscribe [(:get-in-form context) key-path])]
+    [:div {:class (when (= :only-if (:visibility/type value))
+                    "form-field-visibility")}
+     [select-visibility-type context {:id (str "fields-" field-index "-visibility-type")
+                                      :key-path [:form/fields field-index :field/visibility :visibility/type]}]
+     (when (= :only-if (:visibility/type value))
        [:<>
-        [:div.form-group.field.row
-         [:label.col-sm-3.col-form-label {:for id-field} label-field]
-         [:div.col-sm-9
-          [:select.form-control
-           {:id id-field
-            :class (when error-field "is-invalid")
-            :on-change #(rf/dispatch [::form-field-visibility-field field-index {:field/id (.. % -target -value)}])
-            :value (or (:field/id visibility-field) "")}
-           ^{:key "not-selected"} [:option ""]
-           (doall
-            (for [field (form-fields-that-can-be-used-in-visibility form)]
-              ^{:key (str field-index "-" (:field/id field))}
-              [:option {:value (:field/id field)}
-               (text-format :t.create-form/field-n (inc (:field/index field)) (localized (:field/title field)))]))]
-          [:div.invalid-feedback
-           (when error-field (text-format error-field label-field))]]]
-        (when (:field/id visibility-field)
-          [:div.form-group.field.row
-           [:label.col-sm-3.col-form-label {:for id-value} label-value]
-           [:div.col-sm-9
-            [dropdown/dropdown
-             {:id id-value
-              :items (for [value (form-field-values form (:field/id visibility-field))]
-                       {:value (:value value)
-                        :label (localized (:title value))})
-              :item-key #(str field-index "-" %)
-              :item-label :label
-              :item-selected? #(contains? (set visibility-value) (:value %))
-              :multi? true
-              :clearable? true
-              :on-change #(rf/dispatch [::form-field-visibility-values field-index (mapv :value %)])}]
-            [:div.invalid-feedback
-             (when error-value (text-format error-value label-value))]]])])]))
-
-(rf/reg-event-db
- ::form-field-privacy
- (fn [db [_ field-index privacy]]
-   (assoc-in db [::form :data :form/fields field-index :field/privacy] privacy)))
+        [select-visibility-field context {:id (str "fields-" field-index "-visibility-field")
+                                          :key-path [:form/fields field-index :field/visibility :visibility/field]}]
+        (when-let [visibility-field-id (get-in value [:visibility/field :field/id])]
+          [select-visibility-values context {:id (str "fields-" field-index "-visibility-value")
+                                             :key-path [:form/fields field-index :field/visibility :visibility/values]
+                                             :visibility-field-id visibility-field-id}])])]))
 
 (defn- form-field-privacy
   "Component for specifying form field privacy rules.
 
   Privacy concerns the reviewers as they can see only public fields."
   [field-index]
-  (let [form @(rf/subscribe [::form-data])
-        form-errors @(rf/subscribe [::form-errors])
-        error (get-in form-errors [:form/fields field-index :field/privacy])
-        id (str "fields-" field-index "-privacy-type")
-        label (text :t.create-form/type-privacy)
-        privacy (get-in form [:form/fields field-index :field/privacy])]
-    [:div.form-group.field.row {:id (str "container-field" field-index)}
-     [:label.col-sm-2.col-form-label {:for id} label]
+  (let [key-path [:form/fields field-index :field/privacy]
+        value @(rf/subscribe [(:get-in-form context) key-path])
+        error @(rf/subscribe [(:get-form-error context) key-path])
+        id (str "fields-" field-index "-privacy-type")]
+    [:div.form-group.field.row
+     [:label.col-sm-2.col-form-label {:for id}
+      [text :t.create-form/type-privacy]]
      [:div.col-sm-10
       [:select.form-control
        {:id id
         :class (when error "is-invalid")
-        :on-change #(rf/dispatch [::form-field-privacy field-index (keyword (.. % -target -value))])
-        :value (or privacy "public")}
+        :on-change #(->> (event-value %)
+                         keyword
+                         (update-form context key-path))
+        :value (or value "public")}
        [:option {:value "public"} (text :t.create-form.privacy/public)]
        [:option {:value "private"} (text :t.create-form.privacy/private)]]]]))
 
@@ -531,12 +518,12 @@
                                          {:value :label :label (text :t.create-form/type-label)}
                                          {:value :header :label (text :t.create-form/type-header)}]}])
 
-(defn- form-field-optional-checkbox [field]
-  [checkbox context {:keys [:form/fields (:field/index field) :field/optional]
-                     :label (text :t.create-form/optional)}])
+(defn- form-field-optional-checkbox [field-index]
+  [checkbox context {:keys [:form/fields field-index :field/optional]
+                     :label [text :t.create-form/optional]}])
 
-(defn- form-field-table-optional-checkbox [field]
-  [checkbox context {:keys [:form/fields (:field/index field) :field/optional]
+(defn- form-field-table-optional-checkbox [field-index]
+  [checkbox context {:keys [:form/fields field-index :field/optional]
                      :negate? true
                      :label (text :t.create-form/required-table)}])
 
@@ -547,32 +534,6 @@
                                   (rf/dispatch [::add-form-field index]))}
    [atoms/add-symbol] " " (text :t.create-form/add-form-field)])
 
-(defn- remove-form-field-button [field-index]
-  [items/remove-button #(when (js/confirm (text :t.create-form/confirm-remove-field))
-                          (rf/dispatch [::remove-form-field field-index]))])
-
-(defn- move-form-field-up-button [field-index]
-  [items/move-up-button
-   {:on-click #(rf/dispatch [::move-form-field-up field-index])}])
-
-(defn- move-form-field-down-button [field-index]
-  [items/move-down-button
-   {:on-click #(rf/dispatch [::move-form-field-down field-index])}])
-
-(defn- save-form-button [on-click]
-  [:button.btn.btn-primary
-   {:type :button
-    :id :save
-    :on-click (fn []
-                (rf/dispatch [:rems.app/user-triggered-navigation]) ;; scroll to top
-                (on-click))}
-   (text :t.administration/save)])
-
-(defn- cancel-button []
-  [atoms/link {:class "btn btn-secondary"}
-   "/administration/forms"
-   (text :t.administration/cancel)])
-
 (defn- format-validation-link [target content]
   [:li [:a {:href "#" :on-click (focus-input-field target)}
         content]])
@@ -580,9 +541,11 @@
 (defn- format-error-for-localized-field [error label lang]
   (text-format error (str (text label) " (" (str/upper-case (name lang)) ")")))
 
-(defn- format-field-validation [field field-errors]
-  (let [field-index (:field/index field)]
-    [:li (text-format :t.create-form/field-n (inc field-index) (localized (:field/title field)))
+(defn- format-field-validation [field field-index field-errors]
+  (let [title (text-format :t.create-form/field-n
+                           (inc field-index)
+                           (localized (:field/title field)))]
+    [:li title
      (into [:ul]
            (concat
             (for [[lang error] (:field/title field-errors)]
@@ -635,6 +598,7 @@
                           (format-validation-link (str "fields-" field-index "-columns-" column-id "-label-" (name lang))
                                                   (format-error-for-localized-field error :t.create-form/option-label lang))))]]))))]))
 
+;; XXX: shared component with rems.administration.form
 (defn format-validation-errors [form-errors form]
   ;; TODO: deduplicate with field definitions
   (into [:ul
@@ -652,134 +616,186 @@
 
         (for [[field-index field-errors] (into (sorted-map) (:form/fields form-errors))]
           (let [field (get-in form [:form/fields field-index])]
-            [format-field-validation field field-errors]))))
+            [format-field-validation field field-index field-errors]))))
 
 (defn- validation-errors-summary []
-  (let [form @(rf/subscribe [::form-data])
-        errors @(rf/subscribe [::form-errors])]
-    (when errors
-      [:div.alert.alert-danger (text :t.actions.errors/validation-errors)
-       [format-validation-errors errors form]])))
+  (when-some [errors (not-empty @(rf/subscribe [::form-errors]))]
+    [:div.alert.alert-danger (text :t.actions.errors/validation-errors)
+     [format-validation-errors errors @(rf/subscribe [::form-data])]]))
 
-(defn- form-fields [fields]
-  (into [:div
-         [:div.form-field.new-form-field
-          [add-form-field-button 0]]]
+(defn- field-controls [idx title field-count]
+  [:div.form-field-header.d-flex
+   [:h3 (text-format :t.create-form/field-n (inc idx) (localized title))]
+   [:div.form-field-controls.text-nowrap.ml-auto
+    [items/move-up-button {:on-click (when (> idx 0) #(rf/dispatch [::move-form-field-up idx]))
+                           :data-index idx}]
+    [items/move-down-button {:on-click (when (< idx (dec field-count)) #(rf/dispatch [::move-form-field-down idx]))
+                             :data-index idx}]
+    [items/remove-button {:on-click (let [label (text :t.create-form/confirm-remove-field)]
+                                      #(when (js/confirm label)
+                                         (rf/dispatch [::remove-form-field idx])))
+                          :data-index idx}]]])
 
-        (for [{index :field/index :as field} fields]
-          [:<>
-           [:div.form-field {:id (field-editor-id (:field/id field))
-                             :key index
-                             :data-field-index index}
-            [collapsible/minimal
-             {:id (field-editor-id (:field/id field))
-              :always
-              [:div.form-field-header.d-flex
-               [:h3 (text-format :t.create-form/field-n (inc index) (localized (:field/title field)))]
-               [:div.form-field-controls.text-nowrap.ml-auto
-                [move-form-field-up-button index]
-                [move-form-field-down-button index]
-                [remove-form-field-button index]]]
-              :collapse
-              [:div
-               {:id (str (field-editor-id (:field/id field)) "-contents")
-                :tab-index "-1"}
-               [form-field-title-field index]
-               [form-field-type-radio-group index]
-               (when (common-form/supports-optional? field)
-                 (if (= :table (:field/type field))
-                   [form-field-table-optional-checkbox field]
-                   [form-field-optional-checkbox field]))
-               (when (common-form/supports-info-text? field)
-                 [form-field-info-text index])
-               (when (common-form/supports-placeholder? field)
-                 [form-field-placeholder-field index])
-               (let [id (str "fields-" index "-additional")]
-                 [:div.form-group.field
-                  [:label.administration-field-label
-                   (text :t.create-form/additional-settings)
-                   " "
-                   [collapsible/controls id (text :t.collapse/show) (text :t.collapse/hide) false]]
-                  [:div.collapse.solid-group {:id id}
-                   [form-field-id-field index]
-                   (when (common-form/supports-max-length? field)
-                     [form-field-max-length-field index])
-                   (when (common-form/supports-privacy? field)
-                     [form-field-privacy index])
-                   (when (common-form/supports-visibility? field)
-                     [form-field-visibility index])]])
-               (when (common-form/supports-options? field)
-                 [form-field-option-fields index])
-               (when (common-form/supports-columns? field)
-                 [form-field-column-fields index])]}]]
+(defn- field-editor [idx field field-count]
+  (let [columns? (common-form/supports-columns? field)
+        info-text? (common-form/supports-info-text? field)
+        max-length? (common-form/supports-max-length? field)
+        optional? (common-form/supports-optional? field)
+        options? (common-form/supports-options? field)
+        placeholder? (common-form/supports-placeholder? field)
+        privacy? (common-form/supports-privacy? field)
+        visibility? (common-form/supports-visibility? field)
+        collapsible-id (field-collapsible-id (:field/id field))]
 
-           [:div.form-field.new-form-field
-            [add-form-field-button (inc index)]]])))
+    [collapsible/minimal
+     {:id collapsible-id
+      :always [field-controls idx (:field/title field) field-count]
+      :footer [collapsible/toggle-control collapsible-id]
+      :collapse [:<>
+                 [form-field-title-field idx]
+                 [form-field-type-radio-group idx]
 
-(rf/reg-event-db
- ::set-field-value
- (fn [db [_ field-id field-value]]
-   (assoc-in db [::preview field-id] field-value)))
+                 (when optional?
+                   (if (= :table (:field/type field))
+                     [form-field-table-optional-checkbox idx]
+                     [form-field-optional-checkbox idx]))
 
-(rf/reg-sub
- ::preview
- (fn [db _]
-   (::preview db {})))
+                 (when placeholder? [form-field-placeholder-field idx])
+                 (when options? [form-field-option-fields idx])
+                 (when info-text? [form-field-info-text idx])
 
-(defn form-preview [form]
-  (let [preview @(rf/subscribe [::preview])]
+                 (let [additional-settings-id (keys-to-id [:form/fields idx :additional-settings])]
+                   [:div.form-group.field
+                    [:label.administration-field-label.d-flex.align-items-center
+                     (text :t.create-form/additional-settings)
+                     [collapsible/toggle-control additional-settings-id]]
+                    [collapsible/minimal
+                     {:id additional-settings-id
+                      :collapse [:div.solid-group
+                                 [form-field-id-field idx]
+                                 (when max-length? [form-field-max-length-field idx])
+                                 (when privacy? [form-field-privacy idx])
+                                 (when visibility? [form-field-visibility idx])]}]])
+
+                 (when columns? [form-field-column-fields idx])]}]))
+
+(defn- get-field-key [field idx]
+  (or (not-blank (:field/id field))
+      (str "new-field-" idx)))
+
+(defn- form-fields []
+  (let [fields (indexed @(rf/subscribe [::fields]))
+        field-count (count fields)]
+    (into [:<>
+           [:div.new-form-field
+            [add-form-field-button 0]]]
+          (for [[idx field] fields]
+            ^{:key (get-field-key field idx)}
+            [:<>
+             [:div.form-field {:data-field-id (:field/id field)
+                               :data-field-index idx}
+              [field-editor idx field field-count]]
+             [:div.new-form-field
+              [add-form-field-button (inc idx)]]]))))
+
+(defn- render-preview-hidden []
+  [:div {:style {:position :absolute
+                 :top 0
+                 :left 0
+                 :right 0
+                 :bottom 0
+                 :z-index 1
+                 :display :flex
+                 :flex-direction :column
+                 :justify-content :center
+                 :align-items :flex-end
+                 :border-radius "0.4rem"
+                 :margin "-0.5rem"
+                 :background-color "rgba(230,230,230,0.5)"}}
+   [:div.pr-4 (text :t.create-form.visibility/hidden)]])
+
+(defn- preview-field [field]
+  (let [field-id (:field/id field)
+        preview (r/cursor preview-fields [field-id])
+        depended-id (common-form/field-depends-on-field field)]
+    [:<>
+     [fields/field (assoc field
+                          :form/id 1 ; dummy value
+                          :on-change (r/partial reset! preview)
+                          :field/value @preview)]
+     ;; performance trick, to avoid referencing all preview fields
+     (when-not (field-visible? field {depended-id @(r/cursor preview-fields [depended-id])})
+       [render-preview-hidden])]))
+
+(defn- use-preview-fields
+  "Resets form preview state on component unmount."
+  []
+  @(ra/make-reaction identity {:on-dispose #(reset! preview-fields nil)}))
+
+;; XXX: shared component with rems.administration.form
+(defn form-preview [& [form]]
+  @(r/track use-preview-fields)
+
+  (let [form-fields (if form
+                      (:form/fields form)
+                      @(rf/subscribe [::fields]))]
     [collapsible/component
      {:id "preview-form"
       :title (text :t.administration/preview)
       :always (into [:div#preview-form-contents]
-                    (for [field (:form/fields form)]
-                      [:div.field-preview {:id (str "field-preview-" (:field/id field))}
-                       [fields/field (assoc field
-                                            :form/id 1 ; dummy value
-                                            :on-change #(rf/dispatch [::set-field-value (:field/id field) %])
-                                            :field/value (get-in preview [(:field/id field)]))]
-                       (when-not (field-visible? field preview)
-                         [:div {:style {:position :absolute
-                                        :top 0
-                                        :left 0
-                                        :right 0
-                                        :bottom 0
-                                        :z-index 1
-                                        :display :flex
-                                        :flex-direction :column
-                                        :justify-content :center
-                                        :align-items :flex-end
-                                        :border-radius "0.4rem"
-                                        :margin "-0.5rem"
-                                        :background-color "rgba(230,230,230,0.5)"}}
-                          [:div.pr-4 (text :t.create-form.visibility/hidden)]])]))}]))
+                    (for [[idx field] (indexed form-fields)]
+                      ^{:key (get-field-key field idx)}
+                      [:div.field-preview {:data-field-id (:field/id field)
+                                           :data-field-index idx}
+                       [preview-field field]]))}]))
+
+(defn- cancel-action []
+  (atoms/cancel-action
+   {:url (str "/administration/forms" (andstr "/" @(rf/subscribe [::form-id])))}))
+
+(defn- save-form-action []
+  (let [editing? @(rf/subscribe [::edit-form?])
+        always-on-save #(rf/dispatch [:rems.spa/user-triggered-navigation])] ; scroll to top
+    (atoms/save-action
+     {:id :save
+      :on-click (if editing?
+                  (comp #(rf/dispatch [::edit-form]) always-on-save)
+                  (comp #(rf/dispatch [::create-form]) always-on-save))})))
+
+(defn- form-page-wrapper []
+  @use-autoscroll
+
+  [:div.row
+   [:div.col-lg
+    [collapsible/component
+     {:id "create-form"
+      :title (text :t.administration/form)
+      :always [:div.fields
+               [form-organization-field]
+               [form-internal-name-field]
+               [form-external-title-field]
+               [form-fields]
+               [:div.col.commands
+                [atoms/action-button (cancel-action)]
+                [atoms/rate-limited-action-button (save-form-action)]]]}]]
+   [:div.col-lg [form-preview]]])
 
 (defn create-form-page []
-  (enable-autoscroll!)
-  (let [form @(rf/subscribe [::form-data])
-        edit-form? @(rf/subscribe [::edit-form?])
-        loading? @(rf/subscribe [::form :fetching?])]
+  (let [editing? @(rf/subscribe [::edit-form?])]
     [:div
      [administration/navigator]
-     [document-title (page-title edit-form?)]
+     [document-title (if editing?
+                       (text :t.administration/edit-form)
+                       (text :t.administration/create-form))]
      [flash-message/component :top]
-     (if loading?
-       [:div [spinner/big]]
+     (cond
+       (and editing? (not @(rf/subscribe [::form :initialized?])))
+       [spinner/big]
+
+       (and editing? @(rf/subscribe [::form :fetching?]))
+       [spinner/big]
+
+       :else
        [:<>
         [validation-errors-summary]
-        [:div.row
-         [:div.col-lg
-          [collapsible/component
-           {:id "create-form"
-            :class "fields"
-            :title [text :t.administration/form]
-            :always [:div
-                     [form-organization-field]
-                     [form-internal-name-field]
-                     [form-external-title-field]
-                     [form-fields (:form/fields form)]
-                     [:div.col.commands
-                      [cancel-button]
-                      [save-form-button #(rf/dispatch [::send-form])]]]}]]
-         [:div.col-lg
-          [form-preview form]]]])]))
+        [form-page-wrapper]])]))

--- a/src/cljs/rems/administration/create_organization.cljs
+++ b/src/cljs/rems/administration/create_organization.cljs
@@ -197,7 +197,8 @@
        :on-change #(rf/dispatch [::set-owners %])}]]))
 
 (defn- remove-review-email-button [field-index]
-  [items/remove-button #(rf/dispatch [::remove-review-email field-index])])
+  [items/remove-button {:on-click #(rf/dispatch [::remove-review-email field-index])
+                        :data-index field-index}])
 
 (rf/reg-event-db
  ::add-review-email

--- a/src/cljs/rems/administration/create_workflow.cljs
+++ b/src/cljs/rems/administration/create_workflow.cljs
@@ -15,6 +15,7 @@
             [rems.fetcher :as fetcher]
             [rems.fields :as fields]
             [rems.flash-message :as flash-message]
+            [rems.focus :as focus]
             [rems.spinner :as spinner]
             [rems.text :refer [localized localize-command localize-role localize-state text text-format text-format-map]]
             [rems.util :refer [navigate! post! put! trim-when-string]]))
@@ -421,9 +422,8 @@
                [:div.form-field-header
                 [:h4 (text :t.create-workflow/rule)]
                 [:div.form-field-controls
-                 [items/remove-button (fn []
-                                        (rf/dispatch [::remove-disable-command index])
-                                        (rf/dispatch [:rems.focus/scroll-into-view (str "#" id) {:block :end}]))]]]
+                 [items/remove-button {:on-click #(rf/dispatch [::remove-disable-command index])
+                                       :data-index index}]]]
                [select-command {:commands @(rf/subscribe [::commands])
                                 :index index
                                 :on-change #(rf/dispatch [::set-form-field [:disable-commands index :command] %])
@@ -442,7 +442,7 @@
                      :on-click (fn [event]
                                  (.preventDefault event)
                                  (rf/dispatch [::new-disable-command])
-                                 (rf/dispatch [:rems.focus/scroll-into-view (str "#" id) {:block :end}]))}
+                                 (focus/scroll-into-view (str "#" id " .new-rule") {:block :end}))}
         (text :t.create-workflow/create-new-rule)]]]]))
 
 (rf/reg-sub ::processing-states (fn [db _] (get-in db [::form :processing-states])))
@@ -463,9 +463,8 @@
                [:div.form-field-header
                 [:h4 (get-processing-state-title value)]
                 [:div.form-field-controls
-                 [items/remove-button (fn []
-                                        (rf/dispatch [::remove-processing-state index])
-                                        (rf/dispatch [:rems.focus/scroll-into-view (str "#" id) {:block :end}]))]]]
+                 [items/remove-button {:on-click #(rf/dispatch [::remove-processing-state index])
+                                       :data-index index}]]]
                [text-field context {:keys [:processing-states index :processing-state/value]
                                     :label (text :t.administration/technical-value)}]
                [localized-text-field context {:keys [:processing-states index :processing-state/title]
@@ -475,7 +474,7 @@
                      :on-click (fn [event]
                                  (.preventDefault event)
                                  (rf/dispatch [::new-processing-state])
-                                 (rf/dispatch [:rems.focus/scroll-into-view (str "#" id) {:block :end}]))}
+                                 (focus/scroll-into-view (str "#" id " .new-rule") {:block :end}))}
         (text :t.create-workflow/create-new-processing-state)]]]]))
 
 ;;;; page component

--- a/src/cljs/rems/administration/items.cljs
+++ b/src/cljs/rems/administration/items.cljs
@@ -31,36 +31,37 @@
         other (min last-index (inc index))]
     (swap items index other)))
 
-(defn remove-button [on-click]
+(defn remove-button [{:keys [on-click data-index]}]
   [:a.remove
    {:href "#"
+    :data-index data-index
     :on-click (fn [event]
                 (.preventDefault event)
-                (on-click))
+                (when on-click (on-click)))
     :aria-label (text :t.item-lists/remove)
     :title (text :t.item-lists/remove)}
    [:i.icon-link.fas.fa-times
     {:aria-hidden true}]])
 
-(defn move-up-button [{:keys [on-click class]}]
-  [:a
-   {:className (str "move-up " class)
-    :href "#"
+(defn move-up-button [{:keys [on-click data-index]}]
+  [:a.move-up
+   {:href "#"
+    :data-index data-index
     :on-click (fn [event]
                 (.preventDefault event)
-                (on-click))
+                (when on-click (on-click)))
     :aria-label (text :t.item-lists/move-up)
     :title (text :t.item-lists/move-up)}
    [:i.icon-link.fas.fa-chevron-up
     {:aria-hidden true}]])
 
-(defn move-down-button [{:keys [on-click class]}]
-  [:a
-   {:className (str "move-down " class)
-    :href "#"
+(defn move-down-button [{:keys [on-click data-index]}]
+  [:a.move-down
+   {:href "#"
+    :data-index data-index
     :on-click (fn [event]
                 (.preventDefault event)
-                (on-click))
+                (when on-click (on-click)))
     :aria-label (text :t.item-lists/move-down)
     :title (text :t.item-lists/move-down)}
    [:i.icon-link.fas.fa-chevron-down

--- a/src/cljs/rems/atoms.cljs
+++ b/src/cljs/rems/atoms.cljs
@@ -4,10 +4,8 @@
             [medley.core :refer [remove-vals update-existing]]
             [reagent.core :as r]
             [reagent.impl.util]
-            [rems.common.util :refer [escape-element-id]]
             [rems.guide-util :refer [component-info example]]
-            [rems.text :refer [text text-format localized localize-attachment]]
-            [rems.util :refer [focus-when-collapse-opened]]))
+            [rems.text :refer [text text-format localized localize-attachment]]))
 
 (defn external-link []
   [:i {:class "fa fa-external-link-alt"}
@@ -75,6 +73,8 @@
 (defn shown-to-applying-users-symbol []
   [:i.fas.fa-eye {:title (text :t.applications/shown-to-applying-users)}
    [:span.sr-only (text :t.applications/shown-to-applying-users)]])
+
+(defn info-symbol [] [:i.fa.fa-info-circle])
 
 (defn textarea [attrs]
   [autosize/textarea (merge {:min-rows 5}
@@ -230,34 +230,6 @@
     (when heading?
       [:h1 the-title])))
 
-(defn expander
-  "Displays an expandable block of content with animated chevron.
-
-   Pass a map of options with the following keys:
-   * `id` unique id for expanded content
-   * `content` content which is displayed in expanded state
-   * `expanded?` initial expanded state
-   * `title` content which is always displayed together with animated chevron"
-  [{:keys [expanded?] :or {expanded? false}}]
-  (let [expanded (r/atom expanded?)]
-    (fn [{:keys [id content title]}]
-      (let [id (escape-element-id id)]
-        [:<>
-         [:button.info-button.btn.d-flex.align-items-center.px-0 ; .btn adds unnecessary horizontal padding
-          {:data-toggle "collapse"
-           :href (str "#" id)
-           :aria-expanded (if @expanded "true" "false")
-           :aria-controls id
-           :on-click #(swap! expanded not)
-           :style {:white-space "normal"}} ; .btn uses "nowrap" which overflows the page with long input
-          [:span.mr-2.fa.fa-chevron-down.animate-transform
-           {:class (when @expanded "rotate-180")}]
-          title]
-         [:div.collapse {:id id
-                         :ref focus-when-collapse-opened
-                         :tab-index "-1"}
-          content]]))))
-
 (defn button
   "Plain button with defaults. `props` are passed to button, except for following keys:
 
@@ -293,21 +265,23 @@
 
 (defn action-button
   "Takes an `action` description and creates a button that triggers it."
-  [{:keys [class id label on-click url]}]
-  [link {:id id
-         :label label
-         :href url
-         :on-click on-click
-         :class (str/trim (str "btn btn-secondary " class))}])
+  [{:keys [class id label on-click url] :as action}]
+  [link (merge (dissoc action :class :id :label :on-click :url)
+               {:id id
+                :label label
+                :href url
+                :on-click on-click
+                :class (str/trim (str "btn btn-secondary " class))})])
 
 (defn action-link
   "Takes an `action` description and creates a link that triggers it."
-  [{:keys [class id label on-click url]}]
-  [link {:id id
-         :label label
-         :href url
-         :on-click on-click
-         :class (str/trim (str "btn btn-link " class))}])
+  [{:keys [class id label on-click url] :as action}]
+  [link (merge (dissoc action :class :id :label :on-click :url)
+               {:id id
+                :label label
+                :href url
+                :on-click on-click
+                :class (str/trim (str "btn btn-link " class))})])
 
 (defn rate-limited-action-button
   "Takes an `action` description and creates a button that triggers it.
@@ -420,13 +394,6 @@
        (example "attachment-link, long filename"
                 [attachment-link {:attachment/id 123
                                   :attachment/filename "this_is_the_very_very_very_long_filename_of_a_test_file_the_file_itself_is_quite_short_though_abcdefghijklmnopqrstuvwxyz0123456789_overflow_overflow_overflow.txt"}])
-
-       (component-info expander)
-       (example "expander"
-                [expander {:id "guide-expander-id"
-                           :title "Expander block with animated chevron"
-                           :expanded? false
-                           :content [:p "Expanded content"]}])
 
        (component-info action-link)
        (example "example command as link"

--- a/src/cljs/rems/collapsible.cljs
+++ b/src/cljs/rems/collapsible.cljs
@@ -1,255 +1,214 @@
 (ns rems.collapsible
   (:require [reagent.core :as r]
-            [rems.text :refer [text]]
-            [rems.guide-util :refer [component-info example]]))
+            [reagent.ratom :as ra]
+            [reagent.impl.util]
+            [re-frame.core :as rf]
+            [rems.atoms :as atoms]
+            [rems.guide-util :refer [component-info example]]
+            [rems.text :refer [text]]))
 
-(defn- show [id callback]
-  (let [element (js/$ (str "#" id))]
-    (.collapse element "show")
-    (.focus element))
-  ;; bootstrap's .collapse returns immediately, so in order to avoid
-  ;; momentarily showing both buttons we wait for a hidden.bs.collapse event
-  (.. (js/$ (str "." id "-more"))
-      (collapse "hide")
-      (one "hidden.bs.collapse" (fn [_] (. (js/$ (str "." id "-less")) collapse "show"))))
-  (when callback
-    (callback)))
+(rf/reg-sub ::expanded (fn [db [_ id]] (true? (get-in db [::id id]))))
+(rf/reg-event-db ::set-expanded (fn [db [_ id expanded?]] (assoc-in db [::id id] (true? expanded?))))
+(rf/reg-event-db ::toggle (fn [db [_ id]] (update-in db [::id id] not)))
 
-(defn- hide [id callback]
-  (.collapse (js/$ (str "#" id)) "hide")
-  (.. (js/$ (str "." id "-less"))
-      (collapse "hide")
-      (one "hidden.bs.collapse" (fn [_]
-                                  (. (js/$ (str "." id "-more")) collapse "show")
-                                  (when callback
-                                    (callback)))))
-  (.focus (js/$ (str "#" id "-more-link"))))
+(defn- init-collapsible! [id state]
+  @(ra/make-reaction #(rf/dispatch-sync [::set-expanded id state])))
 
-(defn- header [{:keys [title class]}]
-  [:h2.card-header.rems-card-margin-fix {:class (or class "rems-card-header")}
-   title])
+(rf/reg-event-fx ::show-and-focus (fn [{:keys [db]} [_ id]]
+                                    (when-not (get-in db [::id id])
+                                      {:db (assoc-in db [::id id] true)
+                                       :dispatch [:rems.focus/focus-input {:selector ".collapse-open"
+                                                                           :target (.getElementById js/document id)}]})))
 
-(defn- show-more-button [{:keys [label id expanded callback]}]
-  [:a.collapse
-   {:class [(str id "-more") (when-not expanded
-                               "show")]
-    :href "#"
-    :id (str id "-more-link")
-    :on-click (fn [event]
-                (.preventDefault event)
-                (show id callback))}
-   label])
+(defn- base-action [id]
+  (let [state @(rf/subscribe [::expanded id])]
+    {:aria-controls id
+     :aria-expanded (if state
+                      "true"
+                      "false")
+     :label (if state
+              (text :t.collapse/hide)
+              (text :t.collapse/show))}))
 
-(defn- show-less-button [{:keys [label id expanded callback]}]
-  [:a.collapse
-   {:class [(str id "-less") (when expanded
-                               "show")]
-    :href "#"
-    :on-click (fn [event]
-                (.preventDefault event)
-                (hide id callback))}
-   label])
+(defn toggle-action
+  "Action that toggles collapsible state."
+  [id & [on-click]]
+  (assoc (base-action id)
+         :on-click (fn [& args]
+                     (rf/dispatch [::toggle id])
+                     (some-> on-click (apply args)))))
 
-(defn controls
-  "A hide/show button that toggles the visibility of a div. Arguments
+(defn- show-and-focus! [id]
+  (fn [^js event]
+    (rf/dispatch [::show-and-focus id])
+    (doto event (.preventDefault))))
 
-  `id` id of the div to control. Should have the collapse class
-  `label-show` label to show when div is collapsed
-  `label-hide` label to show when div is expanded
-  `open?` should the collapse be open initially?"
-  [id label-show label-hide open?]
-  [:<>
-   [show-more-button {:label label-show
-                      :id id
-                      :expanded open?}]
-   [show-less-button {:label label-hide
-                      :id id
-                      :expanded open?}]])
+(defn- show-control [id & [{:keys [label on-click]}]]
+  [:div.text-center
+   [atoms/action-link (-> (base-action id)
+                          (assoc :on-click (comp (or on-click identity) (show-and-focus! id))
+                                 :label (or label (text :t.collapse/show))
+                                 :class "show-more-link"
+                                 :url "#"))]])
 
-(defn- block [{:keys [open?]}]
-  (let [show? (r/atom open?)] ; track internal open/closed status
-    (fn [{:keys [id open? on-open on-close content-always content-hideable content-hidden content-footer top-less-button? bottom-less-button? class]}]
-      (let [always? (not-empty content-always)
-            hidden (not-empty content-hidden)
-            show-more [:div.collapse-toggle
-                       [show-more-button {:label (if (or always? hidden)
-                                                   (text :t.collapse/show-more)
-                                                   (text :t.collapse/show))
-                                          :id id
-                                          :expanded open?
-                                          :callback (fn []
-                                                      (reset! show? true)
-                                                      (when on-open
-                                                        (on-open)))}]]
-            show-less [:div.collapse-toggle
-                       [show-less-button {:label (if (or always? hidden)
-                                                   (text :t.collapse/show-less)
-                                                   (text :t.collapse/hide))
-                                          :id id
-                                          :expanded open?
-                                          :callback (fn []
-                                                      (reset! show? false)
-                                                      (when on-close
-                                                        (on-close)))}]]]
-        [:div {:class class}
-         content-always
-         (when (seq content-hideable)
-           [:div
-            (when top-less-button? show-less)
-            (when-not @show? hidden)
-            [:div.collapse {:id id
-                            :class (when open?
-                                     "show")
-                            :tab-index "-1"}
-             content-hideable]
-            show-more
-            (when-not (false? bottom-less-button?) show-less)])
-         content-footer]))))
+(defn- hide-control [id & [{:keys [label on-click]}]]
+  [:div.text-center
+   [atoms/action-link (-> (base-action id)
+                          (assoc :on-click (fn [& args]
+                                             (rf/dispatch [::set-expanded id false])
+                                             (some-> on-click (apply args)))
+                                 :label (or label (text :t.collapse/hide))
+                                 :class "show-less-link"
+                                 :url "#"))]])
 
-(defn minimal
-  "Displays a minimal collapsible block of content.
+(defn toggle-control
+  "A hide/show button that externally toggles the visibility of a collapsible.
 
-  The difference to `component` is that there are no borders around the content.
+   - `:id` id of the controlled collapsible"
+  [id & [on-click]]
+  (if @(rf/subscribe [::expanded id])
+    [hide-control id {:on-click on-click}]
+    [show-control id {:on-click on-click}]))
 
-  Pass a map of options with the following keys:
-  `:id` unique id required
-  `:class` optional class for wrapper div
-  `:open?` should the collapsible be open? Default false
-  `:top-less-button?` should top show less button be shown? Default false
-  `:bottom-less-button?` should bottom show less button be shown? Default true
-  `:on-open` triggers the function callback given as an argument when load-more is clicked
-  `:on-close` triggers the function callback given as an argument when show less is clicked
-  `:title` component displayed in title area
-  `:title-class` class for the title area
-  `:always` component displayed always before collapsible area
-  `:collapse` component that is toggled displayed or not
-  `:collapse-hidden` component that is displayed when content is collapsed. Defaults nil
-  `:footer` component displayed always after collapsible area"
-  [{:keys [id class open? on-open on-close title title-class always collapse collapse-hidden footer top-less-button? bottom-less-button?]}]
-  [:div {:id id :class class}
-   (when title
-     [header {:title title
-              :class title-class}])
-   (when (or always collapse footer)
-     [block {:id (str id "-collapse")
-             :open? open?
-             :on-open on-open
-             :on-close on-close
-             :content-always always
-             :content-hideable collapse
-             :content-hidden collapse-hidden
-             :content-footer footer
-             :top-less-button? top-less-button?
-             :bottom-less-button? bottom-less-button?}])])
+(defn- collapse-block [id collapse & [collapse-hidden]]
+  (when (some? collapse)
+    (if @(rf/subscribe [::expanded id])
+      [:div.collapse-open collapse]
+      [:div.collapse-closed collapse-hidden])))
 
 (defn component
-  "Displays a collapsible block of content.
-
+  "Collapsible content block that can show hidden content on click.
+  Contains distinct border, and location of toggle controls are customizable.
+  
   Pass a map of options with the following keys:
-  `:id` unique id required
-  `:class` optional class for wrapper div
-  `:open?` should the collapsible be open? Default false
-  `:top-less-button?` should top show less button be shown? Default false
-  `:bottom-less-button?` should bottom show less button be shown? Default true
-  `:on-open` triggers the function callback given as an argument when load-more is clicked
-  `:on-close` triggers the function callback given as an argument when show less is clicked
-  `:title` component displayed in title area
-  `:title-class` class for the title area
-  `:always` component displayed always before collapsible area
-  `:collapse` component that is toggled displayed or not
-  `:collapse-hidden` component that is displayed when content is collapsed. Defaults nil
-  `:footer` component displayed always after collapsible area"
-  [{:keys [id class open? on-open on-close title title-class always collapse collapse-hidden footer top-less-button? bottom-less-button?]}]
-  [:div.collapse-wrapper {:id id
-                          :class class}
-   (when title
-     [header {:title title
-              :class title-class}])
-   (when (or always collapse footer)
-     [block {:id (str id "-collapse")
-             :class "collapse-content"
-             :open? open?
-             :on-open on-open
-             :on-close on-close
-             :content-always always
-             :content-hideable collapse
-             :content-hidden collapse-hidden
-             :content-footer footer
-             :top-less-button? top-less-button?
-             :bottom-less-button? bottom-less-button?}])])
+  - `:always` component displayed always before collapsible area
+  - `:bottom-less-button?` should bottom show less button be shown?
+  - `:collapse` component that is toggled displayed or not
+  - `:collapse-hidden` component that is displayed when content is collapsed
+  - `:footer` component displayed always after collapsible area
+  - `:id` unique string
+  - `:on-close` triggers the function callback given as an argument when show less is clicked
+  - `:on-open` triggers the function callback given as an argument when collapse is toggled open
+  - `:open?` should the collapsible be initially open?
+  - `:title` component or text displayed in title area
+  - `:top-less-button?` should top show less button be shown?"
+  [{:keys [always bottom-less-button? collapse collapse-hidden footer id on-close on-open open? title top-less-button?]
+    :or {bottom-less-button? true}}]
+  (r/with-let [_ (init-collapsible! id open?)]
+    (let [expanded? @(rf/subscribe [::expanded id])]
+      [:div.collapsible.bordered-collapsible {:id id}
+       [:h2.card-header title]
+       [:div.collapsible-contents
+        always
+        (when collapse
+          [:<>
+           (when (and expanded? top-less-button?) [hide-control id {:on-click on-close}])
+           [collapse-block id collapse collapse-hidden]
+           (when (not expanded?) [show-control id {:on-click on-open}])
+           (when (and expanded? bottom-less-button?) [hide-control id {:on-click on-close}])])
+        footer]])))
 
-(defn open-component
-  "A helper for opening a collapsible/component or collapsible/minimal"
-  [id]
-  (show (str id "-collapse") nil))
+(defn minimal
+  "Collapsible variation that does not have border or title, and controls
+  must be provided externally with e.g. `rems.collapsible/toggle-control`.
+  
+  Pass a map of options with the following keys:
+  - `:always` component displayed always before collapsible area
+  - `:collapse` component that is toggled displayed or not
+  - `:collapse-hidden` component that is displayed when content is collapsed
+  - `:class` optional class for wrapping element
+  - `:footer` component displayed always after collapsible area
+  - `:id` (required) unique id
+  - `:open?` should the collapsible be initially open?
+  - `:title` component or text displayed in title area"
+  [{:keys [always class collapse collapse-hidden footer id open? title]}]
+  (r/with-let [_ (init-collapsible! id open?)]
+    [:div.collapsible (merge {:id id} (when class {:class class}))
+     (when title [:h2.card-header title])
+     [:div.collapsible-contents
+      always
+      [collapse-block id collapse collapse-hidden]
+      footer]]))
+
+(defn expander
+  "Collapsible variation where simple title is the toggle control.
+  
+  Pass a map of options with the following keys:
+  - `:collapse` component that is toggled displayed or not
+  - `:id` (required) unique id
+  - `:open?` should the collapsible be initially open?
+  - `:title` component or text displayed in title area"
+  [{:keys [collapse id open? title]}]
+  (r/with-let [_ (init-collapsible! id open?)]
+    (let [expanded? @(rf/subscribe [::expanded id])]
+      [:div.collapsible.expander-collapsible {:id id}
+       [atoms/action-link (assoc (toggle-action id)
+                                 :class "expander-toggle"
+                                 :label [:div.d-flex.align-items-center.gap-1.pointer
+                                         [:i.fa.fa-chevron-down.animate-transform {:class (when expanded? "rotate-180")}]
+                                         title]
+                                 :url "#")]
+       [:div.collapsible-contents
+        [collapse-block id collapse]]])))
 
 (defn guide
   []
   [:div
    (component-info component)
-   (example "collapsible closed by default"
-            [component {:id "hello1"
-                        :title "Collapse minimized"
+   (example "default use"
+            [component {:id "standard-collapsible-1"
+                        :title "Standard"
                         :always [:p "I am content that is always visible"]
                         :collapse [:p "I am content that you can hide"]}])
-   (example "collapsible expanded by default and footer"
-            [component {:id "hello2"
+   (example "no hide controls"
+            [component {:id "standard-collapsible-2"
+                        :title "Focus on show"
+                        :always [:p "Hidden input receives focus on show"]
+                        :collapse [:input]}])
+   (example "no collapse content"
+            [component {:id "standard-collapsible-3"
+                        :title "No collapse"
+                        :always [:p "I am content that is always visible"]
+                        :footer [:div.solid-group "I am the footer that is always visible"]}])
+   (example "all options"
+            [component {:id "standard-collapsible-4"
+                        :title "Highly customized"
                         :open? true
-                        :title "Collapse expanded"
-                        :always [:p "I am content that is always visible"]
-                        :collapse [:p "I am content that you can hide"]
-                        :footer [:p "I am the footer that is always visible"]}])
-   (example "collapsible without title"
-            [component {:id "hello3"
-                        :open? true
-                        :title nil
-                        :always [:p "I am content that is always visible"]}])
-   (example "collapsible without hideable content can't be opened"
-            [component {:id "hello4"
-                        :title "Collapse without children"
-                        :always [:p "I am content that is always visible"]}])
-   (example "collapsible without always content"
-            [component {:id "hello5"
-                        :title "Collapse without always content"
-                        :collapse [:p "I am content that you can hide"]}])
-   (example "collapsible that opens slowly"
-            [component {:id "hello6"
-                        :class "slow"
-                        :title "Collapse expanded"
-                        :always [:p "I am content that is always visible"]
-                        :collapse (into [:div] (repeat 5 [:p "I am content that you can hide"]))}])
-   (example "collapsible with two show less buttons"
-            [component {:id "hello7"
-                        :class "slow"
-                        :title "Collapse expanded"
-                        :always [:p "I am content that is always visible"]
                         :top-less-button? true
-                        :collapse (into [:div] (repeat 15 [:p "I am long content that you can hide"]))}])
-   (example "collapsible that has different content when toggled"
-            [component {:id "hello8"
-                        :title "Collapsed"
-                        :always [:p "I am content that is always visible"]
+                        :bottom-less-button? true
+                        :on-open #(js/console.log "hello")
+                        :on-close #(js/console.log "bye")
+                        :always [:div.solid-group
+                                 [:b "Custom controls:"]
+                                 [rems.collapsible/toggle-control "standard-collapsible-4"]]
+                        :collapse (into [:div] (repeat 3 [:p "I am long content that you can hide"]))
                         :collapse-hidden [:p "I am content that is only visible when collapsed"]
-                        :collapse (into [:div] (repeat 15 [:p "I am long content that you can hide"]))}])
+                        :footer [:div.solid-group "I am the footer that is always visible"]}])
+
    (component-info minimal)
-   (example "minimal collapsible without title"
-            [minimal {:id "minimal1"
-                      :always [:p "I am content that is always visible"]
-                      :collapse (into [:div] (repeat 5 [:p "I am long content that you can hide"]))}])
-   (example "minimal collapsible with custom border"
-            [minimal {:id "minimal2"
-                      :class "dashed-group m-1"
-                      :always [:p "I am content that is always visible"]
-                      :collapse (into [:div] (repeat 5 [:p "I am long content that you can hide"]))}])
-   (example "minimal collapsible that opens slowly"
-            [minimal {:id "minimal3"
-                      :class "slow"
-                      :title "Minimal expanded"
-                      :always [:p "I am content that is always visible"]
-                      :collapse (into [:div] (repeat 5 [:p "I am long content that you can hide"]))}])
-   (example "minimal collapsible that has different content when toggled"
-            [minimal {:id "minimal4"
-                      :title "Minimal collapsed"
-                      :always [:p "I am content that is always visible"]
+   (example "default use"
+            [minimal {:id "minimal-collapsible-1"
+                      :always [rems.collapsible/toggle-control "minimal-collapsible-1"]
+                      :collapse [:p "I am content that you can hide"]}])
+   (example "footer controls"
+            [minimal {:id "minimal-collapsible-2"
+                      :footer [rems.collapsible/toggle-control "minimal-collapsible-2"]
+                      :collapse [:p "I am content that you can hide"]}])
+   (example "all options"
+            [minimal {:id "minimal-collapsible-3"
+                      :open? true
+                      :always [rems.collapsible/toggle-control "minimal-collapsible-3"]
+                      :collapse (into [:div] (repeat 3 [:p "I am long content that you can hide"]))
                       :collapse-hidden [:p "I am content that is only visible when collapsed"]
-                      :collapse (into [:div] (repeat 5 [:p "I am long content that you can hide"]))}])])
+                      :footer [rems.collapsible/toggle-control "minimal-collapsible-3"]}])
+
+   (component-info expander)
+   (example "defaults"
+            [expander {:id "expander-collapsible-1"
+                       :title "The whole header is clickable"
+                       :collapse (into [:div] (repeat 3 [:p "I am content that you can hide"]))}])
+   (example "all options"
+            [expander {:id "expander-collapsible-2"
+                       :title [:h3.m-0 "Initially open"]
+                       :collapse (into [:div] (repeat 3 [:p "I am content that you can hide"]))
+                       :open? true}])])

--- a/src/cljs/rems/fields.cljs
+++ b/src/cljs/rems/fields.cljs
@@ -4,8 +4,10 @@
             ["diff-match-patch" :refer [diff_match_patch]]
             [goog.functions :refer [debounce rateLimit]]
             [re-frame.core :as rf]
+            [medley.core :refer [assoc-some]]
             [rems.administration.items :as items]
-            [rems.atoms :refer [add-symbol attachment-link download-button close-symbol failure-symbol textarea]]
+            [rems.atoms :as atoms :refer [add-symbol attachment-link download-button close-symbol failure-symbol textarea]]
+            [rems.collapsible :as collapsible]
             [rems.common.attachment-util :as attachment-util]
             [rems.common.form :as common-form]
             [rems.common.util :refer [assoc-not-present build-index getx]]
@@ -14,29 +16,10 @@
             [rems.guide-util :refer [component-info example lipsum-short lipsum-paragraphs]]
             [rems.spinner :as spinner]
             [rems.text :refer [localized text text-format]]
-            [rems.util :refer [focus-when-collapse-opened linkify format-file-size]]))
+            [rems.util :refer [linkify format-file-size event-value]]))
 
 (defn field-name [field]
   (str "form-" (getx field :form/id) "-field-" (getx field :field/id)))
-
-(defn info-collapse
-  "Collapse field from Bootstrap that shows extra information about input fields.
-
-  `:info-id`           - id of the element being described
-  `:aria-label-text`   - text describing aria-label of collapse, see more https://developers.google.com/web/fundamentals/accessibility/semantics-aria/aria-labels-and-relationships
-  `:content`           - component that is shown if open"
-  [{:keys [info-id aria-label-text content]}]
-  [:<> [:button.info-button.btn.btn-link
-        {:data-toggle "collapse"
-         :href (str "#" (str info-id "-collapse"))
-         :aria-label aria-label-text
-         :aria-expanded "false"
-         :aria-controls (str info-id "-collapse")}
-        [:i.fa.fa-info-circle]]
-   [:div.info-collapse.collapse.my-3 {:id (str info-id "-collapse")
-                                      :ref focus-when-collapse-opened
-                                      :tab-index "-1"}
-    content]])
 
 (defn- diff [value previous-value]
   (let [dmp (diff_match_patch.)
@@ -90,6 +73,53 @@
   (readonly-field-raw {:id id
                        :value (linkify (str/trim (str value)))}))
 
+(defn info-collapsible-toggle [{:keys [aria-label id]}]
+  [atoms/action-link
+   (assoc-some (collapsible/toggle-action id)
+               :class "info-collapsible-toggle"
+               :label [atoms/info-symbol]
+               :aria-label aria-label
+               :url "#")])
+
+(defn info-collapsible [{:keys [id collapse]}]
+  [collapsible/minimal
+   {:id id
+    :class "info-collapsible"
+    :collapse [:div.mb-2 collapse]}])
+
+(defn- field-label [{info-text :field/info-text
+                     max-length :field/max-length
+                     title :field/title
+                     optional :field/optional
+                     :keys [fieldset]
+                     :as opts}]
+  (let [raw-title (localized title)
+        info-text (localized info-text)
+        label (->> (conj []
+                         (linkify raw-title)
+                         (when max-length (text-format :t.form/maxlength (str max-length)))
+                         (if optional
+                           (text :t.form/optional)
+                           (text :t.form/required)))
+                   (interpose " "))
+        collapsible-id (str (field-name opts) "-collapsible")
+        info-text? (not (str/blank? info-text))]
+    [:<>
+     (if fieldset ; XXX: currently only used by multiselect-field
+       [:legend.application-field-label
+        label
+        (when info-text? [info-collapsible-toggle {:id collapsible-id
+                                                   :aria-label (str (text :t.create-form/collapse-aria-label) raw-title)}])]
+
+       [:label.application-field-label {:for (field-name opts)}
+        label
+        (when info-text? [info-collapsible-toggle {:id collapsible-id
+                                                   :aria-label (str (text :t.create-form/collapse-aria-label) raw-title)}])])
+
+     (when info-text?
+       [info-collapsible {:id collapsible-id
+                          :collapse [:div.mb-2 (linkify info-text)]}])]))
+
 (defn field-wrapper
   "Common parts of a form field.
 
@@ -110,58 +140,34 @@
 
   editor-component      - HTML, form component for editing the field"
   [{:keys [readonly readonly-component diff diff-component validation on-toggle-diff fieldset] :as opts} editor-component]
-  (let [raw-title (localized (:field/title opts))
-        title (linkify raw-title)
-        optional (:field/optional opts)
-        value (:field/value opts)
+  (let [value (:field/value opts)
         previous-value (:field/previous-value opts)
-        max-length (:field/max-length opts)
-        info-text (localized (:field/info-text opts))
-        collapse-aria-label (str (text :t.create-form/collapse-aria-label) raw-title)]
+        the-field-name (field-name opts)]
     ;; TODO: simplify fieldset code
-    [(if fieldset
-       :fieldset.form-group.field
-       :div.form-group.field)
-     (merge
-      {:id (str "container-" (field-name opts))}
-      (when fieldset
-        {:tab-index -1
-         :aria-invalid (when validation true)
-         :aria-describedby (when validation
-                             (str (field-name opts) "-error"))}))
-     [(if fieldset
-        :legend.application-field-label
-        :label.application-field-label)
-      (when (not fieldset)
-        {:for (field-name opts)})
-      title " "
-      (when max-length
-        (text-format :t.form/maxlength (str max-length)))
-      " "
-      (if optional
-        (text :t.form/optional)
-        (text :t.form/required))
-      (when-not (str/blank? info-text)
-        [info-collapse
-         {:info-id (field-name opts)
-          :aria-label-text collapse-aria-label
-          :content (linkify info-text)}])]
-     (when (and previous-value
-                (not= value previous-value))
-       [toggle-diff-button diff on-toggle-diff])
-     (cond
-       diff (or diff-component
-                [diff-field {:id (field-name opts)
-                             :value value
-                             :previous-value previous-value}])
-       readonly (or readonly-component
-                    [readonly-field {:id (field-name opts)
-                                     :value value}])
-       :else editor-component)
-     (when validation
-       [:div.invalid-feedback
-        {:id (str (field-name opts) "-error")}
-        (text-format (:type validation) raw-title)])]))
+    (into
+     (if fieldset ; XXX: currently only used by multiselect-field
+       [:fieldset.form-group.field {:id (str "container-" the-field-name)
+                                    :tab-index -1
+                                    :aria-invalid (when validation true)
+                                    :aria-describedby (when validation (str the-field-name "-error"))}]
+       [:div.form-group.field {:id (str "container-" the-field-name)}])
+     (list
+      [field-label opts]
+      (when (and previous-value
+                 (not= value previous-value))
+        [toggle-diff-button diff on-toggle-diff])
+      (cond
+        diff (or diff-component
+                 [diff-field {:id the-field-name
+                              :value value
+                              :previous-value previous-value}])
+        readonly (or readonly-component
+                     [readonly-field {:id the-field-name
+                                      :value value}])
+        :else editor-component)
+      (when validation
+        [:div.invalid-feedback {:id (str the-field-name "-error")}
+         (text-format (:type validation) (localized (:field/title opts)))])))))
 
 (defn- non-field-wrapper [opts children]
   [:div.form-group
@@ -330,40 +336,42 @@
                  (localized label)]])))]))
 
 (defn- upload-button [id status on-upload]
-  (let [upload-id (str id "-input")
-        info-id (str id "-info")]
+  (let [upload-id (str id "-input")]
     [:div.upload-file
-     [:input {:style {:display "none"}
-              :type "file"
-              :id upload-id
-              :name upload-id
-              :accept attachment-util/allowed-extensions-string
-              :on-change (fn [event]
-                           (let [filecontent (aget (.. event -target -files) 0)
-                                 form-data (doto (js/FormData.)
-                                             (.append "file" filecontent))]
-                             (set! (.. event -target -value) nil) ; empty selection to fix uploading the same file twice
-                             (on-upload form-data)))}]
-     [:button.btn.btn-outline-secondary
-      {:id id
-       :type :button
-       :on-click (fn [e] (.click (.getElementById js/document upload-id)))}
-      [add-symbol]
-      " "
-      (text :t.form/upload)]
-     [:span.ml-2
-      (case status
-        :pending [spinner/small]
-        :success nil ; the new attachment row appearing is confirmation enough
-        :error [failure-symbol]
-        nil)]
-     [info-collapse
-      {:info-id info-id
-       :aria-label-text (text-format :t.form/upload-extensions attachment-util/allowed-extensions-string)
-       :content [:div
-                 [:p [text-format :t.form/upload-extensions attachment-util/allowed-extensions-string]]
-                 [:p (text-format :t.form/attachment-max-size
-                                  (format-file-size (:attachment-max-size @rems.globals/config)))]]}]]))
+     [:div.mb-3
+      [:input {:style {:display "none"}
+               :type "file"
+               :id upload-id
+               :name upload-id
+               :accept attachment-util/allowed-extensions-string
+               :on-change (fn [event]
+                            (let [filecontent (aget (.. event -target -files) 0)
+                                  form-data (doto (js/FormData.)
+                                              (.append "file" filecontent))]
+                              (set! (.. event -target -value) nil) ; empty selection to fix uploading the same file twice
+                              (on-upload form-data)))}]
+      [:button.btn.btn-outline-secondary
+       {:id id
+        :type :button
+        :on-click (fn [e] (.click (.getElementById js/document upload-id)))}
+       [add-symbol]
+       " "
+       (text :t.form/upload)]
+      [:span.ml-2
+       (case status
+         :pending [spinner/small]
+         :success nil ; the new attachment row appearing is confirmation enough
+         :error [failure-symbol]
+         nil)]
+      [info-collapsible-toggle
+       {:id (str id "-info-collapsible")
+        :aria-label (text-format :t.form/upload-extensions attachment-util/allowed-extensions-string)}]]
+     [info-collapsible
+      {:id (str id "-info-collapsible")
+       :collapse [:div
+                  [:p [text-format :t.form/upload-extensions attachment-util/allowed-extensions-string]]
+                  [:p (text-format :t.form/attachment-max-size
+                                   (format-file-size (:attachment-max-size @rems.globals/config)))]]}]]))
 
 (defn multi-attachment-view [{:keys [id attachments status on-attach on-remove-attachment label]}]
   [:div.form-group

--- a/src/cljs/rems/flash_message.cljs
+++ b/src/cljs/rems/flash_message.cljs
@@ -5,7 +5,8 @@
             [re-frame.core :as rf]
             [rems.administration.status-flags :as status-flags]
             [rems.focus :as focus]
-            [rems.text :refer [text text-format]]))
+            [rems.text :refer [text text-format]]
+            [rems.util :refer [on-element-appear]]))
 
 (defn- location-to-id [location]
   (let [_ (assert (keyword? location))]
@@ -31,7 +32,8 @@
 (rf/reg-event-fx ::show-flash-message
                  (fn [{:keys [db]} [_ message {:keys [focus? timeout] :or {focus? true}}]]
                    (when focus?
-                     (focus/focus-element-async (str "#" (location-to-id (:location message)))))
+                     (on-element-appear {:selector (str "#" (location-to-id (:location message)))
+                                         :on-resolve focus/focus-and-ensure-visible}))
                    (when (some? timeout)
                      (js/setTimeout #(rf/dispatch [::reset (:location message)]) timeout))
                    ;; TODO: flash the message with CSS

--- a/src/cljs/rems/profile.cljs
+++ b/src/cljs/rems/profile.cljs
@@ -9,7 +9,7 @@
             [rems.spinner :as spinner]
             [rems.text :refer [text]]
             [rems.user :as user]
-            [rems.util :refer [put!]]))
+            [rems.util :refer [event-value put!]]))
 
 (rf/reg-event-fx
  ::enter-page
@@ -85,9 +85,7 @@
                      {:type "email"
                       :id id
                       :value (:notification-email form)
-                      :on-change (fn [event]
-                                   (let [value (.. event -target -value)]
-                                     (rf/dispatch [::set-form (assoc form :notification-email value)])))}]])
+                      :on-change #(rf/dispatch [::set-form (assoc form :notification-email (event-value %))])}]])
 
                  [:button.btn.btn-primary
                   {:type "submit"}

--- a/src/cljs/rems/search.cljs
+++ b/src/cljs/rems/search.cljs
@@ -2,10 +2,10 @@
   (:require [clojure.string :as str]
             [goog.functions :refer [debounce]]
             [reagent.core :as r]
-            [rems.atoms :refer [close-symbol]]
+            [rems.atoms :as atoms]
+            [rems.collapsible :as collapsible]
             [rems.spinner :as spinner]
-            [rems.text :refer [text]]
-            [rems.util :refer [fetch focus-when-collapse-opened]]))
+            [rems.text :refer [text]]))
 
 (defn search-field [{:keys [id on-search searching? info debounce-time] :or {debounce-time 500}}]
   (r/with-let [input-value (r/atom "")
@@ -44,23 +44,20 @@
                         (reset! input-value "")
                         (on-search "")
                         (.focus @input-element))}
-           [close-symbol]]])]
+           [atoms/close-symbol]]])]
 
       (when info
-        [:a.application-search-tips.btn.btn-link.collapsed
-         {:data-toggle "collapse"
-          :href (str "#" collapse-id)
-          :aria-label (text :t.search/example-searches)
-          :aria-expanded "false"
-          :aria-controls collapse-id}
-         [:i.fa.fa-question-circle]])
+        [atoms/action-link
+         (assoc (collapsible/toggle-action collapse-id)
+                :class "application-search-tips"
+                :label [atoms/search-symbol]
+                :aria-label (text :t.search/example-searches)
+                :url "#")])
       (when searching?
         [spinner/small])]
      (when info
-       [:div.search-tips.collapse.my-3 {:id collapse-id
-                                        :ref focus-when-collapse-opened
-                                        :tab-index "-1"}
-        info])]))
+       [collapsible/minimal {:id collapse-id
+                             :collapse [:div.search-tips.my-3 info]}])]))
 
 (defn- application-search-info [] ; TODO: this should probably be almost completely in localized text
   [:span

--- a/src/cljs/rems/util.cljs
+++ b/src/cljs/rems/util.cljs
@@ -272,3 +272,9 @@
                    (on-element-appear (assoc opts
                                              :on-resolve resolve
                                              :on-reject reject))))))
+
+(defn event-value [^js event]
+  (.. event -target -value))
+
+(defn event-checked [^js event]
+  (.. event -target -checked))

--- a/test/clj/rems/test_browser.clj
+++ b/test/clj/rems/test_browser.clj
@@ -814,6 +814,7 @@
       (is (btu/eventually-visible? {:fn/has-string "Invite member: Success"})))
 
     (testing "invite handler as member"
+      (Thread/sleep 1000)
       (is (not (btu/visible? [:actions-invite-member {:fn/has-text "Invite member"}])))
       (btu/scroll-and-click :invite-member-action-button)
       (is (btu/eventually-visible? [:actions-invite-member {:fn/has-text "Invite member"}]))

--- a/test/clj/rems/test_browser.clj
+++ b/test/clj/rems/test_browser.clj
@@ -39,15 +39,14 @@
 (use-fixtures
   :each
   btu/reset-context-fixture
-  btu/refresh-driver-fixture)
+  btu/smoke-test-fixture
+  btu/init-driver-fixture)
 
 (use-fixtures
   :once
   btu/ensure-empty-directories-fixture
   btu/test-dev-or-standalone-fixture
-  btu/smoke-test
-  btu/accessibility-report-fixture
-  btu/init-driver-fixture)
+  btu/accessibility-report-fixture)
 
 ;;; common functionality
 

--- a/test/cljs/rems/administration/test_create_form.cljs
+++ b/test/cljs/rems/administration/test_create_form.cljs
@@ -1,53 +1,55 @@
 (ns rems.administration.test-create-form
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [rems.administration.create-form :refer [build-request build-request-field build-localized-string]]
+            [reagent.core :as r]
+            [rems.administration.create-form :refer [build-request build-request-field]]
             [rems.common.util :refer [getx-in]]
             [rems.globals]
             [rems.testing :refer [init-spa-fixture]]))
 
 (use-fixtures :each init-spa-fixture)
 
-(defn reset-form []
-  (rf/dispatch-sync [:rems.administration.create-form/enter-page]))
+(defn- set-roles! [roles] (reset! rems.globals/roles roles))
+(defn- set-languages! [languages] (r/rswap! rems.globals/config assoc :languages languages))
+
+(defn- reset-form! [] (rf/dispatch-sync [:rems.administration.create-form/enter-page]))
 
 (deftest add-form-field-test
-  (reset! rems.globals/roles [:owner])
+  (set-roles! [:owner])
   (let [form (rf/subscribe [:rems.administration.create-form/form-data])]
     (testing "adds fields"
-      (reset-form)
-      (is (= {:form/fields []}
-             @form)
+      (reset-form!)
+      (is (= nil @form)
           "before")
 
       (rf/dispatch-sync [:rems.administration.create-form/add-form-field])
 
-      (is (= {:form/fields [{:field/id "fld1" :field/index 0 :field/type :text}]}
+      (is (= {:form/fields [{:field/id "fld1" :field/type :text}]}
              @form)
           "after"))
 
     (testing "adds fields to the end"
-      (reset-form)
+      (reset-form!)
       (rf/dispatch-sync [:rems.administration.create-form/add-form-field])
-      (rf/dispatch-sync [:rems.administration.create-form/set-form-field [:form/fields 0 :foo] "old field"])
-      (is (= {:form/fields [{:field/id "fld1" :field/index 0 :field/type :text :foo "old field"}]}
+      (rf/dispatch-sync [:rems.administration.create-form/update-form [:form/fields 0 :foo] "old field"])
+      (is (= {:form/fields [{:field/id "fld1" :field/type :text :foo "old field"}]}
              @form)
           "before")
 
       (rf/dispatch-sync [:rems.administration.create-form/add-form-field])
 
-      (is (= {:form/fields [{:field/id "fld1" :field/index 0 :field/type :text :foo "old field"}
-                            {:field/id "fld2" :field/index 1 :field/type :text}]}
+      (is (= {:form/fields [{:field/id "fld1" :field/type :text :foo "old field"}
+                            {:field/id "fld2" :field/type :text}]}
              @form)
           "after"))))
 
 (deftest remove-form-field-test
-  (reset! rems.globals/roles [:owner])
+  (set-roles! [:owner])
   (let [form (rf/subscribe [:rems.administration.create-form/form-data])]
     (testing "removes fields"
-      (reset-form)
+      (reset-form!)
       (rf/dispatch-sync [:rems.administration.create-form/add-form-field])
-      (is (= {:form/fields [{:field/id "fld1" :field/index 0 :field/type :text}]}
+      (is (= {:form/fields [{:field/id "fld1" :field/type :text}]}
              @form)
           "before")
 
@@ -58,65 +60,65 @@
           "after"))
 
     (testing "removes only the field at the specified index"
-      (reset-form)
+      (reset-form!)
       (rf/dispatch-sync [:rems.administration.create-form/add-form-field])
       (rf/dispatch-sync [:rems.administration.create-form/add-form-field])
       (rf/dispatch-sync [:rems.administration.create-form/add-form-field])
-      (rf/dispatch-sync [:rems.administration.create-form/set-form-field [:form/fields 0 :foo] "field 0"])
-      (rf/dispatch-sync [:rems.administration.create-form/set-form-field [:form/fields 1 :foo] "field 1"])
-      (rf/dispatch-sync [:rems.administration.create-form/set-form-field [:form/fields 2 :foo] "field 2"])
-      (is (= {:form/fields [{:field/id "fld1" :field/index 0 :field/type :text :foo "field 0"}
-                            {:field/id "fld2" :field/index 1 :field/type :text :foo "field 1"}
-                            {:field/id "fld3" :field/index 2 :field/type :text :foo "field 2"}]}
+      (rf/dispatch-sync [:rems.administration.create-form/update-form [:form/fields 0 :foo] "field 0"])
+      (rf/dispatch-sync [:rems.administration.create-form/update-form [:form/fields 1 :foo] "field 1"])
+      (rf/dispatch-sync [:rems.administration.create-form/update-form [:form/fields 2 :foo] "field 2"])
+      (is (= {:form/fields [{:field/id "fld1" :field/type :text :foo "field 0"}
+                            {:field/id "fld2" :field/type :text :foo "field 1"}
+                            {:field/id "fld3" :field/type :text :foo "field 2"}]}
              @form)
           "before")
 
       (rf/dispatch-sync [:rems.administration.create-form/remove-form-field 1])
 
-      (is (= {:form/fields [{:field/id "fld1" :field/index 0 :field/type :text :foo "field 0"}
-                            {:field/id "fld3" :field/index 1 :field/type :text :foo "field 2"}]}
+      (is (= {:form/fields [{:field/id "fld1" :field/type :text :foo "field 0"}
+                            {:field/id "fld3" :field/type :text :foo "field 2"}]}
              @form)
           "after"))))
 
 (deftest move-form-field-up-test
-  (reset! rems.globals/roles [:owner])
+  (set-roles! [:owner])
   (let [form (rf/subscribe [:rems.administration.create-form/form-data])]
     (testing "moves fields up"
-      (reset-form)
+      (reset-form!)
       (rf/dispatch-sync [:rems.administration.create-form/add-form-field])
       (rf/dispatch-sync [:rems.administration.create-form/add-form-field])
       (rf/dispatch-sync [:rems.administration.create-form/add-form-field])
-      (rf/dispatch-sync [:rems.administration.create-form/set-form-field [:form/fields 0 :foo] "field 0"])
-      (rf/dispatch-sync [:rems.administration.create-form/set-form-field [:form/fields 1 :foo] "field 1"])
-      (rf/dispatch-sync [:rems.administration.create-form/set-form-field [:form/fields 2 :foo] "field X"])
-      (is (= {:form/fields [{:field/id "fld1" :field/index 0 :field/type :text :foo "field 0"}
-                            {:field/id "fld2" :field/index 1 :field/type :text :foo "field 1"}
-                            {:field/id "fld3" :field/index 2 :field/type :text :foo "field X"}]}
+      (rf/dispatch-sync [:rems.administration.create-form/update-form [:form/fields 0 :foo] "field 0"])
+      (rf/dispatch-sync [:rems.administration.create-form/update-form [:form/fields 1 :foo] "field 1"])
+      (rf/dispatch-sync [:rems.administration.create-form/update-form [:form/fields 2 :foo] "field X"])
+      (is (= {:form/fields [{:field/id "fld1" :field/type :text :foo "field 0"}
+                            {:field/id "fld2" :field/type :text :foo "field 1"}
+                            {:field/id "fld3" :field/type :text :foo "field X"}]}
              @form)
           "before")
 
       (rf/dispatch-sync [:rems.administration.create-form/move-form-field-up 2])
 
-      (is (= {:form/fields [{:field/id "fld1" :field/index 0 :field/type :text :foo "field 0"}
-                            {:field/id "fld3" :field/index 1 :field/type :text :foo "field X"}
-                            {:field/id "fld2" :field/index 2 :field/type :text :foo "field 1"}]}
+      (is (= {:form/fields [{:field/id "fld1" :field/type :text :foo "field 0"}
+                            {:field/id "fld3" :field/type :text :foo "field X"}
+                            {:field/id "fld2" :field/type :text :foo "field 1"}]}
              @form)
           "after move 1")
 
       (rf/dispatch-sync [:rems.administration.create-form/move-form-field-up 1])
 
-      (is (= {:form/fields [{:field/id "fld3" :field/index 0 :field/type :text :foo "field X"}
-                            {:field/id "fld1" :field/index 1 :field/type :text :foo "field 0"}
-                            {:field/id "fld2" :field/index 2 :field/type :text :foo "field 1"}]}
+      (is (= {:form/fields [{:field/id "fld3" :field/type :text :foo "field X"}
+                            {:field/id "fld1" :field/type :text :foo "field 0"}
+                            {:field/id "fld2" :field/type :text :foo "field 1"}]}
              @form)
           "after move 2")
 
       (testing "unless already first"
         (rf/dispatch-sync [:rems.administration.create-form/move-form-field-up 0])
 
-        (is (= {:form/fields [{:field/id "fld3" :field/index 0 :field/type :text :foo "field X"}
-                              {:field/id "fld1" :field/index 1 :field/type :text :foo "field 0"}
-                              {:field/id "fld2" :field/index 2 :field/type :text :foo "field 1"}]}
+        (is (= {:form/fields [{:field/id "fld3" :field/type :text :foo "field X"}
+                              {:field/id "fld1" :field/type :text :foo "field 0"}
+                              {:field/id "fld2" :field/type :text :foo "field 1"}]}
                @form)
             "after move 3")))))
 
@@ -124,47 +126,48 @@
   (reset! rems.globals/roles [:owner])
   (let [form (rf/subscribe [:rems.administration.create-form/form-data])]
     (testing "moves fields down"
-      (reset-form)
+      (reset-form!)
       (rf/dispatch-sync [:rems.administration.create-form/add-form-field])
       (rf/dispatch-sync [:rems.administration.create-form/add-form-field])
       (rf/dispatch-sync [:rems.administration.create-form/add-form-field])
-      (rf/dispatch-sync [:rems.administration.create-form/set-form-field [:form/fields 0 :foo] "field X"])
-      (rf/dispatch-sync [:rems.administration.create-form/set-form-field [:form/fields 1 :foo] "field 1"])
-      (rf/dispatch-sync [:rems.administration.create-form/set-form-field [:form/fields 2 :foo] "field 2"])
-      (is (= {:form/fields [{:field/id "fld1" :field/index 0 :field/type :text :foo "field X"}
-                            {:field/id "fld2" :field/index 1 :field/type :text :foo "field 1"}
-                            {:field/id "fld3" :field/index 2 :field/type :text :foo "field 2"}]}
+      (rf/dispatch-sync [:rems.administration.create-form/update-form [:form/fields 0 :foo] "field X"])
+      (rf/dispatch-sync [:rems.administration.create-form/update-form [:form/fields 1 :foo] "field 1"])
+      (rf/dispatch-sync [:rems.administration.create-form/update-form [:form/fields 2 :foo] "field 2"])
+      (is (= {:form/fields [{:field/id "fld1" :field/type :text :foo "field X"}
+                            {:field/id "fld2" :field/type :text :foo "field 1"}
+                            {:field/id "fld3" :field/type :text :foo "field 2"}]}
              @form)
           "before")
 
       (rf/dispatch-sync [:rems.administration.create-form/move-form-field-down 0])
 
-      (is (= {:form/fields [{:field/id "fld2" :field/index 0 :field/type :text :foo "field 1"}
-                            {:field/id "fld1" :field/index 1 :field/type :text :foo "field X"}
-                            {:field/id "fld3" :field/index 2 :field/type :text :foo "field 2"}]}
+      (is (= {:form/fields [{:field/id "fld2" :field/type :text :foo "field 1"}
+                            {:field/id "fld1" :field/type :text :foo "field X"}
+                            {:field/id "fld3" :field/type :text :foo "field 2"}]}
              @form)
           "after move 1")
 
       (rf/dispatch-sync [:rems.administration.create-form/move-form-field-down 1])
 
-      (is (= {:form/fields [{:field/id "fld2" :field/index 0 :field/type :text :foo "field 1"}
-                            {:field/id "fld3" :field/index 1 :field/type :text :foo "field 2"}
-                            {:field/id "fld1" :field/index 2 :field/type :text :foo "field X"}]}
+      (is (= {:form/fields [{:field/id "fld2" :field/type :text :foo "field 1"}
+                            {:field/id "fld3" :field/type :text :foo "field 2"}
+                            {:field/id "fld1" :field/type :text :foo "field X"}]}
              @form)
           "after move 2")
 
       (testing "unless already last"
         (rf/dispatch-sync [:rems.administration.create-form/move-form-field-down 2])
 
-        (is (= {:form/fields [{:field/id "fld2" :field/index 0 :field/type :text :foo "field 1"}
-                              {:field/id "fld3" :field/index 1 :field/type :text :foo "field 2"}
-                              {:field/id "fld1" :field/index 2 :field/type :text :foo "field X"}]}
+        (is (= {:form/fields [{:field/id "fld2" :field/type :text :foo "field 1"}
+                              {:field/id "fld3" :field/type :text :foo "field 2"}
+                              {:field/id "fld1" :field/type :text :foo "field X"}]}
                @form)
             "after move 3")))))
 
 (deftest build-request-field-test
+  (set-languages! [:en :fi])
+
   (let [fields [{:field/id "fld1"
-                 :field/index 0
                  :field/title {:en "en title"
                                :fi "fi title"}
                  :field/info-text {:en "en info text"
@@ -173,8 +176,7 @@
                  :field/type :text
                  :field/max-length "12"
                  :field/placeholder {:en "en placeholder"
-                                     :fi "fi placeholder"}}]
-        languages [:en :fi]]
+                                     :fi "fi placeholder"}}]]
     (testing "basic fields"
       (is (= [{:field/id "fld1"
                :field/title {:en "en title"
@@ -186,8 +188,7 @@
                :field/max-length 12
                :field/placeholder {:en "en placeholder"
                                    :fi "fi placeholder"}}]
-
-             (mapv #(build-request-field % languages) fields)))
+             (mapv build-request-field fields)))
 
       (testing "empty info texts should be passed on except when all empty"
         (is (= [{:field/id "fld1"
@@ -198,8 +199,7 @@
                  :field/max-length 12
                  :field/placeholder {:en "en placeholder"
                                      :fi "fi placeholder"}}]
-
-               (mapv #(build-request-field % languages)
+               (mapv build-request-field
                      (assoc-in fields [0 :field/info-text] {:en "" :fi ""}))))
         (is (= [{:field/id "fld1"
                  :field/title {:en "en title"
@@ -212,16 +212,17 @@
                  :field/placeholder {:en "en placeholder"
                                      :fi "fi placeholder"}}]
 
-               (mapv #(build-request-field % languages)
+               (mapv build-request-field
                      (assoc-in fields [0 :field/info-text :fi] ""))))))))
 
 (deftest build-request-test
+  (set-languages! [:en :fi])
+
   (let [form {:organization {:organization/id "abc"}
               :form/internal-name "the name"
               :form/external-title {:en "en external title"
                                     :fi "fi external title"}
               :form/fields [{:field/id "fld1"
-                             :field/index 0
                              :field/title {:en "en title"
                                            :fi "fi title"}
                              :field/info-text {:en "en info text"
@@ -230,9 +231,7 @@
                              :field/type :text
                              :field/max-length "12"
                              :field/placeholder {:en "en placeholder"
-                                                 :fi "fi placeholder"}}]}
-
-        languages [:en :fi]]
+                                                 :fi "fi placeholder"}}]}]
 
     (testing "basic form"
       (is (= {:organization {:organization/id "abc"}
@@ -249,7 +248,7 @@
                              :field/max-length 12
                              :field/placeholder {:en "en placeholder"
                                                  :fi "fi placeholder"}}]}
-             (build-request form languages))))
+             (build-request form))))
 
     (testing "with empty info text"
       (is (= {:organization {:organization/id "abc"}
@@ -264,14 +263,13 @@
                              :field/max-length 12
                              :field/placeholder {:en "en placeholder"
                                                  :fi "fi placeholder"}}]}
-             (build-request (assoc-in form [:form/fields 0 :field/info-text] {:en "" :fi ""})
-                            languages))))
+             (build-request (assoc-in form [:form/fields 0 :field/info-text] {:en "" :fi ""})))))
 
     (testing "with missing title"
       (is (= {:form/external-title {:en "en external title" :fi ""}}
-             (select-keys (build-request (assoc-in form [:form/external-title :fi] "") languages) [:form/external-title])))
+             (select-keys (build-request (assoc-in form [:form/external-title :fi] "")) [:form/external-title])))
       (is (= {:form/external-title {:en "en external title" :fi nil}}
-             (select-keys (build-request (assoc-in form [:form/external-title :fi] nil) languages) [:form/external-title]))))
+             (select-keys (build-request (assoc-in form [:form/external-title :fi] nil)) [:form/external-title]))))
 
     (testing "trim strings"
       (is (= {:organization {:organization/id "abc"}
@@ -288,7 +286,7 @@
                              :field/max-length 12
                              :field/placeholder {:en "en placeholder"
                                                  :fi "fi placeholder"}}]}
-             (build-request (assoc form :form/internal-name " the name\t\n") languages))))
+             (build-request (assoc form :form/internal-name " the name\t\n")))))
 
     (testing "zero fields"
       (is (= {:organization {:organization/id "abc"}
@@ -296,7 +294,7 @@
               :form/external-title {:en "en external title"
                                     :fi "fi external title"}
               :form/fields []}
-             (build-request (assoc-in form [:form/fields] []) languages))))
+             (build-request (assoc-in form [:form/fields] [])))))
 
     (testing "date fields"
       (let [form (assoc-in form [:form/fields 0 :field/type] :date)]
@@ -311,25 +309,25 @@
                                                  :fi "fi info text"}
                                :field/optional true
                                :field/type :date}]}
-               (build-request form languages)))))
+               (build-request form)))))
 
     (testing "missing optional implies false"
-      (is (false? (getx-in (build-request (assoc-in form [:form/fields 0 :field/optional] nil) languages)
+      (is (false? (getx-in (build-request (assoc-in form [:form/fields 0 :field/optional] nil))
                            [:form/fields 0 :field/optional]))))
 
     (testing "placeholder is optional"
       (is (= nil
-             (get-in (build-request (assoc-in form [:form/fields 0 :field/placeholder] nil) languages)
+             (get-in (build-request (assoc-in form [:form/fields 0 :field/placeholder] nil))
                      [:form/fields 0 :field/placeholder])
-             (get-in (build-request (assoc-in form [:form/fields 0 :field/placeholder] {:en ""}) languages)
+             (get-in (build-request (assoc-in form [:form/fields 0 :field/placeholder] {:en ""}))
                      [:form/fields 0 :field/placeholder])
-             (get-in (build-request (assoc-in form [:form/fields 0 :field/placeholder] {:en "" :fi ""}) languages)
+             (get-in (build-request (assoc-in form [:form/fields 0 :field/placeholder] {:en "" :fi ""}))
                      [:form/fields 0 :field/placeholder]))))
 
     (testing "max length is optional"
-      (is (nil? (getx-in (build-request (assoc-in form [:form/fields 0 :field/max-length] "") languages)
+      (is (nil? (getx-in (build-request (assoc-in form [:form/fields 0 :field/max-length] ""))
                          [:form/fields 0 :field/max-length])))
-      (is (nil? (getx-in (build-request (assoc-in form [:form/fields 0 :field/max-length] nil) languages)
+      (is (nil? (getx-in (build-request (assoc-in form [:form/fields 0 :field/max-length] nil))
                          [:form/fields 0 :field/max-length]))))
 
     (testing "option fields"
@@ -358,7 +356,7 @@
                                                {:key "no"
                                                 :label {:en "en no"
                                                         :fi "fi no"}}]}]}
-               (build-request form languages)))))
+               (build-request form)))))
 
     (testing "multiselect fields"
       (let [form (-> form
@@ -386,17 +384,17 @@
                                                {:key "bacon"
                                                 :label {:en "Bacon"
                                                         :fi "Pekonia"}}]}]}
-               (build-request form languages)))))
+               (build-request form)))))
 
     (testing "privacy"
-      (is (nil? (get-in (build-request (assoc-in form [:form/fields 0 :field/privacy] :public) languages)
+      (is (nil? (get-in (build-request (assoc-in form [:form/fields 0 :field/privacy] :public))
                         [:form/fields 0 :field/privacy]))
           "public is the default so nothing needs to be included")
-      (is (nil? (get-in (build-request (assoc-in form [:form/fields 0 :field/privacy] :does-not-exist) languages)
+      (is (nil? (get-in (build-request (assoc-in form [:form/fields 0 :field/privacy] :does-not-exist))
                         [:form/fields 0 :field/privacy]))
           "wrong data is not included")
       (is (= :private
-             (getx-in (build-request (assoc-in form [:form/fields 0 :field/privacy] :private) languages)
+             (getx-in (build-request (assoc-in form [:form/fields 0 :field/privacy] :private))
                       [:form/fields 0 :field/privacy]))))
     (testing "visibility"
       (let [form (-> form
@@ -420,14 +418,13 @@
                                                                      :fi "fi placeholder"}}))]
 
         (testing "default"
-          (is (nil? (get-in (build-request (assoc-in form [:form/fields 1 :field/visibility] {:visibility/type :always}) languages)
+          (is (nil? (get-in (build-request (assoc-in form [:form/fields 1 :field/visibility] {:visibility/type :always}))
                             [:form/fields 1 :field/visibility]))
               "always is the default so nothing needs to be included")
           (is (= {:visibility/type :only-if}
                  (getx-in (build-request (assoc-in form
                                                    [:form/fields 1 :field/visibility]
-                                                   {:visibility/type :only-if})
-                                         languages)
+                                                   {:visibility/type :only-if}))
                           [:form/fields 1 :field/visibility]))
               "missing data is not present"))
 
@@ -449,21 +446,5 @@
                                                    [:form/fields 1 :field/visibility]
                                                    {:visibility/type :only-if
                                                     :visibility/field {:field/id "fld1"}
-                                                    :visibility/values ["yes"]})
-                                         languages)
+                                                    :visibility/values ["yes"]}))
                           [:form/fields 1]))))))))
-
-(deftest build-localized-string-test
-  (let [languages [:en :fi]]
-    (testing "localizations are copied as-is"
-      (is (= {:en "x", :fi "y"}
-             (build-localized-string {:en "x", :fi "y"} languages))))
-    (testing "missing localization defaults to an empty string"
-      (is (= {:en "x", :fi ""}
-             (build-localized-string {:en "x"} languages))))
-    (testing "missing all localizations is nil"
-      (is (= nil
-             (build-localized-string {} languages))))
-    (testing "additional languages are excluded"
-      (is (= {:en "x", :fi "y"}
-             (build-localized-string {:en "x", :fi "y", :sv "z"} languages))))))


### PR DESCRIPTION
implements #3105

Form editor now uses more precise, cursor-like state instead of passing and diffing large fields array. Together with earlier optimization of globals, rendering a large amount of fields (200 in test data) now takes a few seconds initially, but creating, removing, moving and updating fields is near instantenous. Previous iteration became noticeably slow at updating more than 20 fields, and over 100 fields was practically unusable.

Other changes:
- added 200 field form to test data
- collapsible component no longer animates on open/close, and does not depend on Bootstrap or jQuery
- removed separate "show/hide" translation from collapsible action, so it now displays either "show more" or "show less"
- changed rems.focus/on-element-appear implementation to use [MutationObserver API](https://developer.mozilla.org/en-US/docs/Web/API/MutationObserver)

Other updates:
- updated Kaocha dependency to latest

# Checklist for author

Remove items that aren't applicable, check items that are done.

## Reviewability
- [x] Link to issue
- [ ] Consider adding screenshots for ease of review

## Documentation
- [x] Update changelog if necessary
- [x] Components are added to guide page

## Testing
- [x] Complex logic is unit tested
- [x] Valuable features are browser tested automatically

## Follow-up
- [ ] New tasks are created for pending or remaining tasks
