### PR TITLE
DB caches, part 1

### DIFF
--- a/src/clj/rems/cache.clj
+++ b/src/clj/rems/cache.clj
@@ -1,0 +1,158 @@
+(ns rems.cache
+  (:refer-clojure :exclude [reset!])
+  (:require [clojure.core.cache :as c]
+            [clojure.core.cache.wrapped :as w]
+            [clojure.tools.logging.readable :as logr]
+            [medley.core :refer [assoc-some]]
+            [rems.util :refer [assert-ex]]))
+
+(defprotocol RefreshableCacheProtocol
+  "Protocol for cache wrapper that can refresh the underlying cache."
+
+  (ensure-initialized! [this]
+    "Reloads the cache if it is not ready.")
+  (reset! [this]
+    "Resets cache to uninitialized state. Next call to ensure-initialized will reload the cache.")
+  (has? [this k]
+    "Checks if cache contains `k`.")
+  (entries! [this]
+    "Retrieves the current cache snapshot.")
+  (lookup! [this k] [this k not-found]
+    "Retrieves `k` from cache if it exists, or `not-found` if specified.")
+  (lookup-or-miss! [this k] [this k value-fn]
+    "Retrieves `k` from cache if it exists, else updates the cache for `k` to `(miss-fn k)` or `(value-fn k)` and performs the lookup again.")
+  (evict! [this k]
+    "Removes `k` from cache.")
+  (evict-and-miss! [this k] [this k value-fn]
+    "Removes `k` from cache and immediately performs lookup to update the cache for `k` to `(miss-fn k)` or `(value-fn k)`."))
+
+(defrecord RefreshableCache [id
+                             ^clojure.lang.Volatile initialized?
+                             ^clojure.lang.IAtom the-cache
+                             ^clojure.lang.IFn wrap-miss-fn
+                             ^clojure.lang.IFn on-evict
+                             ^clojure.lang.IFn miss-fn
+                             ^clojure.lang.IFn reload-fn
+                             ^clojure.lang.IFn reset-fn]
+  RefreshableCacheProtocol
+
+  (ensure-initialized! [this]
+    (when-not @initialized? ; no need to acquire lock if already initialized
+      (locking id
+        (when-not @initialized?
+          (logr/debug :reload id)
+          (w/seed the-cache (if reload-fn
+                              (reload-fn)
+                              {}))
+          (logr/info :reloaded id {:count (count @the-cache)})
+          (vreset! initialized? true))))
+    the-cache)
+
+  (reset! [this]
+    (locking initialized?
+      (logr/debug :reset id {:reset-fn reset-fn})
+      (w/seed the-cache (if reset-fn
+                          (reset-fn)
+                          {}))
+      (vreset! initialized? false)
+      this))
+
+  (has? [this k] (w/has? (ensure-initialized! this) k))
+
+  (entries! [this] @(ensure-initialized! this))
+
+  (lookup! [this k] (w/lookup (ensure-initialized! this) k))
+  (lookup! [this k not-found] (w/lookup (ensure-initialized! this) k not-found))
+
+  (lookup-or-miss! [this k] (lookup-or-miss! this k miss-fn))
+  (lookup-or-miss! [this k value-fn]
+    (if (has? this k)
+      (w/lookup the-cache k)
+      (locking id
+        (w/lookup-or-miss the-cache k wrap-miss-fn value-fn))))
+
+  (evict! [this k]
+    (locking id
+      (w/evict (ensure-initialized! this) k))
+    (when on-evict
+      (on-evict k))
+    this)
+
+  (evict-and-miss! [this k] (evict-and-miss! this k miss-fn))
+  (evict-and-miss! [this k value-fn]
+    (locking id
+      (evict! this k)
+      (w/lookup-or-miss the-cache k wrap-miss-fn value-fn))))
+
+(defn- wrap-cache-miss-fn [id]
+  (fn [f item]
+    (assert-ex (fn? f) {:id id :error "cannot update cache entry, missing value function"})
+    (logr/debug :miss id {:entry item})
+    (f item)))
+
+(defn- make-cache [cache-factory-fn {:keys [id miss-fn on-evict reload-fn reset-fn]} & [cache-opts]]
+  (let [the-cache (if (seq cache-opts)
+                    (cache-factory-fn {} cache-opts)
+                    (cache-factory-fn {}))
+        initialized? false]
+    (->RefreshableCache id
+                        (volatile! initialized?)
+                        (atom the-cache)
+                        (wrap-cache-miss-fn id)
+                        on-evict
+                        miss-fn
+                        reload-fn
+                        reset-fn)))
+
+
+
+;;; public functions for creating new cache, by type
+
+(defn basic
+  "Wrapper for basic-cache-factory."
+  [opts]
+  (make-cache c/basic-cache-factory opts))
+
+(defn fifo
+  "Wrapper for fifo-cache-factory."
+  [{:keys [threshold] :as opts}]
+  (make-cache c/fifo-cache-factory opts (assoc-some {}
+                                                    :threshold threshold)))
+
+(defn lru
+  "Wrapper for lru-cache-factory."
+  [{:keys [threshold] :as opts}]
+  (make-cache c/lru-cache-factory opts (assoc-some {}
+                                                   :threshold threshold)))
+
+(defn ttl
+  "Wrapper for ttl-cache-factory."
+  [{:keys [ttl] :as opts}]
+  (make-cache c/ttl-cache-factory opts (assoc-some {}
+                                                   :ttl ttl)))
+
+(defn lu
+  "Wrapper for lu-cache-factory."
+  [{:keys [threshold] :as opts}]
+  (make-cache c/lu-cache-factory opts (assoc-some {}
+                                                  :threshold threshold)))
+
+(defn lirs
+  "Wrapper for lirs-cache-factory."
+  [{:keys [s-history-limit q-history-limit] :as opts}]
+  (make-cache c/lirs-cache-factory opts (assoc-some {}
+                                                    :s-history-limit s-history-limit
+                                                    :q-history-limit q-history-limit)))
+
+(defn soft
+  "Wrapper for soft-cache-factory."
+  [opts]
+  (make-cache c/soft-cache-factory opts))
+
+(comment
+  (def basic-cache
+    (basic {:id :test
+            :miss-fn (fn [k] {:k k})
+            :reload-fn (fn []
+                         (println "reloading basic cache")
+                         {"x" {:k true} "y" {:k false}})})))

--- a/src/clj/rems/db/applications.clj
+++ b/src/clj/rems/db/applications.clj
@@ -72,7 +72,6 @@
 (def ^:private license-cache (cache/ttl {:id ::license-cache}))
 (def ^:private user-cache (cache/ttl {:id ::user-cache}))
 (def ^:private users-with-role-cache (cache/ttl {:id ::users-with-role-cache}))
-(def ^:private workflow-cache (cache/ttl {:id ::workflow-cache}))
 (def ^:private blacklist-cache (cache/ttl {:id ::blacklist-cache}))
 
 (defn empty-injections-cache! []
@@ -81,7 +80,6 @@
   (cache/reset! license-cache)
   (cache/reset! user-cache)
   (cache/reset! users-with-role-cache)
-  (cache/reset! workflow-cache)
   (cache/reset! blacklist-cache))
 
 (defn empty-injection-cache!
@@ -92,8 +90,7 @@
   NB: only the necessary invalidations have been implemented"
   [cache-key]
   (cache/reset! (case cache-key
-                  :blacklisted? blacklist-cache
-                  :get-workflow workflow-cache)))
+                  :blacklisted? blacklist-cache)))
 
 (def fetcher-injections
   {:get-attachments-for-application attachments/get-attachments-for-application
@@ -104,7 +101,7 @@
    :get-license #(cache/lookup-or-miss! license-cache % licenses/get-license)
    :get-user #(cache/lookup-or-miss! user-cache % users/get-user)
    :get-users-with-role #(cache/lookup-or-miss! users-with-role-cache % users/get-users-with-role)
-   :get-workflow #(cache/lookup-or-miss! workflow-cache % workflow/get-workflow)
+   :get-workflow rems.db.workflow/get-workflow
    :blacklisted? #(cache/lookup-or-miss! blacklist-cache [%1 %2] (fn [[userid resource]]
                                                                    (blacklist/blacklisted? userid resource)))
    ;; TODO: no caching for these, but they're only used by command handlers currently

--- a/src/clj/rems/main.clj
+++ b/src/clj/rems/main.clj
@@ -21,6 +21,7 @@
             [rems.handler :as handler]
             [rems.json :as json]
             [rems.locales]
+            [rems.service.caches]
             [rems.service.fix-userid]
             [rems.service.test-data :as test-data]
             [rems.validate :as validate])
@@ -86,6 +87,7 @@
 
 (defn- refresh-caches []
   (log/info "Refreshing caches")
+  (rems.service.caches/start-all-caches!)
   (applications/refresh-all-applications-cache!)
   (search/refresh!)
   (log/info "Caches refreshed"))

--- a/src/clj/rems/migrations/example.clj
+++ b/src/clj/rems/migrations/example.clj
@@ -10,4 +10,4 @@
 (defn migrate-up [config]
   (binding [*db* (:conn config)]
     (assert (= [{:test 1}] (jdbc/query *db* ["select 1 as test"])))
-    (assert (workflow/get-workflows {}))))
+    (assert (workflow/get-workflows))))

--- a/src/clj/rems/service/caches.clj
+++ b/src/clj/rems/service/caches.clj
@@ -1,0 +1,20 @@
+(ns rems.service.caches
+  (:require [rems.cache :as cache]
+            [rems.db.workflow]))
+
+(def db-caches
+  "Caches that use existing database."
+  #{#'rems.db.workflow/workflow-cache})
+
+(defn start-caches! [& caches]
+  (->> caches
+       (mapcat identity)
+       (run! #(cache/ensure-initialized! (cond-> % (var? %) var-get)))))
+
+(defn reset-caches! [& caches]
+  (->> caches
+       (mapcat identity)
+       (run! #(cache/reset! (cond-> % (var? %) var-get)))))
+
+(defn start-all-caches! [] (start-caches! db-caches))
+(defn reset-all-caches! [] (reset-caches! db-caches))

--- a/src/clj/rems/service/dependencies.clj
+++ b/src/clj/rems/service/dependencies.clj
@@ -47,7 +47,7 @@
          :when (some? (val (first dep)))] ; remove nil dependencies, e.g. optional formid
      {:from {:catalogue-item/id (:id cat)} :to dep})
 
-   (for [workflow (workflow/get-workflows {})
+   (for [workflow (workflow/get-workflows)
          dep (concat
               (->> (get-in workflow [:workflow :licenses])
                    (mapv #(select-keys % [:license/id])))

--- a/src/clj/rems/service/fix_userid.clj
+++ b/src/clj/rems/service/fix_userid.clj
@@ -254,7 +254,7 @@
 
 (defn fix-workflow [old-userid new-userid simulate?]
   (doall
-   (for [old (rems.db.workflow/get-workflows nil)
+   (for [old (rems.db.workflow/get-workflows)
          :let [old {:id (:id old)
                     :organization (:organization old)
                     :title (:title old)

--- a/src/clj/rems/service/invitation.clj
+++ b/src/clj/rems/service/invitation.clj
@@ -79,7 +79,7 @@
               (not (:invitation/accepted invitation))
               (do
                 (workflow/edit-workflow! {:id workflow-id
-                                          :handlers (conj handlers userid)})
+                                          :handlers (vec (conj handlers userid))})
                 (invitation/accept-invitation! userid token)
                 (applications/reload-cache!)
                 {:success true

--- a/src/clj/rems/service/organizations.clj
+++ b/src/clj/rems/service/organizations.clj
@@ -78,7 +78,7 @@
 (defn get-available-owners [] (users/get-users))
 
 (defn get-handled-organizations [{:keys [userid]}]
-  (for [workflow (workflow/get-workflows nil)
+  (for [workflow (workflow/get-workflows)
         :let [handlers (set (mapv :userid (get-in workflow [:workflow :handlers])))]
         :when (contains? handlers userid)
         :let [organization (organizations/getx-organization-by-id (get-in workflow [:organization :organization/id]))]]

--- a/test/clj/rems/api/test_api.clj
+++ b/test/clj/rems/api/test_api.clj
@@ -7,7 +7,7 @@
             [rems.handler :refer [handler]]
             [ring.mock.request :refer :all]))
 
-(use-fixtures :once api-fixture)
+(use-fixtures :each api-fixture)
 
 (deftest test-api-not-found
   (testing "unknown endpoint"

--- a/test/clj/rems/api/test_blacklist.clj
+++ b/test/clj/rems/api/test_blacklist.clj
@@ -9,7 +9,7 @@
   (:import [org.joda.time DateTimeUtils]))
 
 (use-fixtures
-  :once
+  :each
   api-fixture
   (fn [f]
     ;; TODO this needs to be in the future so that we can use the

--- a/test/clj/rems/api/test_extra_pages.clj
+++ b/test/clj/rems/api/test_extra_pages.clj
@@ -5,7 +5,7 @@
             [rems.handler :refer [handler]]
             [ring.mock.request :refer :all]))
 
-(use-fixtures :once api-fixture)
+(use-fixtures :each api-fixture)
 
 (deftest extra-pages-api-test
   (test-data/create-test-api-key!)

--- a/test/clj/rems/api/test_permissions.clj
+++ b/test/clj/rems/api/test_permissions.clj
@@ -13,7 +13,7 @@
             [schema.core :as s]))
 
 (use-fixtures
-  :once
+  :each
   api-fixture)
 
 (deftest jwk-api

--- a/test/clj/rems/api/test_public.clj
+++ b/test/clj/rems/api/test_public.clj
@@ -5,7 +5,7 @@
             [ring.mock.request :refer :all]))
 
 (use-fixtures
-  :once
+  :each
   api-fixture)
 
 (deftest service-translations-test

--- a/test/clj/rems/api/test_user_settings.clj
+++ b/test/clj/rems/api/test_user_settings.clj
@@ -8,7 +8,7 @@
   (:import [java.util UUID]))
 
 (use-fixtures
-  :once
+  :each
   api-fixture)
 
 (deftest user-settings-api-test

--- a/test/clj/rems/api/testing.clj
+++ b/test/clj/rems/api/testing.clj
@@ -7,7 +7,7 @@
             [mount.core :as mount]
             [muuntaja.core :as muuntaja]
             [peridot.multipart]
-            [rems.db.testing :refer [reset-db-fixture rollback-db-fixture test-db-fixture reset-caches-fixture search-index-fixture]]
+            [rems.db.testing :refer [reset-db-fixture rollback-db-fixture test-db-fixture search-index-fixture]]
             [rems.handler :refer :all]
             [rems.locales]
             [rems.middleware]
@@ -38,8 +38,7 @@
   (join-fixtures [test-db-fixture
                   rollback-db-fixture
                   handler-fixture
-                  search-index-fixture
-                  reset-caches-fixture]))
+                  search-index-fixture]))
 
 (defn authenticate [request api-key user-id]
   (cond-> request

--- a/test/clj/rems/application/test_rejecter_bot.clj
+++ b/test/clj/rems/application/test_rejecter_bot.clj
@@ -5,10 +5,10 @@
             [rems.application.rejecter-bot :as rejecter-bot]
             [rems.db.applications :as applications]
             [rems.db.test-data-helpers :as test-helpers]
-            [rems.db.testing :refer [test-db-fixture reset-caches-fixture rollback-db-fixture]]))
+            [rems.db.testing :refer [test-db-fixture rollback-db-fixture]]))
 
 (use-fixtures :once test-db-fixture)
-(use-fixtures :each rollback-db-fixture reset-caches-fixture)
+(use-fixtures :each rollback-db-fixture)
 
 ;; These tests are integration tests via rems.service.command
 ;; since we'd need to mock get-application to unit-test

--- a/test/clj/rems/application/test_search.clj
+++ b/test/clj/rems/application/test_search.clj
@@ -9,8 +9,9 @@
 (use-fixtures
   :once
   test-db-fixture
-  rollback-db-fixture
   search-index-fixture)
+
+(use-fixtures :each rollback-db-fixture)
 
 (deftest test-application-search
   ;; generate users with full names and emails

--- a/test/clj/rems/auth/test_oidc.clj
+++ b/test/clj/rems/auth/test_oidc.clj
@@ -52,7 +52,7 @@
       (with-fake-login-users {} (f)))))
 
 (use-fixtures
-  :once
+  :each
   api-fixture)
 
 (deftest test-user-does-not-exist

--- a/test/clj/rems/db/test_applications.clj
+++ b/test/clj/rems/db/test_applications.clj
@@ -2,7 +2,6 @@
   (:require [clojure.string :as str]
             [clojure.test :refer :all]
             [clojure.test.check.generators :as generators]
-            [mount.core :as mount]
             [rems.application.events :as events]
             [rems.db.applications :as applications]
             [rems.db.core :as db]
@@ -16,13 +15,7 @@
            [org.joda.time DateTime DateTimeZone]))
 
 (use-fixtures :once test-db-fixture)
-
-(use-fixtures :each
-  rollback-db-fixture
-  (fn [f]
-    (mount/stop #'applications/all-applications-cache)
-    (mount/start #'applications/all-applications-cache)
-    (f)))
+(use-fixtures :each rollback-db-fixture)
 
 (deftest test-event-serialization
   (testing "round trip serialization"

--- a/test/clj/rems/db/test_blacklist.clj
+++ b/test/clj/rems/db/test_blacklist.clj
@@ -5,10 +5,8 @@
             [rems.db.test-data-helpers :as test-helpers]
             [rems.db.testing :refer [test-db-fixture rollback-db-fixture]]))
 
-(use-fixtures
-  :each
-  test-db-fixture
-  rollback-db-fixture)
+(use-fixtures :once test-db-fixture)
+(use-fixtures :each rollback-db-fixture)
 
 (deftest test-blacklist-event-storage
   (test-helpers/create-user! {:userid "user1"})

--- a/test/clj/rems/db/test_entitlements.clj
+++ b/test/clj/rems/db/test_entitlements.clj
@@ -6,7 +6,7 @@
             [rems.db.core :as db]
             [rems.db.entitlements :as entitlements]
             [rems.db.test-data-helpers :as test-helpers]
-            [rems.db.testing :refer [reset-caches-fixture test-db-fixture rollback-db-fixture]]
+            [rems.db.testing :refer [test-db-fixture rollback-db-fixture]]
             [rems.json :as json]
             [rems.testing-util :refer [fixed-time-fixture suppress-logging-fixture]]
             [stub-http.core :as stub]))
@@ -18,9 +18,9 @@
   :once
   (fixed-time-fixture +test-time+)
   (suppress-logging-fixture "rems.db.entitlements")
-  test-db-fixture
-  rollback-db-fixture
-  reset-caches-fixture)
+  test-db-fixture)
+
+(use-fixtures :each rollback-db-fixture)
 
 (def +entitlements+
   [{:resid "res1" :catappid 11 :userid "user1" :start (time/date-time 2001 10 11) :mail "user1@tes.t" :end (time/date-time 2003 10 11)}

--- a/test/clj/rems/db/test_outbox.clj
+++ b/test/clj/rems/db/test_outbox.clj
@@ -5,10 +5,8 @@
             [rems.db.outbox :as outbox])
   (:import [org.joda.time DateTime Duration DateTimeUtils]))
 
-(use-fixtures
-  :once
-  test-db-fixture
-  rollback-db-fixture)
+(use-fixtures :once test-db-fixture)
+(use-fixtures :each rollback-db-fixture)
 
 (deftest test-outbox
   (let [deadline (-> (time/now) (.plusMinutes 1))

--- a/test/clj/rems/db/test_transactions.clj
+++ b/test/clj/rems/db/test_transactions.clj
@@ -6,7 +6,7 @@
             [rems.db.core :as db]
             [rems.db.events :as events]
             [rems.db.test-data-helpers :as test-helpers]
-            [rems.db.testing :refer [reset-caches-fixture test-db-fixture reset-db-fixture]]
+            [rems.db.testing :refer [test-db-fixture reset-db-fixture]]
             [rems.db.users :as users])
   (:import [java.sql SQLException]
            [java.util.concurrent Executors Future TimeUnit ExecutorService]
@@ -15,8 +15,7 @@
 (use-fixtures
   :once
   test-db-fixture
-  reset-db-fixture
-  reset-caches-fixture)
+  reset-db-fixture)
 
 (defn- create-dummy-user []
   (let [user-id "user"]

--- a/test/clj/rems/db/test_workflow.clj
+++ b/test/clj/rems/db/test_workflow.clj
@@ -8,7 +8,7 @@
 (use-fixtures :each rollback-db-fixture)
 
 (deftest test-get-all-workflow-roles
-  (is (= nil (workflow/get-all-workflow-roles "anyone")))
+  (is (= #{} (workflow/get-all-workflow-roles "anyone")))
 
   (testing "handler role"
     (test-helpers/create-user! {:userid "handler-user"})

--- a/test/clj/rems/db/testing.clj
+++ b/test/clj/rems/db/testing.clj
@@ -6,20 +6,32 @@
             [mount.core :as mount]
             [rems.application.search]
             [rems.config :refer [env]]
-            [rems.db.applications :as applications]
-            [rems.db.catalogue :as catalogue]
-            [rems.db.category :as category]
+            [rems.db.applications]
+            [rems.db.catalogue]
+            [rems.db.category]
             [rems.db.core :as db]
-            [rems.db.events :as events]
-            [rems.db.user-mappings :as user-mappings]
+            [rems.db.events]
+            [rems.db.user-mappings]
             [rems.db.user-settings]
             [rems.locales]
-            [rems.service.dependencies :as dependencies]
+            [rems.service.caches]
+            [rems.service.dependencies]
             [rems.service.test-data :as test-data]))
+
+(defn- reset-caches! []
+  (rems.service.caches/reset-all-caches!)
+  (rems.db.applications/reset-cache!)
+  (rems.db.applications/empty-injections-cache!)
+  (rems.db.catalogue/reset-cache!)
+  (rems.db.category/reset-cache!)
+  (rems.service.dependencies/reset-cache!)
+  (rems.db.user-mappings/reset-cache!)
+  (rems.db.events/empty-event-cache!))
 
 (defn reset-db-fixture [f]
   (try
     (f)
+    (reset-caches!)
     (finally
       (migrations/migrate ["reset"] {:database-url (:test-database-url env)}))))
 
@@ -30,35 +42,20 @@
                          #'rems.locales/translations
                          #'rems.db.core/*db*)
   (db/assert-test-database!)
-
-  ;; these are db level caches and tests use db rollback
-  ;; it's best for us to start from scratch here
-  (applications/empty-injections-cache!)
-
   (migrations/migrate ["migrate"] {:database-url (:test-database-url env)})
   ;; need DB to start these
   (mount/start #'rems.db.events/low-level-events-cache
-               #'rems.db.user-settings/low-level-user-settings-cache)
-  (f)
-  (mount/stop))
+               #'rems.db.user-settings/low-level-user-settings-cache
+               #'rems.db.applications/all-applications-cache)
+  (reset-caches!)
+  (f))
 
 (defn search-index-fixture [f]
   ;; no specific teardown. relies on the teardown of test-db-fixture.
   (mount/start #'rems.application.search/search-index)
   (f))
 
-(defn reset-caches-fixture [f]
-  (try
-    (mount/start #'applications/all-applications-cache)
-    (f)
-    (finally
-      (applications/reset-cache!)
-      (catalogue/reset-cache!)
-      (category/reset-cache!)
-      (dependencies/reset-cache!)
-      (user-mappings/reset-cache!)
-      (events/empty-event-cache!))))
-(def +test-api-key+ test-data/+test-api-key+) ;; re-exported for convenience
+(def +test-api-key+ test-data/+test-api-key+) ; re-exported for convenience
 
 (defn owners-fixture [f]
   (test-data/create-owners!)
@@ -67,5 +64,5 @@
 (defn rollback-db-fixture [f]
   (conman/with-transaction [db/*db* {:isolation :serializable}]
     (jdbc/db-set-rollback-only! db/*db*)
-    (events/empty-event-cache!) ; NB can't rollback this cache so reset
-    (f)))
+    (f)
+    (reset-caches!)))

--- a/test/clj/rems/service/test_catalogue.clj
+++ b/test/clj/rems/service/test_catalogue.clj
@@ -8,18 +8,12 @@
             [rems.db.core :as db]
             [rems.db.category :as category]
             [rems.db.test-data-helpers :as test-helpers]
-            [rems.db.testing :refer [reset-caches-fixture rollback-db-fixture test-db-fixture]]
+            [rems.db.testing :refer [rollback-db-fixture test-db-fixture]]
             [rems.testing-util :refer [with-user]])
   (:import org.joda.time.DateTime))
 
-(use-fixtures
-  :once
-  test-db-fixture)
-
-(use-fixtures
-  :each
-  reset-caches-fixture
-  rollback-db-fixture)
+(use-fixtures :once test-db-fixture)
+(use-fixtures :each rollback-db-fixture)
 
 (defn- status-flags [item-id]
   (-> (catalogue/get-localized-catalogue-item item-id)

--- a/test/clj/rems/service/test_dependencies.clj
+++ b/test/clj/rems/service/test_dependencies.clj
@@ -3,13 +3,10 @@
             [rems.service.dependencies :as dependencies]
             [rems.db.core :as db]
             [rems.db.test-data-helpers :as test-helpers]
-            [rems.db.testing :refer [reset-caches-fixture test-db-fixture rollback-db-fixture]]))
+            [rems.db.testing :refer [test-db-fixture rollback-db-fixture]]))
 
 (use-fixtures :once test-db-fixture)
-(use-fixtures
-  :each
-  rollback-db-fixture
-  reset-caches-fixture)
+(use-fixtures :each rollback-db-fixture)
 
 (deftest test-dependencies
   (let [shared-license (test-helpers/create-license! {})

--- a/test/clj/rems/service/test_invitation.clj
+++ b/test/clj/rems/service/test_invitation.clj
@@ -2,7 +2,7 @@
   (:require [clojure.test :refer :all]
             [rems.service.invitation :as invitation]
             [rems.db.test-data-helpers :as test-helpers]
-            [rems.db.testing :refer [reset-caches-fixture rollback-db-fixture test-db-fixture]]
+            [rems.db.testing :refer [rollback-db-fixture test-db-fixture]]
             [rems.email.core :as email]
             [rems.testing-util :refer [fixed-time-fixture with-user]])
   (:import [org.joda.time DateTime DateTimeUtils DateTimeZone]))
@@ -13,7 +13,6 @@
 (use-fixtures
   :once
   test-db-fixture
-  reset-caches-fixture
   (fixed-time-fixture invitation-time))
 
 (use-fixtures :each rollback-db-fixture)

--- a/test/clj/rems/service/test_workflow.clj
+++ b/test/clj/rems/service/test_workflow.clj
@@ -2,15 +2,11 @@
   (:require [clojure.test :refer :all]
             [rems.db.applications :as applications]
             [rems.db.test-data-helpers :as test-helpers]
-            [rems.db.testing :refer [reset-caches-fixture rollback-db-fixture test-db-fixture]]
+            [rems.db.testing :refer [rollback-db-fixture test-db-fixture]]
             [rems.service.workflow :as workflow]
             [rems.testing-util :refer [with-user]]))
 
-(use-fixtures
-  :once
-  test-db-fixture
-  reset-caches-fixture)
-
+(use-fixtures :once test-db-fixture)
 (use-fixtures :each rollback-db-fixture)
 
 (defn- create-users []

--- a/test/clj/rems/test_handler.clj
+++ b/test/clj/rems/test_handler.clj
@@ -7,7 +7,7 @@
             [rems.handler :refer :all]
             [ring.mock.request :refer :all]))
 
-(use-fixtures :once api-fixture)
+(use-fixtures :each api-fixture)
 
 (deftest test-caching
   (with-redefs [git/+version+ {:version "0.0.0" :revision "abcd1234"}]

--- a/test/clj/rems/test_redirects.clj
+++ b/test/clj/rems/test_redirects.clj
@@ -10,7 +10,7 @@
             [ring.mock.request :refer :all]))
 
 (use-fixtures
-  :once
+  :each
   api-fixture
   (fn [f]
     ;; need to set an explicit public-url since dev and test configs use different ports


### PR DESCRIPTION
#2783 

Most cache needs are very basic, but having a standard way of accessing the cache is probably beneficial, for example making sure that db entity cache is ready for use without explicit instructions in every db namespace.

Double-locking in ensure-initialized! is workaround to potential cache stampede issue in current clojure.core.cache.wrapped implementation. This may be fixed in a future release, in which case the double-locking can be removed.

- workflow db cache

# Checklist for author

Remove items that aren't applicable, check items that are done.

## Reviewability
- [ ] Link to issue
- [ ] Note if PR is on top of other PR
- [ ] Note if related change in rems-deploy repo
- [ ] Consider adding screenshots for ease of review

## Backwards compatibility
- [ ] API is backwards compatible or completely new
- [ ] Events are backwards compatible _or_ have migrations
- [ ] Config is backwards compatible
- [ ] Feature appears correctly in PDF print

## Documentation
- [ ] Update changelog if necessary
- [ ] API is documented and shows up in Swagger UI
- [ ] Components are added to guide page
- [ ] Update docs/ (if applicable)
- [ ] Update manual/ (if applicable)
- [ ] ADR for major architectural decisions or experiments
- [ ] New config options in config-defaults.edn

## Testing
- [ ] Complex logic is unit tested
- [ ] Valuable features are integration / browser / acceptance tested automatically

## Follow-up
- [ ] New tasks are created for pending or remaining tasks
