### PR TITLE
User simulator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ have notable changes.
 
 Changes since v2.38
 
+### Additions
+- REMS now includes user simulator, which is a developer tool intended for load testing REMS. The initial version is fairly basic and does not have a lot of features, but it can be used to test system performance and stability. See `docs/development.md` for more details.
+
 ### Changes
 - Create license admin page:
   - When creating attachment license, the save button no longer activates until all attachments have been successfully uploaded. (#3292)

--- a/docs/development.md
+++ b/docs/development.md
@@ -205,3 +205,16 @@ lein migratus up 20211105110533
 ```
 
 NB: The migrations can also be written in Clojure. Then you should replace the `.sql` files with a `.edn` file. See examples in the migrations-directory.
+
+## Performance testing
+
+REMS includes `user simulator`, which is a developer tool intended for load testing REMS. Currently the tool is fairly basic and does not have a lot of features, but it can be used to simulate multiple users accessing the system simultaneously. Only fake login users are supported currently.
+
+User simulator works by running concurrent headless browser instances on target REMS instance. Starting the simulator from command line is simple:
+
+```sh
+lein run user-simulator http://localhost:3000/ alice,elsa,frank
+```
+
+This will set local REMS instance as the target and start 3 concurrent browser instances, each logging in as alice, elsa or frank.
+

--- a/src/clj/rems/user_simulator.clj
+++ b/src/clj/rems/user_simulator.clj
@@ -1,0 +1,213 @@
+(ns rems.user-simulator
+  "Namespace for simulating actual user interactions with in REMS, allowing
+   automated testing of user behavior. Simulations run in a headless browser
+   using etaoin with chromedriver, and can be configured via the command line
+   interface (CLI). Various user scenarios are implemented as functions in this
+   namespace, enabling flexible testing of different workflows. Multiple
+   simulations can run concurrently to test system performance and user load.
+   
+   User simulator can be started from CLI with e.g. Leiningen:
+   - `lein run user-simulator` (uses default values), or
+   - `lein run user-simulator http://localhost:3000/ alice,elsa,frank` when replacing default values"
+  (:require [clj-http.client :as http]
+            [clojure.pprint]
+            [clojure.string :as str]
+            [clojure.tools.logging.readable :as logr]
+            [etaoin.api :as et]
+            [mount.core :as mount]
+            [muuntaja.core :as muuntaja]
+            [rems.browser-test-util :as btu]
+            [rems.common.util :refer [rand-nth*]]
+            [rems.config]
+            [rems.concurrency :as concurrency]
+            [rems.json :as json]
+            [rems.logging :refer [with-mdc]]))
+
+
+;;; threadpool
+
+
+(def ^:private thread-pool (atom nil))
+
+(defn- submit-all [& fns]
+  (let [pool (or @thread-pool
+                 (reset! thread-pool (concurrency/cached-thread-pool {:thread-prefix "user-simulator"})))]
+    (concurrency/submit! pool fns)))
+
+(def task-counter (atom 0))
+(def restart-queue (atom []))
+
+(defn create-simulator-task [{:keys [actions url user-id] :as opts}]
+  (logr/info #'create-simulator-task opts)
+  (binding [btu/*test-context* (atom (assoc (btu/create-test-context)
+                                            :url url))
+            btu/screenshot (constantly nil)
+            btu/screenshot-element (constantly nil)
+            btu/check-axe (constantly nil)
+            btu/postmortem-handler (constantly nil)]
+    (bound-fn simulate-user []
+      (try
+        (logr/info "Simulator thread starting")
+        (btu/init-driver! :chrome (btu/get-server-url))
+        (btu/context-assoc! :user-id user-id)
+
+        (while true
+          (Thread/sleep (+ 200 (rand-int 300)))
+
+          (when (btu/running?)
+            (let [action-var (rand-nth actions)
+                  action (var-get action-var)
+                  task-id (swap! task-counter inc)]
+              (btu/context-assoc! :task-id task-id)
+              (with-mdc {:userid user-id
+                         :request-id task-id}
+                (et/delete-cookies (btu/get-driver))
+                (btu/go (btu/get-server-url))
+                (et/refresh (btu/get-driver))
+                (btu/scroll-and-click [{:css ".language-switcher"} {:fn/text "EN"}]) ; make sure language is stable
+                (action)))))
+
+        (catch InterruptedException e
+          (.interrupt (Thread/currentThread))
+          (logr/info e "Simulator thread interrupted"))
+        (catch Throwable t
+          (logr/error t "Internal error" (with-out-str
+                                           (clojure.pprint/pprint (merge {::context @(btu/test-ctx)}
+                                                                         (ex-data t)))))
+          (swap! restart-queue conj opts))
+        (finally
+          (logr/info "Simulator thread shutting down")
+          (some-> (btu/get-driver)
+                  et/stop-driver))))))
+
+
+;;; api utils
+
+
+(defn- parse-transit [x]
+  (muuntaja/decode json/muuntaja "application/transit+json" x))
+
+(defn- join-url [base path]
+  (let [base (cond-> base
+               (str/ends-with? base "/")
+               (subs 0 (dec (count base))))
+        path (cond-> path
+               (str/starts-with? path "/")
+               (subs 1))]
+    (str base "/" path)))
+
+(comment
+  (= "http://localhost:3000/api/applications"
+     (join-url "http://localhost:3000" "api/applications")
+     (join-url "http://localhost:3000" "/api/applications")
+     (join-url "http://localhost:3000/" "api/applications")
+     (join-url "http://localhost:3000/" "/api/applications")))
+
+(defn- api-get [path & [{:keys [api-key user-id]}]]
+  (let [url (join-url (btu/get-server-url) path)
+        response (http/get url {:accept :transit+json
+                                :headers {"x-rems-api-key" (or api-key 42)
+                                          "x-rems-user-id" (or user-id (btu/context-getx :user-id))}})]
+    (parse-transit (:body response))))
+
+(defn- query-my-applications []
+  (let [user-id (btu/context-getx :user-id)]
+    (->> (api-get "/api/applications")
+         (filter #(= user-id (get-in % [:application/applicant :userid])))
+         (mapv :application/id))))
+
+
+;;; etaoin utils
+
+
+(defn login-as [username]
+  (btu/go (btu/get-server-url))
+  (btu/scroll-and-click {:css ".login-btn"})
+  (when (btu/visible? :show-special-users) ; sometimes the user is in the hidden part
+    (btu/scroll-and-click :show-special-users))
+  (btu/scroll-and-click [{:css ".users"} {:tag :a :fn/text username}])
+  (btu/wait-visible :logout))
+
+(defn logout []
+  (btu/scroll-and-click :logout)
+  (btu/wait-visible {:css ".login-component"}))
+
+(defn click-navigation-menu [link-text]
+  (btu/scroll-and-click [:big-navbar {:tag :a :fn/text link-text}]))
+
+(defn go-to-application [application-id]
+  (click-navigation-menu "Applications")
+  (btu/wait-visible {:tag :h1 :fn/text "Applications – REMS"})
+  (btu/wait-page-loaded)
+  (btu/scroll-and-click [:my-applications
+                         {:css (format "tr[data-row='%s'] > td.view a" application-id)}])
+  (btu/wait-page-loaded))
+
+
+;;; simulations
+
+
+(defn user-views-applications
+  "Simulation flow where
+   - user logs in,
+   - user visits random application pages (that user is applying for)
+   - user logs out."
+  []
+  (logr/info "login")
+  (login-as (btu/context-getx :user-id))
+  (loop [n 0]
+    (Thread/sleep 1000)
+    (btu/context-assoc! :my-applications (query-my-applications))
+    (btu/context-assoc! :application-id (rand-nth* (btu/context-getx :my-applications)))
+    (cond
+      (>= n 100)
+      (do (logr/info "logout")
+          (logout))
+
+      (not (btu/context-getx :application-id))
+      (do (logr/warnf "No applications found for user %s" (btu/context-getx :user-id))
+          (recur (inc n)))
+
+      :else
+      (let [start (System/currentTimeMillis)]
+        (logr/infof "> view application %s/%s, id %s" n 100 (btu/context-getx :application-id))
+        (go-to-application (btu/context-getx :application-id))
+        (logr/infof "< view application %s/%s, id %s (%sms)" n 100 (- (System/currentTimeMillis) start) (btu/context-getx :application-id))
+        (recur (inc n))))))
+
+
+;;; core logic
+
+
+(def all-actions [#'user-views-applications])
+
+(defn- queue-simulate-tasks! [opts]
+  (assert (seq (:users opts)) "no users to simulate?")
+  (assert (seq (:actions opts)) "no actions to simulate?")
+  (assert (:url opts) "missing target REMS url")
+  (logr/info 'queue-simulate-tasks :start opts)
+  (submit-all (vec (for [user-id (:users opts)
+                         :let [task-opts {:actions (:actions opts)
+                                          :url (:url opts)
+                                          :user-id user-id}]]
+                     (create-simulator-task task-opts))))
+  (add-watch restart-queue :task-daemon (fn [_key q _old-state new-state]
+                                          (when (seq new-state)
+                                            (submit-all (mapv create-simulator-task new-state))
+                                            (reset! q [])))))
+
+(defn start! [& [{:keys [actions url users]}]]
+  (mount/start #'rems.config/env)
+  (queue-simulate-tasks! {:actions (or (seq actions) all-actions)
+                          :url (or url "http://localhost:3000/")
+                          :users (or (seq users) ["alice" "elsa" "frank"])}))
+
+(defn stop! []
+  (remove-watch restart-queue :task-daemon)
+  (some-> @thread-pool concurrency/shutdown-now!))
+
+(comment
+  (start! {:actions [#'user-views-applications]
+           :url "http://localhost:3000/"
+           :users ["alice" "elsa" "frank"]})
+  (stop!))

--- a/src/cljc/rems/common/util.cljc
+++ b/src/cljc/rems/common/util.cljc
@@ -724,3 +724,9 @@
   "Like `clojure.core/range`, but starts from 1 and `end` is inclusive."
   [end]
   (range 1 (inc end)))
+
+(defn rand-nth*
+  "As (rand-nth), but returns nil if (seq coll) is nil."
+  [coll]
+  (some-> (seq coll)
+          (rand-nth)))

--- a/test/clj/rems/api/testing.clj
+++ b/test/clj/rems/api/testing.clj
@@ -11,7 +11,6 @@
             [rems.handler :refer :all]
             [rems.locales]
             [rems.middleware]
-            [rems.main]
             [ring.mock.request :refer :all]
             [rems.json :as json]))
 

--- a/test/clj/rems/browser_test_util.clj
+++ b/test/clj/rems/browser_test_util.clj
@@ -29,47 +29,58 @@
 
 ;;; test setup
 
-(defonce test-context
-  (atom {:url "http://localhost:3001/"
-         :mode :test
-         :seed "circle"
-         :reporting-dir (io/file "browsertest-errors")
-         :accessibility-report-dir (io/file "browsertest-accessibility-report")
-         :download-dir (io/file "browsertest-downloads")}))
+(defn create-test-context []
+  {:url "http://localhost:3001/"
+   :mode :test
+   :seed "circle"
+   :reporting-dir (io/file "browsertest-errors")
+   :accessibility-report-dir (io/file "browsertest-accessibility-report")
+   :download-dir (io/file "browsertest-downloads")})
 
-(defn get-driver [] (:driver @test-context))
-(defn get-server-url [] (:url @test-context))
-(defn get-seed [] (:seed @test-context))
+(defonce global-test-context (atom (create-test-context)))
+
+(def ^:dynamic *test-context*)
+
+(defn test-ctx
+  ([] (if (bound? #'rems.browser-test-util/*test-context*)
+        *test-context*
+        global-test-context))
+  ([& ks]
+   (get-in @(test-ctx) ks)))
+
+(defn get-driver [] (test-ctx :driver))
+(defn get-server-url [] (test-ctx :url))
+(defn get-seed [] (test-ctx :seed))
 
 ;; test data uses separate key path to avoid conflicts with configuration data
 
-(defn reset-context! [] (swap! test-context dissoc :test-data))
+(defn reset-context! [] (swap! (test-ctx) dissoc :test-data))
 
-(defn context-get [k] (get (:test-data @test-context) k))
-(defn context-getx [k] (getx (:test-data @test-context) k))
-(defn context-update! [& args] (apply swap! test-context update :test-data args))
+(defn context-get [k] (test-ctx :test-data k))
+(defn context-getx [k] (getx (test-ctx :test-data) k))
+(defn context-update! [& args] (apply swap! (test-ctx) update :test-data args))
 (defn context-assoc! [& args] (apply context-update! assoc args))
 (defn context-dissoc! [& args] (apply context-update! dissoc args))
 
 (defn- ensure-empty-directories! []
-  (ensure-empty-directory! (:reporting-dir @test-context))
-  (ensure-empty-directory! (:accessibility-report-dir @test-context))
-  (ensure-empty-directory! (:download-dir @test-context)))
+  (ensure-empty-directory! (test-ctx :reporting-dir))
+  (ensure-empty-directory! (test-ctx :accessibility-report-dir))
+  (ensure-empty-directory! (test-ctx :download-dir)))
 
 (defn downloaded-files
-  ([] (for [file (.listFiles (:download-dir @test-context))]
+  ([] (for [file (.listFiles (test-ctx :download-dir))]
         file))
   ([name-or-regex] (if (string? name-or-regex)
-                     (let [f (io/file (:download-dir @test-context) name-or-regex)]
+                     (let [f (io/file (test-ctx :download-dir) name-or-regex)]
                        (when (.exists f) [f]))
-                     (for [file (.listFiles (:download-dir @test-context))
+                     (for [file (.listFiles (test-ctx :download-dir))
                            :when (re-matches name-or-regex (.getName file))]
                        file))))
 
 (defn delete-downloaded-files! [name-or-regex]
   (let [files (if (string? name-or-regex)
-                [(io/file (:download-dir @test-context) name-or-regex)]
-                (for [file (.listFiles (:download-dir @test-context))
+                [(io/file (test-ctx :download-dir) name-or-regex)]
+                (for [file (.listFiles (test-ctx :download-dir))
                       :when (re-matches name-or-regex (.getName file))]
                   file))]
     (doseq [file files]
@@ -92,7 +103,7 @@
                :path [:session (:session driver) "chromium/send_command"]
                :data {:cmd "Page.setDownloadBehavior"
                       :params {:behavior "allow"
-                               :downloadPath (.getAbsolutePath (:download-dir @test-context))}}}))
+                               :downloadPath (.getAbsolutePath (test-ctx :download-dir))}}}))
 
 (defn- reset-window-size!
   "Sets window size big enough to show the whole page in the screenshots."
@@ -117,7 +128,7 @@
                          (get (System/getenv) "HEADLESS"))
         dev? (= :development mode)]
     (assoc driver-defaults
-           :download-dir (.getAbsolutePath (:download-dir @test-context))
+           :download-dir (.getAbsolutePath (test-ctx :download-dir))
            :headless (cond
                        non-headless? false
                        dev? false
@@ -137,7 +148,7 @@
     (try
       (et/quit (get-driver))
       (catch Exception e)))
-  (swap! test-context
+  (swap! (test-ctx)
          assoc-some
          :driver (et/with-wait-timeout 60
                    (-> browser-id
@@ -151,7 +162,7 @@
   "Executes a test running a fresh driver except when in development."
   [f]
   (letfn [(run []
-            (when-not (= :development (:mode @test-context))
+            (when-not (= :development (test-ctx :mode))
               (init-driver! :chrome))
             (f))]
     (try
@@ -280,7 +291,7 @@
   run them for real, we use an existing server and db or
   boot everything up and recreate test data too."
   [f]
-  (if (= :development (:mode @test-context))
+  (if (= :development (test-ctx :mode))
     (f)
     ((compose-fixtures standalone-fixture create-test-data) f)))
 
@@ -289,7 +300,7 @@
   (f))
 
 (defn- get-sequence-number []
-  (:sequence-number (swap! test-context update :sequence-number (fnil inc 0))))
+  (:sequence-number (swap! (test-ctx) update :sequence-number (fnil inc 0))))
 
 ;;; etaoin exported
 
@@ -320,7 +331,7 @@
   (let [driver (get-driver)
         _ (wait-for-idle driver 500)
         full-filename (str (get-file-base) filename ".png")
-        file (io/file (:reporting-dir @test-context) full-filename)
+        file (io/file (test-ctx :reporting-dir) full-filename)
 
         window-size (et/get-window-rect driver)
         empty-space (if (et/exists? driver :empty-space) ; if page has not rendered, screenshot can fail due to missing element
@@ -349,7 +360,7 @@
                               (get-sequence-number)
                               (get-current-test-name)
                               filename)
-        file (io/file (:reporting-dir @test-context) full-filename)]
+        file (io/file (test-ctx :reporting-dir) full-filename)]
     (et/screenshot-element (get-driver)
                            q
                            file)))
@@ -366,7 +377,7 @@
                                 (get-current-test-name)
                                 filename
                                 ".txt")
-          file (io/file (:reporting-dir @test-context) full-filename)]
+          file (io/file (test-ctx :reporting-dir) full-filename)]
       (spit file (json/generate-string-pretty content)))))
 
 (defn wait-predicate [pred & [explainer]]
@@ -614,7 +625,7 @@
         (doseq [[target original] originals]
           (when original
             (js-execute (str "var x = document.querySelector('" target "'); if (x && x.style) x.style.outline = \"" original "\";"))))))
-    (swap! test-context update :axe conj-vec results)))
+    (swap! (test-ctx) update :axe conj-vec results)))
 
 (defn accessibility-report-fixture
   "Runs the tests and finally stores the gathered accessibility
@@ -623,20 +634,20 @@
   NB: the individual tests must call `gather-axe-results` in each
   interesting spot to have a sensible report to write."
   [f]
-  (swap! test-context dissoc :axe)
+  (swap! (test-ctx) dissoc :axe)
   (try
     (f)
     (finally
       (let [violations (atom nil)]
-        (doseq [k (->> (:axe @test-context)
+        (doseq [k (->> (test-ctx :axe)
                        (mapcat keys)
                        distinct)
                 :let [filename (str (str/lower-case (name k)) ".json")
-                      content (->> (:axe @test-context)
+                      content (->> (test-ctx :axe)
                                    (mapcat #(get % k))
                                    distinct
                                    (sort-by :impact))]]
-          (spit (io/file (:accessibility-report-dir @test-context) filename)
+          (spit (io/file (test-ctx :accessibility-report-dir) filename)
                 (json/generate-string-pretty content))
           (when (and (= :violations k) (seq content))
             (reset! violations content)))
@@ -660,7 +671,7 @@
   "Simplified version of `etaoin.api/postmortem-handler`"
   [ex]
   (let [driver (get-driver)
-        dir (:reporting-dir @test-context)]
+        dir (test-ctx :reporting-dir)]
 
     (io/make-parents dir)
 

--- a/test/clj/rems/test_browser.clj
+++ b/test/clj/rems/test_browser.clj
@@ -29,7 +29,6 @@
             [rems.db.test-data-helpers :as test-helpers]
             [rems.db.testing :refer [save-cache-statistics!]]
             [rems.db.user-settings]
-            [rems.main]
             [rems.testing-util :refer [with-user with-fake-login-users]]
             [rems.text :refer [localize-time text with-language]]))
 


### PR DESCRIPTION
Implements simple tool that generates user traffic to target REMS.

Creates headless browser for each simulated user, who login and proceed to navigate into random applications (that belong to the user). Thread daemon attempts to keep all users working, in case the webdriver crashes or something surprising happens.

Some limitations:
- only supports fake login users at the time
- fixed user actions (viewing random application)
- no load test statistics
- no burst traffic

# Checklist for author

Remove items that aren't applicable, check items that are done.

## Documentation
- [x] Update changelog if necessary
- [x] Update docs/ (if applicable)
