### PR TITLE
Many handlers perf2.1

### DIFF
--- a/resources/sql/queries.sql
+++ b/resources/sql/queries.sql
@@ -663,6 +663,11 @@ INSERT INTO outbox (outboxData)
 VALUES (:outboxdata::jsonb)
 RETURNING id;
 
+-- :name puts-to-outbox! :returning-execute
+INSERT INTO outbox (outboxData)
+SELECT * FROM jsonb_to_recordset(:outboxdatas::jsonb) AS tmp(outboxdata jsonb)
+RETURNING id;
+
 -- :name get-outbox :? :*
 SELECT id, outboxData::text
 FROM outbox

--- a/src/clj/rems/api/applications.clj
+++ b/src/clj/rems/api/applications.clj
@@ -78,7 +78,7 @@
 (defn- overview-only-active-handlers [app]
   (update-in app
              [:application/workflow :workflow.dynamic/handlers]
-             #(filterv :handler/active? %)))
+             #(filter :handler/active? %)))
 
 ;; Api implementation
 
@@ -135,6 +135,14 @@
     (merge {:success true}
            (commands/validate-application application (:field-values request)))))
 
+(defn- get-handled-applications [{:keys [query only-active-handlers limit]}]
+  (time
+  (cond->> (todos/get-handled-todos (getx-user-id))
+    only-active-handlers (map overview-only-active-handlers)
+    query (filter-with-search query)
+    true (sort-by last-activity >)
+    limit (take limit))))
+
 (def my-applications-api
   (context "/my-applications" []
     :tags ["applications"]
@@ -180,11 +188,9 @@
       :query-params [{query :- (describe s/Str "search query [documentation](https://github.com/CSCfi/rems/blob/master/docs/search.md)") nil}
                      {only-active-handlers :- (describe s/Bool "return only workflow handlers that are active making a smaller result") false}
                      {limit :- (describe s/Int "how many results to return") nil}]
-      (ok (cond->> (todos/get-handled-todos (getx-user-id))
-            only-active-handlers (map overview-only-active-handlers)
-            query (filter-with-search query)
-            true (sort-by last-activity >)
-            limit (take limit))))
+      (ok (get-handled-applications {:query query
+                                     :only-active-handlers only-active-handlers
+                                     :limit limit})))
 
     (POST "/create" request
       :summary "Create a new application"

--- a/src/clj/rems/api/applications.clj
+++ b/src/clj/rems/api/applications.clj
@@ -184,6 +184,7 @@
     (GET "/handled" []
       :summary "Get all applications that the current user no more needs to act on."
       :roles #{:logged-in}
+      ;; XXX: checking this schema can be mighty slow (thousands of applications to check individually)
       :return [schema/ApplicationOverview]
       :query-params [{query :- (describe s/Str "search query [documentation](https://github.com/CSCfi/rems/blob/master/docs/search.md)") nil}
                      {only-active-handlers :- (describe s/Bool "return only workflow handlers that are active making a smaller result") false}

--- a/src/clj/rems/api/applications.clj
+++ b/src/clj/rems/api/applications.clj
@@ -137,11 +137,11 @@
 
 (defn- get-handled-applications [{:keys [query only-active-handlers limit]}]
   (time
-  (cond->> (todos/get-handled-todos (getx-user-id))
-    only-active-handlers (map overview-only-active-handlers)
-    query (filter-with-search query)
-    true (sort-by last-activity >)
-    limit (take limit))))
+   (cond->> (todos/get-handled-todos (getx-user-id))
+     only-active-handlers (map overview-only-active-handlers)
+     query (filter-with-search query)
+     true (sort-by last-activity >)
+     limit (take limit))))
 
 (def my-applications-api
   (context "/my-applications" []

--- a/src/clj/rems/db/applications.clj
+++ b/src/clj/rems/db/applications.clj
@@ -384,14 +384,14 @@
         personalize-app (fn [app] ; NB: may return nil if should not see the app
                           (model/apply-user-permissions app userid))
         apps (->> app-ids
-                  (mapv cached-apps)
+                  (map cached-apps)
                   (keep personalize-app))]
     apps))
 
 (defn get-all-applications [userid]
   (->> userid
        get-all-applications-full
-       (mapv ->ApplicationOverview)))
+       (map ->ApplicationOverview)))
 
 (defn get-all-application-roles [userid]
   (-> (refresh-all-applications-cache!)

--- a/src/clj/rems/email/core.clj
+++ b/src/clj/rems/email/core.clj
@@ -30,35 +30,43 @@
       (template/event-to-emails (rems.application.model/enrich-event event users/get-user (constantly nil))
                                 (applications/get-application app-id)))))
 
-(defn- enqueue-email! [email]
-  (outbox/put! {:outbox/type :email
-                :outbox/email email
-                :outbox/deadline (-> (time/now) (.plus ^Period (:email-retry-period env)))}))
-
 (defn generate-event-emails! [new-events]
-  (doseq [event new-events
-          email (event-to-emails event)]
-    (enqueue-email! email)))
+  (let [deadline (-> (time/now) (.plus ^Period (:email-retry-period env)))]
+    (->> (for [event new-events
+               email (event-to-emails event)]
+           {:outbox/type :email
+            :outbox/email email
+            :outbox/deadline deadline})
+         outbox/puts!)
+    nil)) ; no new events
 
 (defn generate-handler-reminder-emails! []
-  (doseq [email (->> (workflow/get-handlers)
-                     (map (fn [handler]
-                            (let [lang (:language (user-settings/get-user-settings (:userid handler)))
-                                  apps (todos/get-todos (:userid handler))]
-                              (template/handler-reminder-email lang handler apps))))
-                     (remove nil?))]
-    (enqueue-email! email)))
+  (let [deadline (-> (time/now) (.plus ^Period (:email-retry-period env)))]
+    (->> (for [email (->> (workflow/get-handlers)
+                          (map (fn [handler]
+                                 (let [lang (:language (user-settings/get-user-settings (:userid handler)))
+                                       apps (todos/get-todos (:userid handler))]
+                                   (template/handler-reminder-email lang handler apps))))
+                          (remove nil?))]
+           {:outbox/type :email
+            :outbox/email email
+            :outbox/deadline deadline})
+         outbox/puts!)))
 
 (defn generate-reviewer-reminder-emails! []
-  (doseq [email (->> (applications/get-users-with-role :reviewer)
-                     (map users/get-user)
-                     (map (fn [reviewer]
-                            (let [lang (:language (user-settings/get-user-settings (:userid reviewer)))
-                                  apps (->> (todos/get-todos (:userid reviewer))
-                                            (map #(= :waiting-for-your-review (:application/todo %))))]
-                              (template/reviewer-reminder-email lang reviewer apps))))
-                     (remove nil?))]
-    (enqueue-email! email)))
+  (let [deadline (-> (time/now) (.plus ^Period (:email-retry-period env)))]
+    (->> (for [email (->> (applications/get-users-with-role :reviewer)
+                          (map users/get-user)
+                          (map (fn [reviewer]
+                                 (let [lang (:language (user-settings/get-user-settings (:userid reviewer)))
+                                       apps (->> (todos/get-todos (:userid reviewer))
+                                                 (map #(= :waiting-for-your-review (:application/todo %))))]
+                                   (template/reviewer-reminder-email lang reviewer apps))))
+                          (remove nil?))]
+           {:outbox/type :email
+            :outbox/email email
+            :outbox/deadline deadline})
+         outbox/puts!)))
 
 (defn- render-invitation-template [invitation]
   (let [lang (:default-language env)] ; we don't know the preferred languages here since there is no user
@@ -67,12 +75,20 @@
             (assert workflow "Can't send invitation, missing workflow")
             (template/workflow-handler-invitation-email lang invitation workflow)))))
 
+(defn- mark-invitations-sent! [invitations]
+  (doseq [invitation invitations]
+    (invitation/mail-sent! (:invitation/id invitation))))
+
 (defn generate-invitation-emails! [invitations]
-  (doseq [invitation invitations
-          :when (not (:invitation/sent invitation))
-          :let [email (render-invitation-template invitation)]]
-    (invitation/mail-sent! (:invitation/id invitation))
-    (enqueue-email! email)))
+  (let [deadline (-> (time/now) (.plus ^Period (:email-retry-period env)))]
+    (->> (for [invitation invitations
+               :when (not (:invitation/sent invitation))
+               :let [email (render-invitation-template invitation)]]
+           {:outbox/type :email
+            :outbox/email email
+            :outbox/deadline deadline})
+         outbox/puts!)
+    (mark-invitations-sent! invitations)))
 
 ;;; Email poller
 

--- a/src/clj/rems/permissions.clj
+++ b/src/clj/rems/permissions.clj
@@ -197,10 +197,10 @@
    permissions are set for the user."
   [application user]
   (reduce (fn [permissions role]
-              (into permissions
-                    (-> application :application/role-permissions role)))
-            #{}
-            (user-roles application user)))
+            (into permissions
+                  (-> application :application/role-permissions role)))
+          #{}
+          (user-roles application user)))
 
 (deftest test-user-permissions
   (testing "unknown user"

--- a/src/clj/rems/permissions.clj
+++ b/src/clj/rems/permissions.clj
@@ -28,10 +28,9 @@
       (update :application/user-roles dissoc-if-empty user)))
 
 (defn user-roles [application user]
-  (let [specific-roles (set (get-in application [:application/user-roles user]))]
-    (if (seq specific-roles)
-      specific-roles
-      #{:everyone-else})))
+  (if-some [specific-roles (seq (-> application :application/user-roles (get user)))]
+    (set specific-roles)
+    #{:everyone-else}))
 
 (deftest test-user-roles
   (testing "give first role"
@@ -197,10 +196,11 @@
    Union of all role specific permissions. Returns an empty set if no
    permissions are set for the user."
   [application user]
-  (->> (user-roles application user)
-       (mapcat (fn [role]
-                 (get-in application [:application/role-permissions role])))
-       set))
+  (reduce (fn [permissions role]
+              (into permissions
+                    (-> application :application/role-permissions role)))
+            #{}
+            (user-roles application user)))
 
 (deftest test-user-permissions
   (testing "unknown user"

--- a/src/clj/rems/service/test_data.clj
+++ b/src/clj/rems/service/test_data.clj
@@ -602,7 +602,8 @@
 
 (defn create-performance-test-data! []
   (log/info "Creating performance test data")
-  (let [resource-count 1000
+  (let [start-time (System/currentTimeMillis)
+        resource-count 1000
         application-count 3000
         user-count 1000
         handler-count 100
@@ -700,13 +701,15 @@
       (in-parallel
        (for [n (range-1 application-count)]
          (fn []
-           (log/info "Creating performance test application" n "/" application-count)
            (let [cat-item-id (rand-nth cat-item-ids)
                  user-id (rand-nth user-ids)
                  handler (rand-nth handlers)
                  app-id (test-helpers/create-application! {:catalogue-item-ids [cat-item-id]
                                                            :actor user-id})
                  long-answer (random-long-string)]
+
+             (log/info "Created performance test application" app-id (str "(" n "/" application-count ")"))
+
              (dotimes [i 20] ; user saves ~ 20 times while writing an application
                (test-helpers/command! {:type :application.command/save-draft
                                        :application-id app-id
@@ -730,7 +733,10 @@
                                      :application-id app-id
                                      :actor handler
                                      :comment ""}))))))
-    (log/info "Performance test applications created")))
+    (let [delta-time (/ (- (System/currentTimeMillis) start-time) 1000.0)]
+      (log/infof "Performance test applications created in %.2fs (%.2f/s)"
+                 delta-time
+                 (/ application-count delta-time)))))
 
 (defn- create-items! [users users-data]
   (let [owner (users :owner)

--- a/test/clj/rems/api/test_applications.clj
+++ b/test/clj/rems/api/test_applications.clj
@@ -3258,3 +3258,14 @@
                  (->> (get-application-for-user application-id userid)
                       :application/events
                       (mapv #(select-keys % [:event/actor :event/type :event/public :application/processing-state]))))))))))
+
+
+(comment
+  ;; This is a way to test the whole API performance
+  ;; e.g. Schema checking and JSON serialization in addition
+  ;; to the business logic.
+  ;;
+  ;; An alternative would be to do the same as the fixtures do
+  ;; to mount a proper handler.
+  (deftest test-todos-performance
+    (clj-async-profiler.core/profile {:interval 100000} (get-handled-todos "handler"))))

--- a/test/clj/rems/api/test_email.clj
+++ b/test/clj/rems/api/test_email.clj
@@ -37,8 +37,8 @@
   (create-application-in-progress!)
   (testing "sends emails"
     (let [outbox-emails (atom [])]
-      (with-redefs [outbox/put! (fn [email]
-                                  (swap! outbox-emails conj email))]
+      (with-redefs [outbox/puts! (fn [emails]
+                                  (swap! outbox-emails concat emails))]
         (let [body (-> (request :post "/api/email/send-handler-reminder")
                        (authenticate test-data/+test-api-key+ "developer")
                        handler
@@ -64,8 +64,8 @@
 
   (testing "sends emails"
     (let [outbox-emails (atom [])]
-      (with-redefs [outbox/put! (fn [email]
-                                  (swap! outbox-emails conj email))]
+      (with-redefs [outbox/puts! (fn [emails]
+                                   (swap! outbox-emails concat emails))]
         (let [body (-> (request :post "/api/email/send-reviewer-reminder")
                        (authenticate test-data/+test-api-key+ "developer")
                        handler
@@ -91,8 +91,8 @@
 
   (testing "sends emails"
     (let [outbox-emails (atom [])]
-      (with-redefs [outbox/put! (fn [email]
-                                  (swap! outbox-emails conj email))]
+      (with-redefs [outbox/puts! (fn [emails]
+                                   (swap! outbox-emails concat emails))]
         (let [body (-> (request :post "/api/email/send-reminders")
                        (authenticate test-data/+test-api-key+ "developer")
                        handler

--- a/test/clj/rems/api/test_email.clj
+++ b/test/clj/rems/api/test_email.clj
@@ -38,7 +38,7 @@
   (testing "sends emails"
     (let [outbox-emails (atom [])]
       (with-redefs [outbox/puts! (fn [emails]
-                                  (swap! outbox-emails concat emails))]
+                                   (swap! outbox-emails concat emails))]
         (let [body (-> (request :post "/api/email/send-handler-reminder")
                        (authenticate test-data/+test-api-key+ "developer")
                        handler

--- a/test/clj/rems/application/test_eraser.clj
+++ b/test/clj/rems/application/test_eraser.clj
@@ -73,7 +73,7 @@
         outbox-emails (atom [])]
 
     (testing "does not process applications when expirer-bot user does not exist"
-      (with-redefs [outbox/put! (fn [email] (swap! outbox-emails conj email))
+      (with-redefs [outbox/puts! (fn [emails] (swap! outbox-emails concat emails))
                     env {:application-expiration {:application.state/draft {:delete-after "P90D"}}}]
         (log-test/with-log
           (testing "processing applications does not delete applications"
@@ -92,7 +92,7 @@
           (is (log-test/logged? "rems.application.eraser" :warn "Cannot process applications, because user expirer-bot does not exist")))))
 
     (testing "does not delete applications when configuration is not valid"
-      (with-redefs [outbox/put! (fn [email] (swap! outbox-emails conj email))
+      (with-redefs [outbox/puts! (fn [emails] (swap! outbox-emails concat emails))
                     env {}]
         (test-helpers/create-user! {:userid expirer-bot/bot-userid})
         (roles/add-role! expirer-bot/bot-userid :expirer)
@@ -116,7 +116,7 @@
           (is (log-test/logged? "rems.application.eraser" :info "No applications to process")))))
 
     (testing "cannot remove other than draft applications"
-      (with-redefs [outbox/put! (fn [email] (swap! outbox-emails conj email))
+      (with-redefs [outbox/puts! (fn [emails] (swap! outbox-emails concat emails))
                     env {:application-expiration {:application.state/submitted {:delete-after "P90D"}}}]
         (log-test/with-log
           (testing "processing applications does not delete applications"
@@ -146,7 +146,7 @@
             (is (not (log-test/logged? "rems.db.applications" :info #"Finished deleting application")))))))
 
     (testing "deletes expired draft application"
-      (with-redefs [outbox/put! (fn [email] (swap! outbox-emails conj email))
+      (with-redefs [outbox/puts! (fn [emails] (swap! outbox-emails concat emails))
                     env {:application-expiration {:application.state/draft {:delete-after "P90D"}}}]
         (with-fixed-time test-time
           (log-test/with-log
@@ -198,7 +198,7 @@
       (doseq [expiration [{:application.state/draft {:delete-after "P90D"}}
                           {:application.state/draft {:reminder-before "P7D"}}
                           nil]]
-        (with-redefs [outbox/put! (fn [email] (swap! outbox-emails conj email))
+        (with-redefs [outbox/puts! (fn [emails] (swap! outbox-emails concat emails))
                       env {:application-id-column :id
                            :public-url "localhost/"
                            :application-expiration expiration}]
@@ -218,7 +218,7 @@
                 (is (empty? @outbox-emails))))))))
 
     (testing "send expiration notifications"
-      (with-redefs [outbox/put! (fn [email] (swap! outbox-emails conj email))
+      (with-redefs [outbox/puts! (fn [emails] (swap! outbox-emails concat emails))
                     user-settings/get-user-settings (constantly {:language :en})
                     env {:application-id-column :id
                          :public-url "localhost/"


### PR DESCRIPTION
Replaces #3313 

Continues work in #3305 

Includes:
- Makes sure handled applications list is fetched lazily so correct amount of work is done when a limit is given (e.g. only 50).
- Logs test data creation speed to be able to easily follow it. This gives an indication of general REMS performance.
- Emails for one application were sent one at a time. E.g., with 12 handlers there would 12 separate calls to save the email into the outbox. Now this is done with a single call, which helps the 100 handler "worst-case scenario". Tests needed updating to use the new function.
- Replaced `mapcat` with other code to make it faster (micro-optimization).
- The main problem for the performance of the `/api/applications/handled` is actually the verification of the return Schema. If there are thousands of applications, there is a lot of data and half of the time is just spent verifying that it matches our Schema. We could investigate if we can leave the checking out in some cases (e.g., when we know there are a lot of applications). See [issue](https://github.com/orgs/CSCfi/projects/13/views/1?pane=issue&itemId=75940840)

# Checklist for author

Remove items that aren't applicable, check items that are done.

## Reviewability
- [x] Link to issue

## Backwards compatibility
- [x] API is backwards compatible or completely new

## Documentation
- [ ] Update changelog if necessary  (no need for a new one as the last improvement is already mentioned)

## Testing
- [ ] Complex logic is unit tested
- [x] Valuable features are integration / browser / acceptance tested automatically

## Follow-up
- [x] New tasks are created for pending or remaining tasks (see [issue](https://github.com/orgs/CSCfi/projects/13/views/1?pane=issue&itemId=75940840))
