### PR TITLE
Many handlers perf

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -114,6 +114,7 @@
 
    :project/dev {:dependencies [[binaryage/devtools "1.0.7"]
                                 [com.clojure-goes-fast/clj-memory-meter "0.3.0"]
+                                [com.clojure-goes-fast/clj-async-profiler "1.2.0"]
                                 [criterium "0.4.6"]
                                 [lambdaisland/kaocha "1.87.1366"]
                                 [lambdaisland/kaocha-junit-xml "1.17.101"]

--- a/resources/sql/queries.sql
+++ b/resources/sql/queries.sql
@@ -542,10 +542,14 @@ SELECT userAttrs::TEXT
 FROM users
 WHERE userId = :user;
 
--- :name get-user-settings :? :1
-SELECT settings::TEXT
-from user_settings
-where userId = :user;
+-- :name get-user-settings :? :*
+SELECT userid, settings::TEXT
+FROM user_settings
+WHERE 1=1
+/*~ (when (:user params) */
+  AND userId = :user
+/*~ ) ~*/
+;
 
 -- :name get-application-events :? :*
 SELECT id, eventdata::TEXT

--- a/src/clj/rems/db/outbox.clj
+++ b/src/clj/rems/db/outbox.clj
@@ -168,5 +168,14 @@
                         :outboxdata (json/generate-string (dissoc entry :outbox/id))})
     entry))
 
+(defn attempt-failed-fatally!
+  "Like `attampt-failed!` but it makes no sense to try again."
+  [entry error]
+  (let [entry (assoc (next-attempt entry (time/now) error)
+                     :outbox/next-attempt nil)]
+    (db/update-outbox! {:id (getx entry :outbox/id)
+                        :outboxdata (json/generate-string (dissoc entry :outbox/id))})
+    entry))
+
 (defn attempt-succeeded! [id]
   (db/delete-outbox! {:id id}))

--- a/src/clj/rems/main.clj
+++ b/src/clj/rems/main.clj
@@ -14,12 +14,15 @@
             [rems.db.api-key :as api-key]
             [rems.db.applications :as applications]
             [rems.db.core :as db]
-            [rems.service.fix-userid]
+            [rems.db.events]
             [rems.db.roles :as roles]
-            [rems.service.test-data :as test-data]
+            [rems.db.user-settings]
             [rems.db.users :as users]
             [rems.handler :as handler]
             [rems.json :as json]
+            [rems.locales]
+            [rems.service.fix-userid]
+            [rems.service.test-data :as test-data]
             [rems.validate :as validate])
   (:import [sun.misc Signal SignalHandler]
            [org.eclipse.jetty.server.handler.gzip GzipHandler])
@@ -182,7 +185,8 @@
             (mount/start #'rems.config/env
                          #'rems.db.core/*db*
                          #'rems.locales/translations
-                         #'rems.db.events/low-level-events-cache)
+                         #'rems.db.events/low-level-events-cache
+                         #'rems.db.user-settings/low-level-user-settings-cache)
             (test-data/create-test-data!)
             (log/info "Test data created"))
 
@@ -191,7 +195,8 @@
             (mount/start #'rems.config/env
                          #'rems.db.core/*db*
                          #'rems.locales/translations
-                         #'rems.db.events/low-level-events-cache)
+                         #'rems.db.events/low-level-events-cache
+                         #'rems.db.user-settings/low-level-user-settings-cache)
             (log/info "Creating performance test data")
             (test-data/create-performance-test-data!)
             (log/info "Performance test data created"))
@@ -201,7 +206,8 @@
             (mount/start #'rems.config/env
                          #'rems.db.core/*db*
                          #'rems.locales/translations
-                         #'rems.db.events/low-level-events-cache)
+                         #'rems.db.events/low-level-events-cache
+                         #'rems.db.user-settings/low-level-user-settings-cache)
             (test-data/create-demo-data!))
 
           "dev-setup"
@@ -212,7 +218,8 @@
             (log/info "Creating test data")
             (mount/start #'rems.db.core/*db*
                          #'rems.locales/translations
-                         #'rems.db.events/low-level-events-cache)
+                         #'rems.db.events/low-level-events-cache
+                         #'rems.db.user-settings/low-level-user-settings-cache)
             (test-data/create-test-data!)
             (log/info "Test data created"))
 
@@ -224,7 +231,8 @@
             (log/info "Creating test data")
             (mount/start #'rems.db.core/*db*
                          #'rems.locales/translations
-                         #'rems.db.events/low-level-events-cache)
+                         #'rems.db.events/low-level-events-cache
+                         #'rems.db.user-settings/low-level-user-settings-cache)
             (test-data/create-test-data!)
             (log/info "Test data created")
             (log/info "Creating performance test data")
@@ -289,7 +297,10 @@
               (do (println "\n\n*** Renaming a user's identity can't easily be undone. ***\nType 'YES' to proceed or anything else to run a simulation only.")
                   (let [simulate? (not= "YES" (read-line))]
                     (println (if simulate? "Simulating only..." "Renaming..."))
-                    (mount/start #'rems.config/env #'rems.db.core/*db* #'rems.db.events/low-level-events-cache)
+                    (mount/start #'rems.config/env
+                                 #'rems.db.core/*db*
+                                 #'rems.db.events/low-level-events-cache
+                                 #'rems.db.user-settings/low-level-user-settings-cache)
                     (rems.service.fix-userid/fix-all old-userid new-userid simulate?)
                     (println "Finished.\n\nConsider rebooting the server process next to refresh all the caches, most importantly the application cache.")))))
 

--- a/src/clj/rems/service/test_data.clj
+++ b/src/clj/rems/service/test_data.clj
@@ -579,9 +579,31 @@
   (let [resource-count 1000
         application-count 3000
         user-count 1000
-        handlers [(+fake-users+ :approver1)
-                  (+fake-users+ :approver2)]
+        handler-count 100
+
         owner (+fake-users+ :owner)
+
+        ;; create handlers
+        names (->> vocabulary
+                   (remove #(re-find #"[.,]+" %))
+                   (filter #(> (count %) 3))
+                   (mapv str/capitalize))
+        handlers-data (for [i (range handler-count)
+                            :let [first-name (rand-nth names)
+                                  last-name (rand-nth names)]]
+                        {:userid (str "perf-test-handler-" i)
+                         :name (str first-name " " last-name)
+                         :email (str (str/lower-case first-name) "." (str/lower-case last-name) "@perftester.org")})
+
+        _ (doseq [handler handlers-data]
+            (test-helpers/create-user! handler))
+
+        handlers (concat [(+fake-users+ :approver1)
+                          (+fake-users+ :approver2)]
+                         (for [i (range handler-count)]
+                           (str "perf-test-handler-" i)))
+
+        ;; create domain data
         _perf (organizations/add-organization! {:organization/id "perf"
                                                 :organization/name {:fi "Suorituskykytestiorganisaatio" :en "Performance Test Organization" :sv "Organisationen för utvärderingsprov"}
                                                 :organization/short-name {:fi "Suorituskyky" :en "Performance" :sv "Uvärderingsprov"}

--- a/src/clj/rems/service/test_data.clj
+++ b/src/clj/rems/service/test_data.clj
@@ -670,7 +670,9 @@
                                                            :email (str user-id "@example.com")
                                                            :name (str "Performance Tester " n)})
                              user-id)))))]
-    (with-redefs [rems.config/env (assoc rems.config/env :enable-save-compaction false)] ; generate more events without compaction
+    (with-redefs [rems.config/env (assoc rems.config/env
+                                         :enable-save-compaction false  ; generate more events without compaction
+                                         :enable-handler-emails false)] ; don't bother with emails to speed up
       (in-parallel
        (for [n (range-1 application-count)]
          (fn []

--- a/src/clj/rems/service/test_data.clj
+++ b/src/clj/rems/service/test_data.clj
@@ -585,7 +585,7 @@
 
         ;; create handlers
         names (->> vocabulary
-                   (remove #(re-find #"[.,]+" %))
+                   (remove #(re-find #"[.,;\n]+" %))
                    (filter #(> (count %) 3))
                    (mapv str/capitalize))
         handlers-data (for [i (range handler-count)

--- a/src/cljc/rems/text.cljc
+++ b/src/cljc/rems/text.cljc
@@ -16,9 +16,10 @@
 
 #?(:clj
    (defmacro with-language [lang & body]
-     `(binding [rems.context/*lang* ~lang]
-        (assert (keyword? ~lang) {:lang ~lang})
-        ~@body)))
+     `(let [lang# ~lang] ; ensure lang is evaluated only once
+        (binding [rems.context/*lang* lang#]
+          (assert (keyword? lang#) {:lang lang#})
+          ~@body))))
 
 (defn- failsafe-fallback
   "Fallback for when loading the translations has failed."

--- a/src/cljs/rems/actions.cljs
+++ b/src/cljs/rems/actions.cljs
@@ -21,8 +21,8 @@
                  [::handled-applications-count]
                  [:rems.table/reset]]}))
 
-(fetcher/reg-fetcher ::todo-applications "/api/applications/todo")
-(fetcher/reg-fetcher ::handled-applications "/api/applications/handled")
+(fetcher/reg-fetcher ::todo-applications "/api/applications/todo?only-active-handlers=true")
+(fetcher/reg-fetcher ::handled-applications "/api/applications/handled?only-active-handlers=true")
 (fetcher/reg-fetcher ::handled-applications-count "/api/applications/handled/count")
 
 (rf/reg-sub ::show-all-rows (fn [db _] (::show-all-rows db)))

--- a/test/clj/rems/db/test_users.clj
+++ b/test/clj/rems/db/test_users.clj
@@ -22,6 +22,7 @@
 
   (testing "survives partial user settings"
     (db/update-user-settings! {:user "user1" :settings "{\"language\": \"fi\"}"}) ; missing notification-email
+    (user-settings/reload-user-settings-cache!)
 
     (is (= {:userid "user1"
             :name "What Ever"

--- a/test/clj/rems/db/testing.clj
+++ b/test/clj/rems/db/testing.clj
@@ -4,7 +4,6 @@
             [conman.core :as conman]
             [luminus-migrations.core :as migrations]
             [mount.core :as mount]
-            [rems.service.dependencies :as dependencies]
             [rems.application.search]
             [rems.config :refer [env]]
             [rems.db.applications :as applications]
@@ -12,9 +11,11 @@
             [rems.db.category :as category]
             [rems.db.core :as db]
             [rems.db.events :as events]
-            [rems.service.test-data :as test-data]
             [rems.db.user-mappings :as user-mappings]
-            [rems.locales]))
+            [rems.db.user-settings]
+            [rems.locales]
+            [rems.service.dependencies :as dependencies]
+            [rems.service.test-data :as test-data]))
 
 (defn reset-db-fixture [f]
   (try
@@ -35,7 +36,9 @@
   (applications/empty-injections-cache!)
 
   (migrations/migrate ["migrate"] {:database-url (:test-database-url env)})
-  (mount/start #'rems.db.events/low-level-events-cache) ; needs DB to start
+  ;; need DB to start these
+  (mount/start #'rems.db.events/low-level-events-cache
+               #'rems.db.user-settings/low-level-user-settings-cache)
   (f)
   (mount/stop))
 

--- a/test/clj/rems/test_performance.clj
+++ b/test/clj/rems/test_performance.clj
@@ -5,7 +5,8 @@
             [mount.core :as mount]
             [rems.service.todos :as todos]
             [rems.db.applications :as applications]
-            [rems.db.events :as events])
+            [rems.db.events :as events]
+            [rems.db.user-settings])
   (:import [java.util Locale]))
 
 (defn run-benchmark [benchmark]
@@ -53,10 +54,12 @@
         ;; developer can view much more applications than alice, so it takes longer to filter reviews from all apps
         test-get-todos #(doall (todos/get-todos "developer"))
         no-cache (fn []
-                   (mount/stop #'applications/all-applications-cache #'rems.db.events/low-level-events-cache))
+                   (mount/stop #'applications/all-applications-cache
+                               #'rems.db.events/low-level-events-cache
+                               #'rems.db.user-settings/low-level-user-settings-cache))
         cached (fn []
-                 (mount/stop #'applications/all-applications-cache #'rems.db.events/low-level-events-cache)
-                 (mount/start #'applications/all-applications-cache #'rems.db.events/low-level-events-cache)
+                 (mount/stop #'applications/all-applications-cache #'rems.db.events/low-level-events-cache #'rems.db.user-settings/low-level-user-settings-cache)
+                 (mount/start #'applications/all-applications-cache #'rems.db.events/low-level-events-cache #'rems.db.user-settings/low-level-user-settings-cache)
                  (test-get-all-unrestricted-applications))]
     (run-benchmarks [{:name "get-all-unrestricted-applications, no cache"
                       :benchmark test-get-all-unrestricted-applications


### PR DESCRIPTION
Tries to fix the many handlers perf problems from #3283 

There's two changes here of which one is more subtle.

The original logic from years ago was such that all users rights were
updated whenever there was any change. This was fast for a while.

Last year, updates were implemented to only touch users that were
involved in the applications of the events. This was much faster.
There is however a flaw in this version.

Consider a case where one application was changed but there are 100
potential handlers in the organization. All the rights of these 100
handlers were updated by considering all their applications. Handlers
tend to be members of all applications so that could be 100 times the
application count of updates, e.g. 300K for 3000 applications. This
adds up to a few hundred milliseconds, which is too slow for us now,
,specially after adding more performance test data (10 handlers in
production so 100 handlers in performance test data).

We can avoid this amount of changes by recording how many times you have a
role instead of only whether you have the role. Then we remove the
role once per member of the old application and add 1 per member of new
application. This will total 100 changes for 100 users in one
application, which is as good as it can be. We could also record which
application gives which role, but that is slightly more memory
consuming for no additional gain.

The other subtler change is to cache only ids of applications that a person
has, not the personalized applications. 100 handlers with 3000
applications could result in 300K applications being cached.
Clojure's persistent data structures do help us here and in practice
that would not happen. However, we can avoid this by doing the
personalization in the functions that return results instead and
have less memory use for some runtime cost. We do store the enriched
applications, so this personalization is only in-memory code, so it
should be fast.

These changes seem to be fast for the handled applications case, so it
should be fast enough for the other cases.

Further changes can be done in a new PR also, after we get all the improvement PRs integrated.

Main changes:
- adds 100 handlers to perf test data
- fail outbox job immediately on address error
- faster applications cache updates
- fetch only active handlers from `/handled` API

Potential future tasks:
- fetch only active handlers from other "overview" APIs
- low level cache for more (user) tables
- investigate real performance (in dev)

# Checklist for author

Remove items that aren't applicable, check items that are done.

## Reviewability
- [x] Link to issue

## Backwards compatibility
- [x] API is backwards compatible or completely new

## Documentation
- [ ] Update changelog if necessary (TBD)

## Testing
- [x] Complex logic is unit tested

## Follow-up
- [ ] New tasks are created for pending or remaining tasks (TBD)
