### PR TITLE
Browser test consistency

### DIFF
--- a/test/clj/rems/browser_test_util.clj
+++ b/test/clj/rems/browser_test_util.clj
@@ -611,6 +611,14 @@
        (mapv value-of-el)
        first))
 
+(def ^:private check-axe-js
+  "var args = arguments;
+   var callback = args[args.length-1]; // async callback
+   window.axe.configure({ 'reporter': 'v2' });
+   window.axe.run({ exclude: [['.dev-reload-button'],
+                              ['body > div:not(#app)']]
+   }).then(callback);")
+
 (defn check-axe
   "Runs automated accessibility tests using axe.
 
@@ -622,15 +630,8 @@
 
   See https://www.deque.com/axe/"
   []
-  (let [result (js-async "
-    var args = arguments;
-    var callback = args[args.length-1];
-    window.axe.configure({'reporter': 'v2'});
-    window.axe.run({ exclude:[['.dev-reload-button'],
-                              ['body > div:not(#app)']]})
-
-    .then(callback);")]
-    result))
+  (when (:accessibility-report env)
+    (js-async check-axe-js)))
 
 (defn gather-axe-results
   "Runs automatic accessbility tests using `check-axe`

--- a/test/clj/rems/test_browser.clj
+++ b/test/clj/rems/test_browser.clj
@@ -36,7 +36,10 @@
 (comment ; convenience for development testing
   (btu/init-driver! :chrome "http://localhost:3000/" :development))
 
-(use-fixtures :each btu/fixture-refresh-driver)
+(use-fixtures
+  :each
+  btu/reset-context-fixture
+  btu/refresh-driver-fixture)
 
 (use-fixtures
   :once
@@ -44,7 +47,7 @@
   btu/test-dev-or-standalone-fixture
   btu/smoke-test
   btu/accessibility-report-fixture
-  btu/fixture-init-driver)
+  btu/init-driver-fixture)
 
 ;;; common functionality
 
@@ -3501,7 +3504,7 @@
 
       (btu/screenshot "after-closing")
 
-      (is (nil? (some #{{"name bg-depth-2" (btu/context-get :catalogue-item-name) "commands bg-depth-2" "More info\nOpens in a new window\nRemove from cart"}}
+      (is (nil? (some #{{"name bg-depth-2" (btu/context-getx :catalogue-item-name) "commands bg-depth-2" "More info\nOpens in a new window\nRemove from cart"}}
                       (slurp-rows :catalogue-tree)))
           "can't see item anymore because it's hidden again"))))
 


### PR DESCRIPTION
Minor improvements to etaoin browser tests:
- **Changed internal API of `btu/context-*` (functions that get/manipulate context data during tests)**. Test data is now saved under `:test-data` key in context, and the public functions implicitly use this path. There haven't been any collisions between test data and configuration, but tests should ideally start with clean context.
- Added fixture to reset context test data between tests
- Use `delete-session` and `create-session` from etaoin for refreshing driver, this should provide a more stable starting point than just removing cookies

Other changes:
- Put`check-axe` behind feature flag, so it can be disabled from config when manually testing (it can generate an awful lot of logs when inspecting driver state carelessly)
