### PR TITLE
Better invitation error for handling user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,8 @@ Changes since v2.36
 - The "Change Form" function in administration has been expanded to be able to change both forms and workflows. From now on it is called "Update catalogue item". The old `change-form` API still exists but has been deprecated. (#3271)
 
 ### Changes
-    - Invitation links work multiple times. Previously, they were single-use. The invitation token is spent on the first use and it grants the rights then. However, the user may still use the link later for navigating into the application or workflow in question. (#3275)
+- Invitation links work multiple times. Previously, they were single-use. The invitation token is spent on the first use and it grants the rights then. However, the user may still use the link later for navigating into the application or workflow in question. (#3275)
+- Invitation gives a more informative error when handling user tries to join a draft application. (#3291)
 
 ## v2.36 "Laivapojankuja" 2024-03-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ Changes since v2.36
 
 ### Changes
 - Invitation links work multiple times. Previously, they were single-use. The invitation token is spent on the first use and it grants the rights then. However, the user may still use the link later for navigating into the application or workflow in question. (#3275)
-- Invitation gives a more informative error when handling user tries to join a draft application. (#3291)
+- Invitation gives a more informative error when handling user tries to join application. (#3291)
 
 ## v2.36 "Laivapojankuja" 2024-03-13
 

--- a/resources/translations/da.edn
+++ b/resources/translations/da.edn
@@ -27,7 +27,8 @@
             :decide "Beslut"
             :delete "Slet kladde"
             :delete-intro [:div.intro [:p "Slet denne kladde permanent?"]]
-            :errors {:duplicate-id "Id er allerede i brug."
+            :errors {:cannot-join-draft-as-handling-user nil
+                     :duplicate-id "Id er allerede i brug."
                      ;; %1 - invitation token
                      :invalid-token [:div [:p "Tilslutning til ansøgning mislykkedes."] [:p "Tjek invitationstoken " [:code "%1"]]]
                      :licenses-not-accepted "Brugsvilkår ikke accepteret."

--- a/resources/translations/da.edn
+++ b/resources/translations/da.edn
@@ -27,7 +27,7 @@
             :decide "Beslut"
             :delete "Slet kladde"
             :delete-intro [:div.intro [:p "Slet denne kladde permanent?"]]
-            :errors {:cannot-join-draft-as-handling-user nil
+            :errors {:handling-user-cannot-join nil
                      :duplicate-id "Id er allerede i brug."
                      ;; %1 - invitation token
                      :invalid-token [:div [:p "Tilslutning til ansøgning mislykkedes."] [:p "Tjek invitationstoken " [:code "%1"]]]

--- a/resources/translations/en.edn
+++ b/resources/translations/en.edn
@@ -27,7 +27,7 @@
             :decide "Decide"
             :delete "Delete draft"
             :delete-intro [:div.intro [:p "Permanently delete this draft?"]]
-            :errors {:cannot-join-draft-as-handling-user "Cannot join unsubmitted application because you are already a handling user."
+            :errors {:handling-user-cannot-join "A handling user cannot join application as member."
                      :duplicate-id "Id is already in use."
                      ;; %1 - invitation token
                      :invalid-token [:div [:p "Joining the application failed."] [:p "Check the invitation token " [:code "%1"]]]

--- a/resources/translations/en.edn
+++ b/resources/translations/en.edn
@@ -27,7 +27,8 @@
             :decide "Decide"
             :delete "Delete draft"
             :delete-intro [:div.intro [:p "Permanently delete this draft?"]]
-            :errors {:duplicate-id "Id is already in use."
+            :errors {:cannot-join-draft-as-handling-user "Cannot join unsubmitted application because you are already a handling user."
+                     :duplicate-id "Id is already in use."
                      ;; %1 - invitation token
                      :invalid-token [:div [:p "Joining the application failed."] [:p "Check the invitation token " [:code "%1"]]]
                      :licenses-not-accepted "Terms of use not accepted."

--- a/resources/translations/fi.edn
+++ b/resources/translations/fi.edn
@@ -27,7 +27,7 @@
             :decide "Päätä"
             :delete "Poista luonnos"
             :delete-intro [:div.intro [:p "Haluatko pysyvästi poistaa tämän hakemusluonnoksen?"]]
-            :errors {:cannot-join-draft-as-handling-user "Et voi liittyä luonnostilassa olevaan hakemukseen, koska osallistut jo sen käsittelyyn."
+            :errors {:handling-user-cannot-join "Hakemuksen käsittelyyn osallistuva ei voi liittyä hakemuksen jäseneksi."
                      :duplicate-id "Tunnus on jo käytössä."
                      :invalid-token [:div [:p "Hakemukseen liittyminen epäonnistui."] [:p "Tarkista kutsukoodi " [:code "%1"]]]
                      :licenses-not-accepted "Käyttöehtoja ei ole hyväksytty."

--- a/resources/translations/fi.edn
+++ b/resources/translations/fi.edn
@@ -27,7 +27,8 @@
             :decide "Päätä"
             :delete "Poista luonnos"
             :delete-intro [:div.intro [:p "Haluatko pysyvästi poistaa tämän hakemusluonnoksen?"]]
-            :errors {:duplicate-id "Tunnus on jo käytössä."
+            :errors {:cannot-join-draft-as-handling-user "Et voi liittyä luonnostilassa olevaan hakemukseen, koska osallistut jo sen käsittelyyn."
+                     :duplicate-id "Tunnus on jo käytössä."
                      :invalid-token [:div [:p "Hakemukseen liittyminen epäonnistui."] [:p "Tarkista kutsukoodi " [:code "%1"]]]
                      :licenses-not-accepted "Käyttöehtoja ei ole hyväksytty."
                      :organization-does-not-exist "Organisaatiota \"%1\" ei ole olemassa"

--- a/resources/translations/sv.edn
+++ b/resources/translations/sv.edn
@@ -27,7 +27,8 @@
             :decide "Avgör"
             :delete "Radera utkast"
             :delete-intro [:div.intro [:p "Radera detta utkast permanent?"]]
-            :errors {:duplicate-id "Id:et är redan upptaget."
+            :errors {:cannot-join-draft-as-handling-user "Det gick inte att ansluta till utkast ansökningen, eftersom du redan deltar i dets behandling."
+                     :duplicate-id "Id:et är redan upptaget."
                      :invalid-token [:div [:p "Det gick inte att ansluta till ansökningen."] [:p "Vänligen kontrollera koden för inbjudan." [:code "%1"]]]
                      :licenses-not-accepted "Du har inte godkänt användarvillkoren."
                      :organization-does-not-exist "Organisationen \"%1\" hittades inte."

--- a/resources/translations/sv.edn
+++ b/resources/translations/sv.edn
@@ -27,7 +27,7 @@
             :decide "Avgör"
             :delete "Radera utkast"
             :delete-intro [:div.intro [:p "Radera detta utkast permanent?"]]
-            :errors {:cannot-join-draft-as-handling-user "Det gick inte att ansluta till utkast ansökningen, eftersom du redan deltar i dets behandling."
+            :errors {:handling-user-cannot-join "Den som redan deltar i ansökans behandling kan inte ansluta till ansökningen."
                      :duplicate-id "Id:et är redan upptaget."
                      :invalid-token [:div [:p "Det gick inte att ansluta till ansökningen."] [:p "Vänligen kontrollera koden för inbjudan." [:code "%1"]]]
                      :licenses-not-accepted "Du har inte godkänt användarvillkoren."

--- a/src/clj/rems/application/model.clj
+++ b/src/clj/rems/application/model.clj
@@ -5,7 +5,7 @@
             [medley.core :refer [assoc-some dissoc-in distinct-by filter-vals find-first map-vals update-existing update-existing-in]]
             [rems.application.events :as events]
             [rems.application.master-workflow :as master-workflow]
-            [rems.common.application-util :refer [applicant-and-members can-redact-attachment? is-applying-user?]]
+            [rems.common.application-util :refer [applicant-and-members can-redact-attachment? draft? is-applying-user?]]
             [rems.common.form :as form]
             [rems.common.roles :refer [+handling-roles+]]
             [rems.common.util :refer [assoc-some-in conj-vec getx getx-in into-vec]]
@@ -1064,16 +1064,12 @@
     (assoc :application/todo :waiting-for-your-decision)))
 
 (defn see-application? [application userid]
-  (let [state (:application/state application)
-        roles (permissions/user-roles application userid)]
-    (cond
-      (= :application.state/draft state)
-      (is-applying-user? {:application/roles roles})
+  (cond
+    (draft? application)
+    (is-applying-user? application userid)
 
-      (= #{:everyone-else} roles)
-      false
-
-      :else true)))
+    :else
+    (not= #{:everyone-else} (permissions/user-roles application userid))))
 
 (defn apply-user-permissions [application userid]
   (let [roles (permissions/user-roles application userid)

--- a/src/cljc/rems/common/roles.cljc
+++ b/src/cljc/rems/common/roles.cljc
@@ -5,6 +5,7 @@
 
 (def +admin-write-roles+ #{:organization-owner :owner})
 (def +admin-read-roles+ #{:owner :organization-owner :handler :reporter})
+(def +applying-roles+ #{:applicant :member})
 (def +handling-roles+ #{:handler :reviewer :decider :past-reviewer :past-decider})
 
 (defn is-logged-in? [roles]

--- a/src/cljs/rems/actions/accept_invitation.cljs
+++ b/src/cljs/rems/actions/accept_invitation.cljs
@@ -28,7 +28,8 @@
                               (flash-message/show-success! :top [text :t.actions/accept-invitation-success])
                               (navigate! (str "/application/" (:application-id response))))
 
-                            (= :already-joined (:type error))
+                            (contains? #{:already-joined
+                                         :handling-user-cannot-join} (:type error))
                             (navigate! (str "/application/" (:application-id error)))
 
                             (= :t.actions.errors/invalid-token (:type error))

--- a/src/cljs/rems/application.cljs
+++ b/src/cljs/rems/application.cljs
@@ -929,7 +929,6 @@
         members (:application/members application)
         invited-members (:application/invited-members application)]
     (into [:div
-           [flash-message/component :change-members]
            [member-info {:element-id "applicant"
                          :attributes applicant
                          :application application
@@ -985,16 +984,21 @@
     [collapsible/component
      (cond (is-handler? application userid)
            (assoc component
-                  :always (applicants-details application))
+                  :always [:<>
+                           [flash-message/component :change-members]
+                           [applicants-details application]])
 
            only-one-applicant?
            (assoc component
-                  :always (applicants-details application {:simple? true}))
+                  :always [:<>
+                           [flash-message/component :change-members]
+                           [applicants-details application {:simple? true}]])
 
            :else
            (assoc component
-                  :collapse-hidden (applicants-short application)
-                  :collapse (applicants-details application)))]))
+                  :always [flash-message/component :change-members]
+                  :collapse-hidden [applicants-short application]
+                  :collapse [applicants-details application]))]))
 
 (defn- request-review-dropdown []
   [:div.btn-group

--- a/test/clj/rems/application/test_commands.clj
+++ b/test/clj/rems/application/test_commands.clj
@@ -1306,6 +1306,14 @@
                                                     dummy-member-invited-event
                                                     dummy-member-added-event])))))
 
+    (testing "handler can't join or get application id"
+      (is (= {:errors [{:type :t.actions.errors/handling-user-cannot-join :userid handler-user-id}]}
+             (fail-command {:type :application.command/accept-invitation
+                            :actor handler-user-id
+                            :token "very-secure"}
+                           (build-application-view [dummy-created-event
+                                                    dummy-member-invited-event])))))
+
     (testing "can't use invalid token"
       (is (= {:errors [{:type :t.actions.errors/invalid-token :token "wrong-token"}]}
              (fail-command {:type :application.command/accept-invitation
@@ -1335,6 +1343,15 @@
                          (build-application-view [dummy-created-event
                                                   dummy-member-invited-event
                                                   dummy-submitted-event])))))
+
+    (testing "handler can't join submitted but may see application id"
+      (is (= {:errors [{:type :handling-user-cannot-join :userid handler-user-id :application-id app-id}]}
+             (fail-command {:type :application.command/accept-invitation
+                            :actor handler-user-id
+                            :token "very-secure"}
+                           (build-application-view [dummy-created-event
+                                                    dummy-member-invited-event
+                                                    dummy-submitted-event])))))
 
     (testing "can't join a closed application"
       (is (= {:errors [{:type :forbidden}]}

--- a/test/clj/rems/browser_test_util.clj
+++ b/test/clj/rems/browser_test_util.clj
@@ -314,7 +314,9 @@
         file (io/file (:reporting-dir @test-context) full-filename)
 
         window-size (et/get-window-size driver)
-        empty-space (parse-int (et/get-element-attr driver :empty-space "clientHeight"))
+        empty-space (if (et/exists? driver :empty-space) ; if page has not rendered, screenshot can fail due to missing element
+                      (parse-int (et/get-element-attr driver :empty-space "clientHeight"))
+                      0)
 
         without-extra-height (if (and empty-space
                                       (pos? empty-space))

--- a/test/clj/rems/test_browser.clj
+++ b/test/clj/rems/test_browser.clj
@@ -827,11 +827,10 @@
           (is (btu/eventually-visible? {:tag :h1 :fn/has-text "Catalogue"})
               "was redirected to catalogue")
           (is (btu/eventually-visible? {:fn/has-string "Accept invitation: Failed"}))
-          (is (btu/eventually-visible? {:fn/has-string "Cannot join unsubmitted application because you are already a handling user"}))
+          (is (btu/eventually-visible? {:fn/has-string "A handling user cannot join application as member"}))
           (btu/screenshot "handler-cannot-join-as-member"))))
 
     (logout)
-
 
     (testing "submit application"
       (login-as "alice")

--- a/test/clj/rems/test_browser.clj
+++ b/test/clj/rems/test_browser.clj
@@ -791,7 +791,51 @@
       (btu/scroll-and-click :invite-member)
       (is (btu/eventually-visible? {:fn/has-string "Invite member: Success"})))
 
+    (testing "invite handler as member"
+      (is (not (btu/visible? [:actions-invite-member {:fn/has-text "Invite member"}])))
+      (btu/scroll-and-click :invite-member-action-button)
+      (is (btu/eventually-visible? [:actions-invite-member {:fn/has-text "Invite member"}]))
+      (btu/fill-human [:actions-invite-member :name-invite-member] "Developer")
+      (btu/fill-human [:actions-invite-member :email-invite-member] "developer@example.com")
+      (btu/scroll-and-click :invite-member)
+      (is (btu/eventually-visible? {:fn/has-string "Invite member: Success"}))
+
+      (testing "get invite token"
+        (let [[token invitation] (-> (btu/context-getx :application-id)
+                                     applications/get-application-internal
+                                     :application/invitation-tokens
+                                     second)]
+          (is (string? token))
+          (is (= {:application/member {:name "Developer" :email "developer@example.com"}
+                  :event/actor "alice"}
+                 invitation))
+          (btu/context-assoc! :handler-token token)))
+
+      (logout)
+
+      (testing "accept invitation as handler"
+        (btu/go (str (btu/get-server-url) "application/accept-invitation/" (btu/context-getx :handler-token)))
+        (is (btu/eventually-visible? {:css ".login-btn"}))
+        (btu/scroll-and-click {:css ".login-btn"})
+        (btu/wait-page-loaded)
+        (btu/scroll-and-click :show-special-users)
+        (is (btu/eventually-visible? [{:css ".users"} {:tag :a :fn/text "developer"}]))
+        (btu/scroll-and-click [{:css ".users"} {:tag :a :fn/text "developer"}])
+        (btu/wait-page-loaded)
+
+        (testing "joining the application fails"
+          (is (btu/eventually-visible? {:tag :h1 :fn/has-text "Catalogue"})
+              "was redirected to catalogue")
+          (is (btu/eventually-visible? {:fn/has-string "Accept invitation: Failed"}))
+          (is (btu/eventually-visible? {:fn/has-string "Cannot join unsubmitted application because you are already a handling user"}))
+          (btu/screenshot "handler-cannot-join-as-member"))))
+
+    (logout)
+
+
     (testing "submit application"
+      (login-as "alice")
+      (go-to-application (btu/context-getx :application-id))
       (btu/scroll-and-click :submit)
       (is (btu/eventually-visible? {:fn/has-string "Send application: Success"})))
 

--- a/test/clj/rems/test_browser.clj
+++ b/test/clj/rems/test_browser.clj
@@ -905,7 +905,24 @@
       (is (btu/eventually-visible? {:tag :h1 :fn/has-text "Catalogue"})
           "was redirected to catalogue")
       (is (btu/eventually-visible? {:fn/has-text "Joining the application failed."}))
-      (btu/screenshot "someone-else-cannot-use-the-link"))))
+      (btu/screenshot "someone-else-cannot-use-the-link"))
+
+    (logout)
+
+    (testing "handler can use invite link to view submitted application"
+      (btu/go (str (btu/get-server-url) "application/accept-invitation/" (btu/context-getx :handler-token)))
+      (is (btu/eventually-visible? {:css ".login-btn"}))
+      (btu/scroll-and-click {:css ".login-btn"})
+      (btu/wait-page-loaded)
+      (btu/scroll-and-click :show-special-users)
+      (is (btu/eventually-visible? [{:css ".users"} {:tag :a :fn/text "developer"}]))
+      (btu/scroll-and-click [{:css ".users"} {:tag :a :fn/text "developer"}])
+      (btu/wait-page-loaded)
+      ;; NB: this differs a bit from `login-as` and we should keep them the same
+      (btu/wait-visible :logout)
+      (is (btu/eventually-visible? {:tag :h1 :fn/has-text "test-applicant-member-invite-action"})
+          "gets to the application")
+      (btu/screenshot "handler-can-use-link-after-submit"))))
 
 (deftest test-applicant-member-remove-action
   (testing "submit test data with API"


### PR DESCRIPTION
implements #3291

When handling user tries to use accept invitation to join draft application, they were previously greeted with forbidden page because of trying to view draft application. Accept invitation command itself returned `:already-joined` due to handling users having a role in application, which has a special handling (basically passthrough).

Extra check is now performed for handling users before `already-joined`:
- if draft application, show localized error and redirect to catalogue;
- else, redirect to application.

![Screenshot 2024-05-07 at 18 13 23](https://github.com/CSCfi/rems/assets/794087/90c04c77-b22d-4073-94bc-aade53dfb2f9)

# Checklist for author

Remove items that aren't applicable, check items that are done.

## Reviewability
- [x] Link to issue
- [x] Consider adding screenshots for ease of review

## Documentation
- [x] Update changelog if necessary

## Testing
- [x] Valuable features are browser tested automatically
