### PR TITLE
fix: remove invited member when used

### DIFF
--- a/src/clj/rems/application/model.clj
+++ b/src/clj/rems/application/model.clj
@@ -869,7 +869,9 @@
 
 (defn- enrich-invited-members [application]
   (let [invitations (vals (:application/invitation-tokens application))
-        members (keep :application/member invitations)]
+        members (->> invitations
+                     (remove :token/used?)
+                     (keep :application/member))]
     (-> application
         (assoc :application/invited-members (set members)))))
 


### PR DESCRIPTION
Previously an invited used becomes a member, but the change to keep the invitations forever broke this and the invited user was still there even though the token was spent.

Noticed that invited members are never shown in the PDF. This is as it has been.

# Checklist for author

Remove items that aren't applicable, check items that are done.

## Reviewability
- [ ] Link to issue (none)

## Backwards compatibility
- [x] API is backwards compatible or completely new

## Documentation
- [ ] Update changelog if necessary (no, the feature is not released yet)

## Testing
- [x] Complex logic is unit tested