### PR TITLE
Collapsible leftovers

### DIFF
--- a/resources/translations/da.edn
+++ b/resources/translations/da.edn
@@ -16,7 +16,6 @@
             :assign-external-id "Tildel ekstern id"
             :assign-external-id-info "Ekstern id"
             :bundling-intro [:div.intro [:p "NB: Kun ressourcer med samme ansøgningsarbejdsgang kan lægges sammen."]]
-            :cancel "Afbryd"
             :change-applicant "Gør til ansøger"
             :change-resources "Rediger ressourcer"
             :change-processing-state nil

--- a/resources/translations/en.edn
+++ b/resources/translations/en.edn
@@ -16,7 +16,6 @@
             :assign-external-id "Assign external id"
             :assign-external-id-info "External id"
             :bundling-intro [:div.intro [:p "Note that only resources that have the same application workflow can be bundled together."]]
-            :cancel "Cancel"
             :change-applicant "Make applicant"
             :change-resources "Change resources"
             :change-processing-state "Change state"

--- a/resources/translations/fi.edn
+++ b/resources/translations/fi.edn
@@ -16,7 +16,6 @@
             :assign-external-id "Aseta tunniste"
             :assign-external-id-info "Tunniste"
             :bundling-intro [:div.intro [:p "Huomaa, että vain resursseja, joilla on sama työvuo, voidaan liittää yhteen."]]
-            :cancel "Peruuta"
             :change-applicant "Tee hakija"
             :change-resources "Muuta resursseja"
             :change-processing-state "Muuta alitilaa"

--- a/resources/translations/sv.edn
+++ b/resources/translations/sv.edn
@@ -16,7 +16,6 @@
             :assign-external-id "Ange externt id" ; ELLER Ange id för den resurs ansökan (vai arbetsflödet gäller?
             :assign-external-id-info "Externt id"
             :bundling-intro [:div.intro [:p "Notera att endast resurser med gemensam ansökningsblankett och gemensamt arbetsflöde kan kopplas samman."]]
-            :cancel "Avbryt"
             :change-applicant "Gör till sökanden" ; TODO check
             :change-resources "Ändra resurser"
             :change-processing-state "Ändra delstat" ; TODO: check

--- a/src/clj/rems/css/styles.clj
+++ b/src/clj/rems/css/styles.clj
@@ -324,14 +324,11 @@
 
 (defn collapsible-styles []
   (list
-   ;;; main collapsible styles
    [:.collapsible.bordered-collapsible {:border-radius (u/rem 0.4)
                                         :border "1px solid #ccc"
                                         :background-color (theme-getx :collapse-bgcolor)
                                         :box-shadow (theme-getx :collapse-shadow :table-shadow)}]
-   [:.collapsible.info-collapsible {:white-space :pre-wrap}]
 
-   ;;; collapsible header, bootstrap customization
    [(s/> :.collapsible :.card-header) {:border-bottom "none"
                                        :border-radius (u/rem 0.4)
                                        :font-weight 400
@@ -340,25 +337,17 @@
                                        :font-family (theme-getx :font-family)
                                        :color (theme-getx :table-heading-color :collapse-color)
                                        :background-color (theme-getx :table-heading-bgcolor :color3)
-                                       ;; make sure header overlaps container border
+                                       ;; "stretches" header just so that collapsible background does not leak from borders
                                        :margin (u/px -1)}]
    [(s/descendant :.card-header :a) {:color :inherit}]
-
-   ;;; collapsible contents, aka everything after header
    [".collapsible-contents:not(:empty)" {:margin (u/rem 1)}]
    [(s/> :.collapsible.info-collapsible ".collapsible-contents:not(:empty)") {:margin [[0 (u/rem 1) (u/rem 0.5) 0]]}]
-   [(s/> :.collapsible.expander-collapsible :a.expander-toggle.btn-link) {:text-decoration :none
-                                                                          :white-space :normal
-                                                                          :color (link-color)}]
-   ;;; customizations
    [:.page-create-form
     ;; form editor fields have inner collapsibles with fields that don't align nicely when margin is double applied
     [(s/descendant :#create-form :.collapsible-contents :.collapsible-contents) {:margin 0}]
     ;; improves form editor preview readability on smaller screens
     [(s/> :#preview-form.collapsible :.collapsible-contents) {:margin-left 0}]]
 
-   [(s/descendant :.page-application :.license-panel :.expander-toggle) {:padding-left 0
-                                                                         :padding-top 0}]))
 
 (defn build-screen []
   (list

--- a/src/clj/rems/css/styles.clj
+++ b/src/clj/rems/css/styles.clj
@@ -740,13 +740,13 @@
 
    [:#preview-form {:position :sticky ;; TODO seems to work on Chrome and Firefox. check Edge?
                     :top "100px"}
-    [:#preview-form-contents {:overflow-y :scroll
+    [:#preview-form-contents {:overflow-y :auto
                               :overflow-x :hidden
+                              :padding "0 0.5rem"
                               ;; subtract #preview-form top value plus a margin here to stay inside the viewbox
                               :max-height "calc(100vh - 220px)"}]]
 
-   [:.field-preview {:position :relative
-                     :margin-left (u/rem 1)}]
+   [:.field-preview {:position :relative}]
    [:.full {:width "100%"}]
    [:.intro {:margin-bottom (u/rem 2)}]
    [:.rectangle {:width (u/px 50)

--- a/src/clj/rems/css/styles.clj
+++ b/src/clj/rems/css/styles.clj
@@ -342,12 +342,10 @@
    [(s/descendant :.card-header :a) {:color :inherit}]
    [".collapsible-contents:not(:empty)" {:margin (u/rem 1)}]
    [(s/> :.collapsible.info-collapsible ".collapsible-contents:not(:empty)") {:margin [[0 (u/rem 1) (u/rem 0.5) 0]]}]
-   [:.page-create-form
-    ;; form editor fields have inner collapsibles with fields that don't align nicely when margin is double applied
-    [(s/descendant :#create-form :.collapsible-contents :.collapsible-contents) {:margin 0}]
-    ;; improves form editor preview readability on smaller screens
-    [(s/> :#preview-form.collapsible :.collapsible-contents) {:margin-left 0}]]
 
+   ;; form editor fields have inner collapsibles with fields that don't align nicely when margin is double applied
+   [(s/descendant :#create-form :.collapsible-contents :.collapsible-contents) {:margin 0}]
+   [:.btn.expander-toggle {:padding 0}]))
 
 (defn build-screen []
   (list
@@ -890,13 +888,13 @@
    [:.select-attachments {:display :flex
                           :flex-direction :column
                           :align-items :flex-start
-                          :gap (u/rem 0.5)}
-    [:.select-attachments-row {:display :grid
-                               :grid "auto-flow / [checkbox] auto [content] minmax(0, 1fr)"
-                               :column-gap (u/rem 0.5)
-                               :align-items :center}
-     [(s/> ":first-child") {:grid-column :checkbox}]
-     [(s/> ":not(:first-child)") {:grid-column :content}]]]
+                          :gap (u/rem 0.5)}]
+   [:.select-attachments-row {:display :grid
+                              :grid "auto-flow / [checkbox] auto [content] minmax(0, 1fr)"
+                              :column-gap (u/rem 0.5)
+                              :align-items :center}]
+   [(s/> :.select-attachments-row ":first-child") {:grid-column :checkbox}]
+   [(s/> :.select-attachments-row ":not(:first-child)") {:grid-column :content}]
 
    [:.color-pre {:color "#212529"}] ; same color as bootstrap's default for [:pre]
 

--- a/src/cljs/rems/actions/components.cljs
+++ b/src/cljs/rems/actions/components.cljs
@@ -8,7 +8,7 @@
             [rems.fields :as fields]
             [rems.flash-message :as flash-message]
             [rems.text :refer [text text-format]]
-            [rems.util :refer [event-value post!]]))
+            [rems.util :refer [class-names event-value post!]]))
 
 (defn- action-collapse-id [action-id]
   (str "actions-" action-id))
@@ -17,16 +17,14 @@
   (str action-id "-action-button"))
 
 (defn collapse-action-form [id]
-  (.collapse (js/$ (str "#" (action-collapse-id id))) "hide"))
+  (rf/dispatch [:rems.collapsible/set-expanded (action-collapse-id id) false]))
 
 (defn cancel-action-button [id]
-  [:button.btn.btn-secondary
-   {:type :button
-    :id (str "cancel-" id)
-    :data-toggle "collapse"
-    :data-target (str "#" (action-collapse-id id))
-    :on-click #(.focus (.querySelector js/document (str "#" (action-button-id id))))}
-   (text :t.actions/cancel)])
+  [atoms/action-button
+   (-> (collapsible/hide-action {:collapsible-id (action-collapse-id id)
+                                 :id (str "cancel-" id)
+                                 :on-close #(.focus (.querySelector js/document (str "#" (action-button-id id))))})
+       atoms/cancel-action)])
 
 (rf/reg-sub
  ::selected-attachments
@@ -199,24 +197,21 @@
                                    content
                                    (into [:div.col.commands [cancel-action-button id]] buttons)]}])
 
-(defn action-button [{:keys [id text class on-click]}]
-  [:button.btn
-   {:id (action-button-id id)
-    :class (str (or class "btn-secondary")
-                " btn-opens-more")
-    :data-toggle "collapse"
-    :data-target (str "#" (action-collapse-id id))
-    :on-click on-click}
-   text])
+(defn action-button [{:keys [class id on-click] :as action}]
+  [atoms/action-button
+   (collapsible/toggle-action (assoc action
+                                     :class (class-names "btn-opens-more" class)
+                                     :collapsible-id (action-collapse-id id)
+                                     :id (str id "-action-button")
+                                     :on-open on-click))])
 
-(defn action-link [{:keys [id text on-click]}]
-  [:a.dropdown-item.btn.btn-link
-   {:id (action-button-id id)
-    :href "#"
-    :data-toggle "collapse"
-    :data-target (str "#" (action-collapse-id id))
-    :on-click on-click}
-   text])
+(defn action-link [{:keys [class id on-click] :as action}]
+  [atoms/action-link
+   (collapsible/toggle-action (assoc action
+                                     :class (class-names "dropdown-item" class)
+                                     :collapsible-id (action-collapse-id id)
+                                     :id (str id "-action-button")
+                                     :on-open on-click))])
 
 (defn command! [command params {:keys [description collapse on-finished]}]
   (assert (qualified-keyword? command)

--- a/src/cljs/rems/actions/components.cljs
+++ b/src/cljs/rems/actions/components.cljs
@@ -2,6 +2,7 @@
   (:require [re-frame.core :as rf]
             [rems.atoms :as atoms :refer [attachment-link checkbox enrich-user textarea]]
             [rems.common.attachment-util :as attachment-util]
+            [rems.collapsible :as collapsible]
             [rems.dropdown :as dropdown]
             [rems.fetcher :as fetcher]
             [rems.fields :as fields]
@@ -191,15 +192,12 @@
   `buttons` - the actions that can be executed
   `:collapse-id` - optionally the collapse group the action is part of"
   [id title buttons content & [{:keys [collapse-id]}]]
-  [:div.collapse {:id (action-collapse-id id)
-                  :data-parent (if collapse-id (str "#" collapse-id) "#actions-forms")
-                  :tab-index "-1"
-                  :ref (fn [elem]
-                         (when elem
-                           (.on (js/$ elem) "shown.bs.collapse" #(.focus elem))))}
-   [:h3.mt-3 title]
-   content
-   (into [:div.col.commands [cancel-action-button id]] buttons)])
+  [collapsible/minimal {:id (action-collapse-id id)
+                        :group (or collapse-id "action-form")
+                        :collapse [:<>
+                                   [:h3.mt-3 title]
+                                   content
+                                   (into [:div.col.commands [cancel-action-button id]] buttons)]}])
 
 (defn action-button [{:keys [id text class on-click]}]
   [:button.btn

--- a/src/cljs/rems/administration/components.cljs
+++ b/src/cljs/rems/administration/components.cljs
@@ -207,7 +207,7 @@
       [:div.form-group.field.localized-field
        [:label.administration-field-label.d-flex.align-items-center
         label
-        [collapsible/toggle-control collapsible-id]]
+        [collapsible/toggle-control {:collapsible-id collapsible-id}]]
        [collapsible/minimal {:id collapsible-id
                              :collapse fields}]]
       [:div.form-group.localized-field

--- a/src/cljs/rems/administration/create_form.cljs
+++ b/src/cljs/rems/administration/create_form.cljs
@@ -33,7 +33,7 @@
             [rems.focus :as focus]
             [rems.spinner :as spinner]
             [rems.text :refer [localized text text-format]]
-            [rems.util :refer [event-value focus-input-field navigate! on-element-appear on-element-appear-async post! put! trim-when-string visibility-ratio]]))
+            [rems.util :refer [event-value get-bounding-client-rect navigate! on-element-appear on-element-appear-async post! put! trim-when-string visibility-ratio]]))
 
 (rf/reg-event-fx
  ::enter-page
@@ -106,12 +106,10 @@
    (update-in db [::form :data :form/fields] items/remove field-index)))
 
 (defn- track-moved-field-editor [field-id field-index button-selector]
-  (when-some [before (some-> js/document
-                             (.querySelector (field-selector field-id))
-                             (.getBoundingClientRect))]
+  (when-some [before (get-bounding-client-rect (field-selector field-id))]
     (on-element-appear {:selector (field-selector field-id field-index)
                         :on-resolve (fn [element]
-                                      (let [after (.getBoundingClientRect element)]
+                                      (let [after (get-bounding-client-rect element)]
                                         (focus/scroll-offset before after)
                                         (focus/focus-without-scroll (.querySelector element button-selector))))})))
 
@@ -531,7 +529,10 @@
                      :label (text :t.create-form/required-table)}])
 
 (defn- format-validation-link [target content]
-  [:li [:a {:href "#" :on-click (focus-input-field target)}
+  [:li [:a {:href "#"
+            :on-click (fn [event]
+                        (.preventDefault event)
+                        (focus/focus target))}
         content]])
 
 (defn- format-error-for-localized-field [error label lang]

--- a/src/cljs/rems/administration/create_form.cljs
+++ b/src/cljs/rems/administration/create_form.cljs
@@ -567,7 +567,7 @@
                                        (str (text :t.create-form/type-visibility) ": " (text-format (-> field-errors :field/visibility :visibility/values) (text :t.create-form.visibility/has-value))))])
             (if (= :t.form.validation/options-required (:field/options field-errors))
               [[:li
-                [:a {:href "#" :on-click #(focus/focus-selector (str "#fields-" field-index "-add-option"))}
+                [:a {:href "#" :on-click #(focus/focus (str "#fields-" field-index "-add-option"))}
                  (text :t.form.validation/options-required)]]]
               (for [[option-id option-errors] (into (sorted-map) (:field/options field-errors))]
                 [:li (text-format :t.create-form/option-n (inc option-id))
@@ -581,7 +581,7 @@
                                                   (format-error-for-localized-field error :t.create-form/option-label lang))))]]))
             (if (= :t.form.validation/columns-required (:field/columns field-errors))
               [[:li
-                [:a {:href "#" :on-click #(focus/focus-selector (str "#fields-" field-index "-add-column"))}
+                [:a {:href "#" :on-click #(focus/focus (str "#fields-" field-index "-add-column"))}
                  (text :t.form.validation/columns-required)]]]
               (for [[column-id column-errors] (into (sorted-map) (:field/columns field-errors))]
                 [:li (text-format :t.create-form/column-n (inc column-id))

--- a/src/cljs/rems/administration/create_form.cljs
+++ b/src/cljs/rems/administration/create_form.cljs
@@ -644,7 +644,7 @@
     [:div.form-group.field
      [:label.administration-field-label.d-flex.align-items-center
       (text :t.create-form/additional-settings)
-      [collapsible/toggle-control collapsible-id]]
+      [collapsible/toggle-control {:collapsible-id collapsible-id}]]
      [collapsible/minimal
       {:id collapsible-id
        :collapse [:div.solid-group
@@ -664,7 +664,7 @@
     [collapsible/minimal
      {:id collapsible-id
       :always [field-controls idx (:field/title field) field-count]
-      :footer [collapsible/toggle-control collapsible-id]
+      :footer [collapsible/toggle-control {:collapsible-id collapsible-id}]
       :collapse [:<>
                  [form-field-title-field idx]
                  [form-field-type-radio-group idx]

--- a/src/cljs/rems/administration/create_form.cljs
+++ b/src/cljs/rems/administration/create_form.cljs
@@ -530,13 +530,6 @@
                      :negate? true
                      :label (text :t.create-form/required-table)}])
 
-(defn- add-form-field-button [index]
-  [:a.add-form-field {:href "#"
-                      :on-click (fn [event]
-                                  (.preventDefault event)
-                                  (rf/dispatch [::add-form-field index]))}
-   [atoms/add-symbol] " " (text :t.create-form/add-form-field)])
-
 (defn- format-validation-link [target content]
   [:li [:a {:href "#" :on-click (focus-input-field target)}
         content]])
@@ -689,20 +682,25 @@
   (or (not-blank (:field/id field))
       (str "new-field-" idx)))
 
+(defn- add-form-field-button [idx]
+  [:div.new-form-field {:data-field-index idx}
+   [atoms/action-link
+    (atoms/new-action {:class "add-form-field"
+                       :label (text :t.create-form/add-form-field)
+                       :on-click #(rf/dispatch [::add-form-field idx])})]])
+
 (defn- form-fields []
   (let [fields (indexed @(rf/subscribe [::fields]))
         field-count (count fields)]
     (into [:<>
-           [:div.new-form-field {:data-field-index 0}
-            [add-form-field-button 0]]]
+           [add-form-field-button 0]]
           (for [[idx field] fields]
             ^{:key (get-field-key field idx)}
             [:<>
              [:div.form-field {:data-field-id (:field/id field)
                                :data-field-index idx}
               [field-editor idx field field-count]]
-             [:div.new-form-field {:data-field-index (inc idx)}
-              [add-form-field-button (inc idx)]]]))))
+             [add-form-field-button (inc idx)]]))))
 
 (defn- render-preview-hidden []
   [:div {:style {:position :absolute

--- a/src/cljs/rems/administration/create_form.cljs
+++ b/src/cljs/rems/administration/create_form.cljs
@@ -88,7 +88,7 @@
                 (rf/dispatch [:rems.collapsible/set-expanded (field-collapsible-id field-id) true])
                 (on-element-appear-async {:selector "textarea"
                                           :target element})))
-       (.then focus/focus-without-scroll))))
+       (.then focus/scroll-into-view-and-focus))))
 
 (rf/reg-event-fx
  ::add-form-field

--- a/src/cljs/rems/administration/create_workflow.cljs
+++ b/src/cljs/rems/administration/create_workflow.cljs
@@ -2,6 +2,7 @@
   (:require [better-cond.core :as b]
             [medley.core :refer [indexed remove-nth update-existing]]
             [re-frame.core :as rf]
+            [reagent.format :as rfmt]
             [rems.administration.administration :as administration]
             [rems.administration.components :refer [localized-text-field organization-field radio-button-group text-field]]
             [rems.administration.items :as items]
@@ -413,12 +414,14 @@
        :on-change (comp on-change (partial mapv ::value))}]]))
 
 (defn- workflow-disable-commands []
-  (let [id "disable-commands"]
+  (let [id "disable-commands"
+        rules (indexed @(rf/subscribe [::disable-commands]))
+        rule-count (count rules)]
     [:<>
      [:div.form-group {:id id}
       (into [:div.fields.disable-commands]
-            (for [[index value] (indexed @(rf/subscribe [::disable-commands]))]
-              [:div.form-field.field
+            (for [[index value] rules]
+              [:div.form-field.field {:data-field-index index}
                [:div.form-field-header
                 [:h4 (text :t.create-workflow/rule)]
                 [:div.form-field-controls
@@ -442,7 +445,9 @@
                      :on-click (fn [event]
                                  (.preventDefault event)
                                  (rf/dispatch [::new-disable-command])
-                                 (focus/scroll-into-view (str "#" id " .new-rule") {:block :end}))}
+                                 (focus/scroll-into-view-and-focus
+                                  (rfmt/format ".disable-commands .form-field[data-field-index='%s'] :is(textarea, input)"
+                                               rule-count)))}
         (text :t.create-workflow/create-new-rule)]]]]))
 
 (rf/reg-sub ::processing-states (fn [db _] (get-in db [::form :processing-states])))
@@ -454,12 +459,14 @@
       (text :t.administration/processing-state)))
 
 (defn- workflow-processing-states []
-  (let [id "processing-states"]
+  (let [id "processing-states"
+        rules (indexed @(rf/subscribe [::processing-states]))
+        rule-count (count rules)]
     [:<>
      [:div.form-group {:id id}
       (into [:div.fields.processing-states]
-            (for [[index value] (indexed @(rf/subscribe [::processing-states]))]
-              [:div.form-field.field
+            (for [[index value] rules]
+              [:div.form-field.field {:data-field-index index}
                [:div.form-field-header
                 [:h4 (get-processing-state-title value)]
                 [:div.form-field-controls
@@ -474,7 +481,9 @@
                      :on-click (fn [event]
                                  (.preventDefault event)
                                  (rf/dispatch [::new-processing-state])
-                                 (focus/scroll-into-view (str "#" id " .new-rule") {:block :end}))}
+                                 (focus/scroll-into-view-and-focus
+                                  (rfmt/format ".processing-states .form-field[data-field-index='%s'] :is(textarea, input)"
+                                               rule-count)))}
         (text :t.create-workflow/create-new-processing-state)]]]]))
 
 ;;;; page component

--- a/src/cljs/rems/administration/duo.cljs
+++ b/src/cljs/rems/administration/duo.cljs
@@ -1,14 +1,12 @@
 (ns rems.administration.duo
   (:require [goog.functions :refer [debounce]]
             [re-frame.core :as rf]
-            [rems.atoms :as atoms]
             [rems.administration.components :refer [date-field inline-info-field input-field textarea-autosize text-field]]
             [rems.collapsible :as collapsible]
             [rems.common.duo :refer [duo-restriction-label duo-validation-summary]]
             [rems.common.util :refer [escape-element-id]]
             [rems.dropdown :as dropdown]
             [rems.fetcher :as fetcher]
-            [rems.fields :as fields]
             [rems.text :refer [localized text text-format]]
             [rems.util :refer [linkify]]))
 
@@ -91,11 +89,11 @@
                     [:p (localized (:description duo))]
                     [:div.mb-2
                      [:span (localized (:description duo))]
-                     [fields/info-collapsible-toggle {:id (str collapsible-id "-more-infos")
-                                                      :aria-label (localized (:description duo))}]
-                     [fields/info-collapsible {:id (str collapsible-id "-more-infos")
-                                               :collapse (into [:<>] (for [info more-infos]
-                                                                       [duo-more-info info]))}]])
+                     [collapsible/info-toggle-control {:collapsible-id (str collapsible-id "-more-infos")
+                                                       :aria-label (localized (:description duo))}]
+                     [collapsible/minimal {:id (str collapsible-id "-more-infos")
+                                           :collapse (into [:<>] (for [info more-infos]
+                                                                   [duo-more-info info]))}]])
                   (for [restriction (:restrictions duo)
                         :when (seq (:values restriction))]
                     ^{:key (:type restriction)}

--- a/src/cljs/rems/app.cljs
+++ b/src/cljs/rems/app.cljs
@@ -61,7 +61,7 @@
             [rems.text :refer [text text-format]]
             [rems.theme]
             [rems.user-settings]
-            [rems.util :refer [fetch navigate! read-transit replace-url! set-location! react-strict-mode]]
+            [rems.util :refer [fetch navigate! read-transit replace-url! set-location!]]
             [secretary.core :as secretary])
   (:import goog.history.Html5History))
 

--- a/src/cljs/rems/application.cljs
+++ b/src/cljs/rems/application.cljs
@@ -931,7 +931,7 @@
                  [user/attributes attributes invited-user?]]
       :footer (let [element-id (str id "-operations")]
                 [:div {:id element-id}
-                 [collapsible/toggle-control (str id "-collapsible")]
+                 [collapsible/toggle-control {:collapsible-id (str id "-collapsible")}]
                  [:div.commands
                   (when can-change?
                     [change-applicant-action-button element-id])

--- a/src/cljs/rems/application.cljs
+++ b/src/cljs/rems/application.cljs
@@ -53,7 +53,7 @@
             [rems.spinner :as spinner]
             [rems.text :refer [localize-attachment localize-decision localize-event localized localize-state localize-processing-states localize-time localize-time-with-seconds text text-format]]
             [rems.user :as user]
-            [rems.util :refer [navigate! fetch post! focus-input-field format-file-size]]))
+            [rems.util :refer [navigate! fetch post! format-file-size]]))
 
 ;;;; Helpers
 
@@ -78,13 +78,13 @@
          (for [{:keys [type form-id field-id]} validations]
            [:li (if-some [field (get-in fields [form-id field-id])]
                   [:a {:href "#"
-                       :on-click (case (:field/type field)
-                                   ;; workaround for tables: there's no single input to focus
-                                   :table #(focus/focus (str "#container-"
-                                                             (fields/field-name field)))
-                                   :attachment (focus-input-field (str "upload-"
-                                                                       (fields/field-name field)))
-                                   (focus-input-field (fields/field-name field)))}
+                       :on-click (fn [event]
+                                   (.preventDefault event)
+                                   (focus/focus (case (:field/type field)
+                                                  ;; workaround for tables: there's no single input to focus
+                                                  :table (str "#container-" (fields/field-name field))
+                                                  :attachment (str "#upload-" (fields/field-name field))
+                                                  (fields/field-name field))))}
                    (text-format type (localized (:field/title field)))]
                   (text type))]))])
 

--- a/src/cljs/rems/application.cljs
+++ b/src/cljs/rems/application.cljs
@@ -1115,7 +1115,7 @@
         title (localized (:catalogue-item/title resource))
         more-info-url (when-let [url (catalogue-item-more-info-url resource language config)]
                         [:<>
-                         " - "
+                         " – "
                          [:a {:href url :target :_blank}
                           (text :t.catalogue/more-info) " " [external-link]]])]
     [:div.application-resource

--- a/src/cljs/rems/application.cljs
+++ b/src/cljs/rems/application.cljs
@@ -932,7 +932,8 @@
       :footer (let [element-id (str id "-operations")]
                 [:div {:id element-id}
                  [collapsible/toggle-control {:collapsible-id (str id "-collapsible")}]
-                 [:div.commands
+                 [:div.commands {:class (when (or can-change? can-remove? can-uninvite?)
+                                          "mt-2")}
                   (when can-change?
                     [change-applicant-action-button element-id])
                   (when (or can-remove? can-uninvite?)

--- a/src/cljs/rems/application.cljs
+++ b/src/cljs/rems/application.cljs
@@ -80,8 +80,8 @@
                   [:a {:href "#"
                        :on-click (case (:field/type field)
                                    ;; workaround for tables: there's no single input to focus
-                                   :table #(focus/focus-selector (str "#container-"
-                                                                      (fields/field-name field)))
+                                   :table #(focus/focus (str "#container-"
+                                                             (fields/field-name field)))
                                    :attachment (focus-input-field (str "upload-"
                                                                        (fields/field-name field)))
                                    (focus-input-field (fields/field-name field)))}

--- a/src/cljs/rems/application.cljs
+++ b/src/cljs/rems/application.cljs
@@ -1111,19 +1111,18 @@
   (let [config @rems.globals/config
         duos (get-in resource [:resource/duo :duo/codes])
         language @rems.config/current-language
-        resource-header [:p
-                         (localized (:catalogue-item/title resource))
-                         (when-let [url (catalogue-item-more-info-url resource language config)]
-                           [:<>
-                            " – "
-                            [:a {:href url :target :_blank}
-                             (text :t.catalogue/more-info) " " [external-link]]])]]
+        title (localized (:catalogue-item/title resource))
+        more-info-url (when-let [url (catalogue-item-more-info-url resource language config)]
+                        [:<>
+                         " - "
+                         [:a {:href url :target :_blank}
+                          (text :t.catalogue/more-info) " " [external-link]]])]
     [:div.application-resource
      (if-not (and (:enable-duo @rems.globals/config) (seq duos))
-       resource-header
+       [:p title more-info-url]
        [collapsible/expander
         {:id (str "resource-" (:resource/id resource) "-duos-collapsible")
-         :title resource-header
+         :title [:<> title more-info-url]
          :collapse [collapsible/component
                     {:id (str "resource-" (:resource/id resource) "-duos")
                      :title (text :t.duo/title)

--- a/src/cljs/rems/collapsible.cljs
+++ b/src/cljs/rems/collapsible.cljs
@@ -122,13 +122,17 @@
       always
       (when collapse
         [:<>
-         (when top-less-button? [hide-control id {:on-click on-close}])
-         [collapse-block id collapse collapse-hidden]
-         [show-control id {:on-click on-open}]
-         (when bottom-less-button? [hide-control id {:on-click on-close}])])
-      footer]]
-    (finally
-      (rf/dispatch [::reset-expanded id]))))
+         (when top-less-button? [toggle-control {:collapsible-id id
+                                                 :on-close on-close
+                                                 :on-open false}])
+         [collapse-block id {:content-closed collapse-hidden
+                             :content-open collapse}]
+         [toggle-control {:collapsible-id id
+                          :on-close (if bottom-less-button?
+                                      on-close
+                                      false)
+                          :on-open on-open}]])
+      footer]]))
 
 (defn minimal
   "Collapsible variation that does not have border or title, and controls
@@ -155,10 +159,9 @@
      (when title [:h2.card-header title])
      [:div.collapsible-contents
       always
-      [collapse-block id collapse collapse-hidden]
-      footer]]
-    (finally
-      (rf/dispatch [::reset-expanded id]))))
+      [collapse-block id {:content-open collapse
+                          :content-hidden collapse-hidden}]
+      footer]]))
 
 (defn expander
   "Collapsible variation where simple title is the toggle control.
@@ -185,9 +188,7 @@
                                          title]
                                  :url "#")]
        [:div.collapsible-contents
-        [collapse-block id collapse]]])
-    (finally
-      (rf/dispatch [::reset-expanded id]))))
+        [collapse-block id {:content-open collapse}]]])))
 
 (defn guide
   []

--- a/src/cljs/rems/collapsible.cljs
+++ b/src/cljs/rems/collapsible.cljs
@@ -204,7 +204,7 @@
    (example "no hide controls"
             [component {:id "standard-collapsible-2"
                         :title "Focus on show"
-                        :always [:p "Hidden input receives focus on show"]
+                        :always [:p "Collapsed input receives focus when opened"]
                         :collapse [:input]}])
    (example "no collapse content"
             [component {:id "standard-collapsible-3"
@@ -221,7 +221,7 @@
                         :on-close #(js/console.log "bye")
                         :always [:div.solid-group
                                  [:b "Custom controls:"]
-                                 [rems.collapsible/toggle-control "standard-collapsible-4"]]
+                                 [rems.collapsible/toggle-control {:collapsible-id "standard-collapsible-4"}]]
                         :collapse (into [:div] (repeat 3 [:p "I am long content that you can hide"]))
                         :collapse-hidden [:p "I am content that is only visible when collapsed"]
                         :footer [:div.solid-group "I am the footer that is always visible"]}])
@@ -229,19 +229,19 @@
    (component-info minimal)
    (example "default use"
             [minimal {:id "minimal-collapsible-1"
-                      :always [rems.collapsible/toggle-control "minimal-collapsible-1"]
+                      :always [rems.collapsible/toggle-control {:collapsible-id "minimal-collapsible-1"}]
                       :collapse [:p "I am content that you can hide"]}])
    (example "footer controls"
             [minimal {:id "minimal-collapsible-2"
-                      :footer [rems.collapsible/toggle-control "minimal-collapsible-2"]
+                      :footer [rems.collapsible/toggle-control {:collapsible-id "minimal-collapsible-2"}]
                       :collapse [:p "I am content that you can hide"]}])
    (example "all options"
             [minimal {:id "minimal-collapsible-3"
                       :open? true
-                      :always [rems.collapsible/toggle-control "minimal-collapsible-3"]
+                      :always [rems.collapsible/toggle-control {:collapsible-id "minimal-collapsible-3"}]
                       :collapse (into [:div] (repeat 3 [:p "I am long content that you can hide"]))
                       :collapse-hidden [:p "I am content that is only visible when collapsed"]
-                      :footer [rems.collapsible/toggle-control "minimal-collapsible-3"]}])
+                      :footer [rems.collapsible/toggle-control {:collapsible-id "minimal-collapsible-3"}]}])
 
    (component-info expander)
    (example "defaults"

--- a/src/cljs/rems/collapsible.cljs
+++ b/src/cljs/rems/collapsible.cljs
@@ -184,9 +184,11 @@
                                                  :on-open on-open})
                                  :class "expander-toggle"
                                  :label [:div.d-flex.align-items-center.gap-1.pointer
-                                         [:i.fa.fa-chevron-down.animate-transform {:class (when expanded? "rotate-180")}]
-                                         title]
-                                 :url "#")]
+                                         title
+                                         [:div
+                                          [:i.fa {:class (if expanded?
+                                                           "fa-chevron-up"
+                                                           "fa-chevron-down")}]]])]
        [:div.collapsible-contents
         [collapse-block id {:content-open collapse}]]])))
 

--- a/src/cljs/rems/collapsible.cljs
+++ b/src/cljs/rems/collapsible.cljs
@@ -7,7 +7,8 @@
             [re-frame.core :as rf]
             [rems.atoms :as atoms]
             [rems.guide-util :refer [component-info example]]
-            [rems.text :refer [text]]))
+            [rems.text :refer [text]]
+            [rems.util :refer [class-names]]))
 
 (rf/reg-sub ::expanded (fn [db [_ id]] (true? (get-in db [::id id]))))
 
@@ -85,6 +86,17 @@
        hide [atoms/action-link (hide-action action)]
        open [atoms/action-link (show-action action)])]))
 
+(defn info-toggle-control
+  "Toggle control that uses simple icon as label.
+   
+   `action` is a map that supports following keys:
+   - `:collapse-id` (required) string or keyword, id of controlled collapsible
+   - `:on-close` function, invoked when collapsible is toggled hidden
+   - `:on-open` function, invoked when collapsible is toggled open"
+  [action]
+  [atoms/action-link (-> (toggle-action action)
+                         (update :class class-names :info-collapsible-toggle)
+                         (assoc :label [atoms/info-symbol]))])
 
 (defn- collapse-block [id {:keys [content-closed content-open]}]
   (if @(rf/subscribe [::expanded id])

--- a/src/cljs/rems/collapsible.cljs
+++ b/src/cljs/rems/collapsible.cljs
@@ -6,6 +6,7 @@
             [reagent.impl.util]
             [re-frame.core :as rf]
             [rems.atoms :as atoms]
+            [rems.focus :as focus]
             [rems.guide-util :refer [component-info example]]
             [rems.text :refer [text]]
             [rems.util :refer [class-names]]))
@@ -47,13 +48,17 @@
                                  state (text :t.collapse/hide)
                                  :else (text :t.collapse/show))))))
 
+(defn focus-on-first-input [id]
+  (focus/scroll-into-view-and-focus (rfmt/format "#%s .collapse-open :is(textarea, input)" id)))
+
 (defn show-action
   "Action that shows collapsible on click. Use together with `action-link` or `action-button` atom."
   [{:keys [collapsible-id on-open] :as action}]
   (-> (base-action action)
       (assoc :on-click (fn [^js event]
                          (rf/dispatch [::set-expanded collapsible-id true])
-                         (when on-open (on-open event))))))
+                         (when on-open (on-open event))
+                         (focus-on-first-input collapsible-id)))))
 
 (defn hide-action
   "Action that hides collapsible on click. Use together with `action-link` or `action-button` atom."

--- a/src/cljs/rems/focus.cljs
+++ b/src/cljs/rems/focus.cljs
@@ -1,33 +1,35 @@
 (ns rems.focus
   "Focuses an HTML element as soon as it exists."
-  (:require [medley.core :refer [assoc-some]]
-            [re-frame.core :as rf]
-            [rems.common.util :refer [andstr]]
-            [rems.util :refer [on-element-appear]]))
+  (:require [rems.util :refer [get-bounding-client-rect get-dom-element on-element-appear]]))
 
-(defn focus [element]
-  (doto element
+(defn- fixed-navigation-bottom []
+  (.-bottom (get-bounding-client-rect ".fixed-top")))
+
+(defn- get-absolute-distance-top [el-or-selector]
+  (.-top (get-bounding-client-rect el-or-selector)))
+
+(defn- get-distance-top
+  "Returns distance to fixed navigation bar bottom (top-most element)."
+  [el-or-selector]
+  (+ (get-absolute-distance-top el-or-selector)
+     (fixed-navigation-bottom)))
+
+(defn focus [el-or-selector & [opts]]
+  (doto (get-dom-element el-or-selector)
     (.setAttribute "tabindex" "-1")
-    (.focus)
+    (.focus (clj->js (or opts {})))
     (.removeAttribute "tabindex")))
 
-(defn focus-selector [selector]
-  (focus (.querySelector js/document selector)))
-
-(defn focus-without-scroll [element]
-  (doto element
-    (.setAttribute "tabindex" "-1")
-    (.focus (js-obj "preventScroll" true))
-    (.removeAttribute "tabindex")))
+(defn focus-without-scroll [el-or-selector]
+  (focus el-or-selector (js-obj "preventScroll" true)))
 
 (defn- scroll-below-navigation-menu
   "Scrolls an element into view if it's behind the navigation menu."
   [element]
-  (when-let [navbar (.querySelector js/document ".fixed-top")]
-    (let [navbar-bottom (.-bottom (.getBoundingClientRect navbar))
-          element-top (.-top (.getBoundingClientRect element))]
-      (when (< element-top navbar-bottom)
-        (.scrollBy js/window 0 (- element-top navbar-bottom))))))
+  (let [distance (get-distance-top element)]
+    (when (neg? distance)
+      (.scrollBy js/window 0 distance))
+    element))
 
 (defn focus-and-ensure-visible [element]
   ;; Focusing the element scrolls it into the viewport, but
@@ -35,14 +37,6 @@
   (focus element)
   (scroll-below-navigation-menu element))
 
-(defn scroll-to-top
-  "Scrolls an element to the top of the window (but below the navigation menu)"
-  [element]
-  (let [navbar (.querySelector js/document ".fixed-top")
-        _ (assert navbar)
-        navbar-bottom (.-bottom (.getBoundingClientRect navbar))
-        element-top (.-top (.getBoundingClientRect element))]
-    (.scrollBy js/window 0 (- element-top navbar-bottom))))
 
 (defn scroll-offset
   "Scrolls the window so that an element stays in the same screen position

--- a/src/cljs/rems/search.cljs
+++ b/src/cljs/rems/search.cljs
@@ -48,11 +48,10 @@
 
       (when info
         [atoms/action-link
-         (assoc (collapsible/toggle-action collapse-id)
-                :class "application-search-tips"
-                :label [atoms/search-symbol]
-                :aria-label (text :t.search/example-searches)
-                :url "#")])
+         (collapsible/toggle-action {:aria-label (text :t.search/example-searches)
+                                     :class "application-search-tips"
+                                     :collapsible-id collapse-id
+                                     :label [atoms/search-symbol]})])
       (when searching?
         [spinner/small])]
      (when info

--- a/src/cljs/rems/util.cljs
+++ b/src/cljs/rems/util.cljs
@@ -148,13 +148,6 @@
               %)
            splitted))))
 
-(defn focus-input-field [id]
-  (fn [event]
-    (.preventDefault event)
-    ;; focusing input fields requires JavaScript; <a href="#id"> links don't work
-    (when-let [element (.getElementById js/document id)]
-      (.focus element))))
-
 (defn visibility-ratio
   "Given a DOM node, return a number from 0.0 to 1.0 describing how much of an element is inside the viewport."
   [element]

--- a/src/cljs/rems/util.cljs
+++ b/src/cljs/rems/util.cljs
@@ -7,6 +7,7 @@
             [goog.string :refer [format]]
             [medley.core :refer [assoc-some]]
             [re-frame.core :as rf]
+            [reagent.impl.util]
             ["react" :as react]))
 
 (defn replace-url!
@@ -278,3 +279,11 @@
 
 (defn event-checked [^js event]
   (.. event -target -checked))
+
+(defn class-names
+  "Returns `classes` as string of space-separated, deduplicated CSS classes."
+  [& classes]
+  (-> (flatten classes)
+      distinct
+      reagent.impl.util/class-names
+      str))

--- a/src/cljs/rems/util.cljs
+++ b/src/cljs/rems/util.cljs
@@ -202,11 +202,6 @@
       nil {}
       nil [])))
 
-(defn react-strict-mode
-  "Wrapper around React <StrictMode> component. See more https://react.dev/reference/react/StrictMode#strictmode"
-  [body]
-  [:> react/StrictMode body])
-
 (defn- log-profiler-event [id phase actual-duration base-duration start-time commit-time]
   (js/console.count (str phase " → " id))
   (js/console.debug "\t"

--- a/src/cljs/rems/util.cljs
+++ b/src/cljs/rems/util.cljs
@@ -282,3 +282,11 @@
       distinct
       reagent.impl.util/class-names
       str))
+
+(defn get-dom-element [el-or-selector]
+  (cond->> el-or-selector
+    (string? el-or-selector) (.querySelector js/document)))
+
+(defn get-bounding-client-rect [el-or-selector]
+  (some-> (get-dom-element el-or-selector)
+          (.getBoundingClientRect)))


### PR DESCRIPTION
#3325 

Removes last application code dependencies to Bootstrap and jQuery (excluding styles):
- collapsible supports `:group` that (on show) hides other collapsibles in the same group
- `rems.actions.components` action form/buttons now use collapsible and collapsible actions

Notable changes:
- adjusted `rems.focus/scroll-into-view` to scroll into middle of screen
- show collapsible action calls `rems.focus/scroll-into-view-and-focus` to set focus on first input

Other changes:
- moved info-collapsible from fields to collapsible namespace
- removed animation from expander, as it looked quite off from other UI
- fixed various styling issues with collapsible
- removed `:t.actions/cancel` localization (only one use place, and `:t.administration/cancel` is used by other atom actions as well)

# Checklist for author

Remove items that aren't applicable, check items that are done.

## Reviewability
- [x] Link to issue
- [ ] Consider adding screenshots for ease of review

## Backwards compatibility
- [ ] Feature appears correctly in PDF print

## Documentation
- [ ] Update changelog if necessary

## Testing
- [ ] Complex logic is unit tested
- [ ] Valuable features are integration / browser / acceptance tested automatically

## Follow-up
- [ ] New tasks are created for pending or remaining tasks
