### PR TITLE
fix: dont show collapse control for invalid action

### DIFF
--- a/src/cljs/rems/collapsible.cljs
+++ b/src/cljs/rems/collapsible.cljs
@@ -82,14 +82,21 @@
    - `:collapse-id` (required) string or keyword, id of controlled collapsible
    - `:on-close` function, invoked when collapsible is toggled hidden. false disables hide control 
    - `:on-open` function, invoked when collapsible is toggled open. false disables open control"
-  [{:keys [on-close on-open] :as action}]
-  (let [hide (not (false? on-close))
-        open (not (false? on-open))]
+  [{:keys [collapsible-id on-close on-open] :as action}]
+  (let [on-close? (not (false? on-close))
+        on-open? (not (false? on-open))
+        state @(rf/subscribe [::expanded collapsible-id])]
     [:div.text-center
-     (cond
-       (and hide open) [atoms/action-link (toggle-action action)]
-       hide [atoms/action-link (hide-action action)]
-       open [atoms/action-link (show-action action)])]))
+     (cond (and on-close? on-open?)
+           [atoms/action-link (toggle-action action)]
+
+           on-close?
+           (when state
+             [atoms/action-link (hide-action action)])
+
+           on-open?
+           (when-not state
+             [atoms/action-link (show-action action)]))]))
 
 (defn info-toggle-control
   "Toggle control that uses simple icon as label.
@@ -162,7 +169,6 @@
   - `:class` optional class for wrapping element
   - `:footer` component displayed always after collapsible area
   - `:id` (required) unique id
-  - `:class` string/keyword/vector, for wrapping element
   - `:group` string, only one collapsible in group can be open at a time
   - `:open?` should the collapsible be initially open?
   - `:title` component or text displayed in title area"


### PR DESCRIPTION
Toggle control renders toggle action when given both on-close and on-open parameters, which passes correct opts to action link automatically. However toggle control also has "dual mode" where either callback can be disabled, so that toggle control acts as either hide or show control. This didn't work correctly because parameter check disregarded current state of the collapsible, unlike toggle action.

Example of buggy behaviour in resource view, where 
- toggle control is displayed in both top and bottom, and
- license view is collapsed if there are more than 5 licenses.

![Screenshot 2024-09-16 at 16 19 26](https://github.com/user-attachments/assets/5d9aad2d-bcbf-416f-8a3c-854f44b0b583)

# Checklist for author

Remove items that aren't applicable, check items that are done.

## Reviewability
- [x] Consider adding screenshots for ease of review

## Follow-up
- [ ] New tasks are created for pending or remaining tasks
