### PR TITLE
Fix broken tests

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -118,7 +118,7 @@
                                 [criterium "0.4.6"]
                                 [lambdaisland/kaocha "1.91.1392"]
                                 [lambdaisland/kaocha-junit-xml "1.17.101"]
-                                [etaoin "1.0.40"]
+                                [etaoin "1.1.41"]
                                 [ring/ring-mock "0.4.0" :exclusions [cheshire]]
                                 [se.haleby/stub-http "0.2.14"]
                                 [com.icegreen/greenmail "1.6.15"]

--- a/src/cljs/rems/administration/create_form.cljs
+++ b/src/cljs/rems/administration/create_form.cljs
@@ -693,7 +693,7 @@
   (let [fields (indexed @(rf/subscribe [::fields]))
         field-count (count fields)]
     (into [:<>
-           [:div.new-form-field
+           [:div.new-form-field {:data-field-index 0}
             [add-form-field-button 0]]]
           (for [[idx field] fields]
             ^{:key (get-field-key field idx)}
@@ -701,7 +701,7 @@
              [:div.form-field {:data-field-id (:field/id field)
                                :data-field-index idx}
               [field-editor idx field field-count]]
-             [:div.new-form-field
+             [:div.new-form-field {:data-field-index (inc idx)}
               [add-form-field-button (inc idx)]]]))))
 
 (defn- render-preview-hidden []

--- a/test/clj/rems/browser_test_util.clj
+++ b/test/clj/rems/browser_test_util.clj
@@ -96,7 +96,7 @@
 (defn- reset-window-size!
   "Sets window size big enough to show the whole page in the screenshots."
   [driver]
-  (et/set-window-size driver 1400 7000))
+  (et/set-window-rect driver {:width 1400 :height 7000}))
 
 (defn- init-session! [driver]
   (doto driver
@@ -355,7 +355,7 @@
         full-filename (str (get-file-base) filename ".png")
         file (io/file (:reporting-dir @test-context) full-filename)
 
-        window-size (et/get-window-size driver)
+        window-size (et/get-window-rect driver)
         empty-space (if (et/exists? driver :empty-space) ; if page has not rendered, screenshot can fail due to missing element
                       (parse-int (et/get-element-attr driver :empty-space "clientHeight"))
                       0)
@@ -368,14 +368,14 @@
 
     ;; adjust window to correct size
     (when need-to-adjust?
-      (et/set-window-size driver {:width (:width window-size)
+      (et/set-window-rect driver {:width (:width window-size)
                                   :height without-extra-height}))
 
     (et/screenshot driver file)
 
     ;; restore (big) size
     (when need-to-adjust?
-      (et/set-window-size driver window-size))))
+      (et/set-window-rect driver window-size))))
 
 (defn screenshot-element [filename q]
   (let [full-filename (format "%03d-%s-%s"
@@ -414,7 +414,7 @@
 (defn wrap-etaoin [f]
   (fn [& args] (apply f (get-driver) args)))
 
-(def set-window-size (wrap-etaoin et/set-window-size))
+(def set-window-rect (wrap-etaoin et/set-window-rect))
 (def go (wrap-etaoin et/go))
 (def wait-visible (wrap-etaoin et/wait-visible))
 (def wait-invisible (wrap-etaoin et/wait-invisible))

--- a/test/clj/rems/browser_test_util.clj
+++ b/test/clj/rems/browser_test_util.clj
@@ -104,7 +104,8 @@
     (reset-window-size!)))
 
 (def ^:private driver-defaults
-  {:args ["--lang=en-US"]
+  {:args ["--lang=en-US"
+          "--disable-search-engine-choice-screen"] ; https://stackoverflow.com/a/78800001
    :prefs {:intl.accept_languages "en-US"
            :download.directory_upgrade true
            :safebrowsing.enabled false

--- a/test/clj/rems/service/test_catalogue.clj
+++ b/test/clj/rems/service/test_catalogue.clj
@@ -14,10 +14,12 @@
 
 (use-fixtures
   :once
-  test-db-fixture
-  reset-caches-fixture)
+  test-db-fixture)
 
-(use-fixtures :each rollback-db-fixture)
+(use-fixtures
+  :each
+  reset-caches-fixture
+  rollback-db-fixture)
 
 (defn- status-flags [item-id]
   (-> (catalogue/get-localized-catalogue-item item-id)

--- a/test/clj/rems/test_browser.clj
+++ b/test/clj/rems/test_browser.clj
@@ -1059,7 +1059,7 @@
     (testing "handler should see application after clicking on View"
       (wait-page-title (format "Application %s: test-handling – REMS" (btu/context-getx :external-id))))
     (testing "handler should see the applicant info"
-      (open-collapsible :applicants-info-collapsible)
+      (open-collapsible :applicant-info-collapsible)
       (btu/screenshot "after-opening-applicant-info")
       (is (= {"Name" "Alice Applicant"
               "Accepted terms of use" true

--- a/test/clj/rems/test_browser.clj
+++ b/test/clj/rems/test_browser.clj
@@ -397,9 +397,9 @@
   (when external-links
     (btu/scroll-and-click :licensetype-link)
     (btu/eventually-visible? :localizations-en-link)
-    (btu/fill-human :localizations-en-link (:en external-links))
-    (btu/fill-human :localizations-fi-link (:fi external-links))
-    (btu/fill-human :localizations-sv-link (:sv external-links)))
+    (some->> (:en external-links) (btu/fill-human :localizations-en-link))
+    (some->> (:fi external-links) (btu/fill-human :localizations-fi-link))
+    (some->> (:sv external-links) (btu/fill-human :localizations-sv-link)))
   (when inline-text
     (btu/scroll-and-click :licensetype-text)
     (btu/eventually-visible? :localizations-en-text)

--- a/test/clj/rems/test_browser.clj
+++ b/test/clj/rems/test_browser.clj
@@ -147,12 +147,6 @@
        (finally
          (change-language :en)))))
 
-(defn open-collapsible [id]
-  (btu/scroll-and-click [{:id (name id) :fn/has-class :collapsible}
-                         {:css ".show-more-link"}])
-  (btu/wait-visible [{:id (name id)}
-                     {:css ".collapse-open"}]))
-
 (defn aria-controls [& [id]]
   (if id
     (format "[aria-controls='%s']" (name id))
@@ -163,7 +157,7 @@
     (format "[aria-expanded='%s']" (true? value))
     "[aria-expanded]"))
 
-(defn open-external-collapsible [id]
+(defn open-collapsible [id]
   (btu/scroll-and-click {:css (str (aria-controls id) (aria-expanded false))})
   (btu/wait-visible [{:id (name id)}
                      {:css ".collapse-open"}]))
@@ -2228,15 +2222,15 @@
           (testing "fill localized title"
             (fill-localized-title! "Text field (%s)"))
           (testing "fill localized placeholder"
-            (open-external-collapsible (:id (field-placeholder-collapsible)))
+            (open-collapsible (:id (field-placeholder-collapsible)))
             (fill-localized-placeholder! "Text field placeholder (%s)"))
           (testing "fill localized description"
-            (open-external-collapsible (:id (field-description-collapsible)))
+            (open-collapsible (:id (field-description-collapsible)))
             (fill-localized-description! "Text field description (%s)"))
           (testing "set optional"
             (btu/scroll-and-click (field-component :optional)))
           (testing "set maximum length"
-            (open-external-collapsible (:id (field-settings-collapsible)))
+            (open-collapsible (:id (field-settings-collapsible)))
             (btu/fill-human (field-component :max-length) "127")))
 
         (testing "create text area"
@@ -2245,15 +2239,15 @@
           (testing "fill localized title"
             (fill-localized-title! "Text area (%s)"))
           (testing "fill localized placeholder"
-            (open-external-collapsible (:id (field-placeholder-collapsible)))
+            (open-collapsible (:id (field-placeholder-collapsible)))
             (fill-localized-placeholder! "Text area placeholder (%s)"))
           (testing "fill localized description"
-            (open-external-collapsible (:id (field-description-collapsible)))
+            (open-collapsible (:id (field-description-collapsible)))
             (fill-localized-description! "Text area description (%s)"))
           (testing "set optional"
             (btu/scroll-and-click (field-component :optional)))
           (testing "set maximum length"
-            (open-external-collapsible (:id (field-settings-collapsible)))
+            (open-collapsible (:id (field-settings-collapsible)))
             (btu/fill-human (field-component :max-length) "127")))
 
         (testing "create option field"
@@ -2262,7 +2256,7 @@
           (testing "fill localized title"
             (fill-localized-title! "Option list (%s)"))
           (testing "fill localized description"
-            (open-external-collapsible (:id (field-description-collapsible)))
+            (open-collapsible (:id (field-description-collapsible)))
             (fill-localized-description! "Option description (%s)"))
           (testing "create two options"
             (btu/scroll-and-click (field-component :add-option))
@@ -2334,7 +2328,7 @@
           (testing "fill localized title"
             (fill-localized-title! "Date (%s)"))
           (testing "fill localized description"
-            (open-external-collapsible (:id (field-description-collapsible)))
+            (open-collapsible (:id (field-description-collapsible)))
             (fill-localized-description! "Date description (%s)")))
 
         (testing "create email address field"
@@ -2343,7 +2337,7 @@
           (testing "fill localized title"
             (fill-localized-title! "Email (%s)"))
           (testing "fill localized description"
-            (open-external-collapsible (:id (field-description-collapsible)))
+            (open-collapsible (:id (field-description-collapsible)))
             (fill-localized-description! "Email description (%s)")))
 
         (testing "create phone number field"
@@ -2352,7 +2346,7 @@
           (testing "fill localized title"
             (fill-localized-title! "Phone number (%s)"))
           (testing "fill localized description"
-            (open-external-collapsible (:id (field-description-collapsible)))
+            (open-collapsible (:id (field-description-collapsible)))
             (fill-localized-description! "Phone number description (%s)")))
 
         (testing "create ip address field"
@@ -2361,7 +2355,7 @@
           (testing "fill localized title"
             (fill-localized-title! "IP address (%s)"))
           (testing "fill localized description"
-            (open-external-collapsible (:id (field-description-collapsible)))
+            (open-collapsible (:id (field-description-collapsible)))
             (fill-localized-description! "IP address description (%s)")))
 
         (testing "create attachment field"
@@ -2370,7 +2364,7 @@
           (testing "fill localized title"
             (fill-localized-title! "Attachment (%s)"))
           (testing "fill localized description"
-            (open-external-collapsible (:id (field-description-collapsible)))
+            (open-collapsible (:id (field-description-collapsible)))
             (fill-localized-description! "Attachment description (%s)"))
           (testing "attachment has extra info in preview"
             (btu/context-assoc! ::attachment-collapsible (str "upload-" (:id (preview-component :info-collapsible))))
@@ -2465,9 +2459,9 @@
         (btu/wait-page-loaded)
         (wait-page-title "Edit form – REMS")
 
-        (open-external-collapsible (str "field-collapsible-" (btu/context-getx :field-id)))
+        (open-collapsible (str "field-collapsible-" (btu/context-getx :field-id)))
         (btu/scroll-and-click (field-component :type-description))
-        (open-external-collapsible (:id (field-description-collapsible)))
+        (open-collapsible (:id (field-description-collapsible)))
         (btu/fill-human (field-component :info-text-en) "Description (EN)")
         (btu/fill-human (field-component :info-text-fi) "Description (FI)")
         (btu/fill-human (field-component :info-text-sv) " ")
@@ -2668,7 +2662,7 @@
         (testing "fill localized title"
           (fill-localized-title! "Text (%s)"))
         (testing "set visibility to only if field 1 has true selected"
-          (open-external-collapsible (:id (field-settings-collapsible)))
+          (open-collapsible (:id (field-settings-collapsible)))
           (is (btu/eventually-visible? (field-component :visibility-type)))
           (btu/fill (field-component :visibility-type) "Only if\n")
           (is (btu/eventually-visible? (field-component :visibility-field)))
@@ -2682,7 +2676,7 @@
         (testing "fill localized title"
           (fill-localized-title! "Email (%s)"))
         (testing "set visibility to only if field 2 has X,Z selected"
-          (open-external-collapsible (:id (field-settings-collapsible)))
+          (open-collapsible (:id (field-settings-collapsible)))
           (is (btu/eventually-visible? (field-component :visibility-type)))
           (btu/fill (field-component :visibility-type) "Only if\n")
           (is (btu/eventually-visible? (field-component :visibility-field)))

--- a/test/clj/rems/test_browser.clj
+++ b/test/clj/rems/test_browser.clj
@@ -3169,7 +3169,7 @@
   (btu/with-postmortem
     (login-as "alice")
     (go-to-catalogue)
-    (btu/set-window-size 400 600) ; small enough for mobile
+    (btu/set-window-rect {:width 400 :height 600}) ; small enough for mobile
     (btu/wait-invisible :small-navbar)
     (btu/scroll-and-click {:css ".navbar-toggler"})
     (is (btu/eventually-visible? :small-navbar))

--- a/test/clj/rems/test_browser.clj
+++ b/test/clj/rems/test_browser.clj
@@ -1443,14 +1443,18 @@
       (btu/scroll-and-click :request-review-dropdown)
       (is (btu/eventually-visible? :request-review-action-button))
       (btu/scroll-and-click :request-review-action-button)
-
       (is (btu/eventually-visible? :actions-request-review))
+
+      (Thread/sleep 500) ; wait for /reviewers api request
+
       (btu/scroll-and-click [:actions-request-review
                              {:css ".form-group > .dropdown-container"}])
       (is (btu/eventually-visible? {:css ".dropdown-select__menu"}))
 
-      (btu/scroll-and-click [{:css ".dropdown-select__menu"}
-                             {:tag :div :fn/has-text "Carl Reviewer"}])
+      (btu/scroll-and-click [:actions-request-review
+                             {:css ".form-group > .dropdown-container"}
+                             {:css ".dropdown-select__menu"}
+                             {:fn/has-text "Carl Reviewer"}])
 
       (btu/scroll-and-click :request-review-button)
       (is (btu/eventually-visible? {:css ".alert-success"}))


### PR DESCRIPTION
Fixes issue with browser tests not passing:
- `open-collapsible` helper no longer uses class name in selector
- `add-form-field!` helper uses less explicit id management (again)

Other changes:
- removed unused refresh driver fixture (actually was removed already before, due to stability issues)
- added flag to disable chrome from asking default search (quite annoying when running non-headless)
- removed custom implementation of `fill-human` and replaced with etaoin.api/fill-human. tuning the algorithm was quite time consuming and it wouldn't prevent tests from flaking anyway
- added wait and extra selector path to dropdown select in `test-invite-reviewer` (perhaps flaky due too fast clicking)
- updated `etaoin` to latest, introduced some new API
