### PR TITLE
Fixes for blacklist

### DIFF
--- a/src/clj/rems/application/events_cache.clj
+++ b/src/clj/rems/application/events_cache.clj
@@ -38,7 +38,7 @@
 (defn update-cache!
   "Updates the cache with any update.
    `update-fn` should be a function which takes as parameters the previously
-   cached state and a list of new events, and returns the updated state."
+   cached state, and returns the updated state."
   [cache update-fn]
   (let [cache-enabled? (atom? cache)
         cached (if cache-enabled? @cache empty-cache)

--- a/src/clj/rems/db/applications.clj
+++ b/src/clj/rems/db/applications.clj
@@ -386,11 +386,12 @@
     (let [apps (refresh-all-applications-cache!)
           app-ids (->> by-userids
                        (mapcat (fn [by-userid]
-                                 (->> (get-in apps [:state ::app-ids-by-user by-userid])
+                                 (->> (get-in apps [::app-ids-by-user by-userid])
                                       (mapv :application/id))))
                        distinct)]
       (log/info "Reloading" (count app-ids) "applications because of user changes")
-      (update-in-all-applications-cache! app-ids)))
+      (when (seq app-ids)
+        (update-in-all-applications-cache! app-ids))))
 
   (when (seq by-workflow-ids)
     (let [apps (refresh-all-applications-cache!)
@@ -400,7 +401,8 @@
                        (filter (comp wf-ids :workflow/id :application/workflow))
                        (mapv :application/id))]
       (log/info "Reloading" (count app-ids) "applications because of workflow changes")
-      (update-in-all-applications-cache! app-ids)))
+      (when (seq app-ids)
+        (update-in-all-applications-cache! app-ids))))
 
   nil)
 

--- a/src/clj/rems/db/blacklist.clj
+++ b/src/clj/rems/db/blacklist.clj
@@ -53,6 +53,7 @@
 
 (defn get-events [& [params]]
   (->> (vals (cache/entries! blacklist-event-cache))
+       (sort-by :event/id)
        (apply-filters params)))
 
 (defn add-event! [event]

--- a/src/clj/rems/db/blacklist.clj
+++ b/src/clj/rems/db/blacklist.clj
@@ -49,11 +49,11 @@
                 :reload-fn (fn []
                              (->> (db/get-blacklist-events)
                                   (build-index {:keys [:event/id]
-                                                :value-fn parse-blacklist-event-raw})))}))
+                                                :value-fn parse-blacklist-event-raw})
+                                  (into (sorted-map))))}))
 
 (defn get-events [& [params]]
   (->> (vals (cache/entries! blacklist-event-cache))
-       (sort-by :event/id)
        (apply-filters params)))
 
 (defn add-event! [event]

--- a/test/clj/rems/api/test_blacklist.clj
+++ b/test/clj/rems/api/test_blacklist.clj
@@ -1,11 +1,12 @@
 (ns ^:integration rems.api.test-blacklist
-  (:require [clojure.test :refer :all]
-            [rems.api.testing :refer :all]
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [clojure.tools.logging.test :as log-test]
+            [rems.api.testing :refer [api-fixture assert-response-is-ok assert-response-is-unprocessable-entity authenticate read-ok-body]]
             [rems.db.api-key]
             [rems.db.applications]
             [rems.db.test-data-helpers :as test-helpers]
             [rems.handler :refer [handler]]
-            [ring.mock.request :refer :all])
+            [ring.mock.request :refer [json-body request]])
   (:import [org.joda.time DateTimeUtils]))
 
 (use-fixtures
@@ -72,15 +73,21 @@
       (is (= []
              (:application/blacklist (get-app)))))
     (testing "add three entries"
-      (assert-add-ok! {:blacklist/user {:userid "user1"}
-                       :blacklist/resource {:resource/ext-id "A"}
-                       :comment "bad"})
-      (assert-add-ok! {:blacklist/user {:userid "user1-alt-id"}
-                       :blacklist/resource {:resource/ext-id "B"}
-                       :comment "quite bad"})
-      (assert-add-ok! {:blacklist/user {:userid "user2"}
-                       :blacklist/resource {:resource/ext-id "B"}
-                       :comment "very bad"})
+      (log-test/with-log
+        (assert-add-ok! {:blacklist/user {:userid "user1"}
+                         :blacklist/resource {:resource/ext-id "A"}
+                         :comment "bad"})
+        (is (log-test/logged? "rems.db.applications" :info "Reloading 0 applications because of user changes")))
+      (log-test/with-log
+        (assert-add-ok! {:blacklist/user {:userid "user1-alt-id"}
+                         :blacklist/resource {:resource/ext-id "B"}
+                         :comment "quite bad"})
+        (is (log-test/logged? "rems.db.applications" :info "Reloading 0 applications because of user changes")))
+      (log-test/with-log
+        (assert-add-ok! {:blacklist/user {:userid "user2"}
+                         :blacklist/resource {:resource/ext-id "B"}
+                         :comment "very bad"})
+        (is (log-test/logged? "rems.db.applications" :info "Reloading 1 applications because of user changes")))
       (is (= [{:blacklist/resource {:resource/ext-id "A"}
                :blacklist/user {:userid "user1" :name nil :email nil}
                :blacklist/added-by {:userid "owner" :name "Owner" :email "owner@example.com"}
@@ -118,9 +125,11 @@
       (is (= [{:resource/ext-id "B" :userid "user2"}]
              (simplify (fetch {:resource "B" :user "user2"})))))
     (testing "remove entry"
-      (assert-remove-ok! {:blacklist/user {:userid "user2"}
-                          :blacklist/resource {:resource/ext-id "B"}
-                          :comment "oops"})
+      (log-test/with-log
+        (assert-remove-ok! {:blacklist/user {:userid "user2"}
+                            :blacklist/resource {:resource/ext-id "B"}
+                            :comment "oops"})
+        (is (log-test/logged? "rems.db.applications" :info "Reloading 1 applications because of user changes")))
       (is (= []
              (fetch {:resource "B" :user "user2"}))))
     (testing "application is updated when user is removed from blacklist"
@@ -133,9 +142,11 @@
       (is (= [{:resource/ext-id "B" :userid "user2"}]
              (simplify (fetch {:resource "B" :user "user2"})))))
     (testing "remove nonexistent entry"
-      (assert-remove-ok! {:blacklist/user {:userid "user3"}
-                          :blacklist/resource {:resource/ext-id "C"}
-                          :comment "undo"})
+      (log-test/with-log
+        (assert-remove-ok! {:blacklist/user {:userid "user3"}
+                            :blacklist/resource {:resource/ext-id "C"}
+                            :comment "undo"})
+        (is (log-test/logged? "rems.db.applications" :info "Reloading 0 applications because of user changes")))
       (is (= [{:resource/ext-id "A" :userid "user1"}
               {:resource/ext-id "B" :userid "user1"}
               {:resource/ext-id "B" :userid "user2"}]
@@ -145,19 +156,27 @@
         (is (= [{:resource/ext-id "A" :userid "user1"}
                 {:resource/ext-id "B" :userid "user1"}
                 {:resource/ext-id "B" :userid "user2"}] blacklist))
-        (assert-add-unprocessable-entity! {:blacklist/user {:userid "definitely-not-found"}
-                                           :blacklist/resource {:resource/ext-id "A"}
-                                           :comment "not found"})
-        (is (= blacklist (simplify (fetch {}))))
-        (assert-add-unprocessable-entity! {:blacklist/user {:userid "user1"}
-                                           :blacklist/resource {:resource/ext-id "definitely-not-found"}
-                                           :comment "not found"})
-        (is (= blacklist (simplify (fetch {}))))
-        (assert-remove-unprocessable-entity! {:blacklist/user {:userid "definitely-not-found"}
-                                              :blacklist/resource {:resource/ext-id "B"}
-                                              :comment "not found"})
-        (is (= blacklist (simplify (fetch {}))))
-        (assert-remove-unprocessable-entity! {:blacklist/user {:userid "user2"}
-                                              :blacklist/resource {:resource/ext-id "definitely-not-found"}
-                                              :comment "not found"})
-        (is (= blacklist (simplify (fetch {}))))))))
+
+        (log-test/with-log
+          (assert-add-unprocessable-entity! {:blacklist/user {:userid "definitely-not-found"}
+                                             :blacklist/resource {:resource/ext-id "A"}
+                                             :comment "not found"})
+          (is (= blacklist (simplify (fetch {}))))
+
+          (assert-add-unprocessable-entity! {:blacklist/user {:userid "user1"}
+                                             :blacklist/resource {:resource/ext-id "definitely-not-found"}
+                                             :comment "not found"})
+          (is (= blacklist (simplify (fetch {}))))
+
+          (assert-remove-unprocessable-entity! {:blacklist/user {:userid "definitely-not-found"}
+                                                :blacklist/resource {:resource/ext-id "B"}
+                                                :comment "not found"})
+          (is (= blacklist (simplify (fetch {}))))
+
+          (assert-remove-unprocessable-entity! {:blacklist/user {:userid "user2"}
+                                                :blacklist/resource {:resource/ext-id "definitely-not-found"}
+                                                :comment "not found"})
+          (is (= blacklist (simplify (fetch {}))))
+
+          (is (not (log-test/logged? "rems.db.applications" :info #"Reloading"))
+              "application reloading should not be triggered"))))))


### PR DESCRIPTION
Fixes erratic behaviour in blacklist and subsequent applications reloading.

- Blacklist events are now sorted before event reducer. 
  - Previous behaviour caused events to be processed in semi-random order after generating enough events (>=10 or so).
- Blacklisting now correctly handles application cache update. 
  - Previously applications reload never occurred, because the code used wrong cache path for user-ids.

# Checklist for author

Remove items that aren't applicable, check items that are done.

## Reviewability
- [ ] Link to issue (no issue)

## Documentation
- [ ] Update changelog if necessary (fixes issue in unreleased feature)

## Testing
- [x] Complex logic is unit tested
