### PR TITLE
fix: failing to create temp file attachments

### DIFF
--- a/src/clj/rems/db/test_data_helpers.clj
+++ b/src/clj/rems/db/test_data_helpers.clj
@@ -21,7 +21,8 @@
             [rems.db.test-data-users :refer [+fake-user-data+]]
             [rems.db.users]
             [rems.db.user-mappings]
-            [rems.testing-util :refer [copy-temp-file with-user]])
+            [rems.testing-util :refer [with-user]]
+            [rems.util :refer [to-bytes]])
   (:import [java.util UUID]))
 
 (defn select-config-langs [m]
@@ -123,13 +124,13 @@
                               {:user-id (or actor "owner")
                                :file {:filename "license-fi.txt"
                                       :content-type "text/plain"
-                                      :tempfile (copy-temp-file "Suomenkielinen lisenssi." "license-fi.txt")}})))
+                                      :tempfile (to-bytes "Suomenkielinen lisenssi.")}})))
         en-attachment (when (:en langs)
                         (:id (rems.service.attachment/create-license-attachment!
                               {:user-id (or actor "owner")
                                :file {:filename "license-en.txt"
                                       :content-type "text/plain"
-                                      :tempfile (copy-temp-file "License in English." "license-en.txt")}})))]
+                                      :tempfile (to-bytes "License in English.")}})))]
     (with-user actor
       (create-license! {:actor actor
                         :license/type :attachment
@@ -333,10 +334,9 @@
     app-id))
 
 (defn create-attachment! [{:keys [actor application-id filename filetype data]}]
-  (let [filename (or filename "attachment.pdf")
-        file {:filename filename
+  (let [file {:filename (or filename "attachment.pdf")
               :content-type (or filetype "application/pdf")
-              :tempfile (copy-temp-file (or data "") filename)}
+              :tempfile (to-bytes (or data ""))}
         attachment (rems.service.attachment/add-application-attachment actor application-id file)]
     (:id attachment)))
 

--- a/src/clj/rems/service/attachment.clj
+++ b/src/clj/rems/service/attachment.clj
@@ -12,7 +12,7 @@
             [rems.db.applications]
             [rems.db.attachments]
             [rems.multipart :refer [scan-for-malware]]
-            [rems.util :refer [file-to-bytes]]
+            [rems.util :refer [to-bytes]]
             [ring.util.http-response :refer :all])
   (:import [java.io ByteArrayInputStream ByteArrayOutputStream]
            [java.util.zip ZipOutputStream ZipEntry ZipException]
@@ -69,7 +69,7 @@
 (defn save-attachment! [{:keys [file user-id application-id]}]
   (check-size file)
   (check-allowed-attachment file)
-  (let [data (file-to-bytes (:tempfile file))]
+  (let [data (to-bytes (:tempfile file))]
     (check-for-malware-if-enabled data)
     {:id (rems.db.attachments/save-attachment! {:data data
                                                 :filename (:filename file)
@@ -81,7 +81,7 @@
 (defn create-license-attachment! [{:keys [file user-id]}]
   (check-size file)
   (check-allowed-attachment file)
-  (let [data (file-to-bytes (:tempfile file))]
+  (let [data (to-bytes (:tempfile file))]
     (check-for-malware-if-enabled data)
     {:id (rems.db.attachments/create-license-attachment! {:data data
                                                           :filename (:filename file)

--- a/test/clj/rems/testing_util.clj
+++ b/test/clj/rems/testing_util.clj
@@ -54,14 +54,6 @@
                                       "test"
                                       (make-array FileAttribute 0))))
 
-(defn copy-temp-file
-  "Copies `file` to new temp directory as `filename`.
-   Useful for copying and renaming a file temporarily for tests."
-  [file filename]
-  (let [f (io/file (create-temp-dir) filename)]
-    (io/copy file f)
-    f))
-
 (defmacro with-user [user & body]
   `(binding [context/*user* (rems.db.users/get-user ~user)
              context/*roles* (set/union (rems.db.roles/get-roles ~user)


### PR DESCRIPTION
relates #2783

Rahti container had issue with creating temp directory, but the test data doesn't really need to write anything into file system; it should be good enough to write file data into byte array.

# Checklist for author

Remove items that aren't applicable, check items that are done.

## Reviewability
- [x] Link to issue

## Testing
- [x] Valuable features are integration / browser / acceptance tested automatically
