### PR TITLE
Admin UI fixes

### DIFF
--- a/src/cljs/rems/administration/blacklist.cljs
+++ b/src/cljs/rems/administration/blacklist.cljs
@@ -45,7 +45,7 @@
                        :top
                        description
                        (fn []
-                         (rf/dispatch [::fetch-blacklist])
+                         (rf/dispatch [::fetch-blacklist {:resource (:resource/ext-id resource)}])
                          (rf/dispatch [::set-validation-errors nil])
                          (rf/dispatch [::set-selected-user nil])
                          (rf/dispatch [::set-comment nil])))
@@ -63,7 +63,7 @@
              :handler (flash-message/default-success-handler
                        :top
                        description
-                       #(rf/dispatch [::fetch-blacklist]))
+                       #(rf/dispatch [::fetch-blacklist {:resource (:resource/ext-id resource)}]))
              :error-handler (flash-message/default-error-handler :top description)}))
    {}))
 

--- a/src/cljs/rems/administration/catalogue_item.cljs
+++ b/src/cljs/rems/administration/catalogue_item.cljs
@@ -2,7 +2,7 @@
   (:require [clojure.string :as str]
             [re-frame.core :as rf]
             [rems.administration.administration :as administration]
-            [rems.administration.components :refer [inline-info-field]]
+            [rems.administration.components :refer [inline-info-field perform-action-button]]
             [rems.administration.status-flags :as status-flags]
             [rems.atoms :as atoms :refer [document-title readonly-checkbox]]
             [rems.collapsible :as collapsible]
@@ -47,6 +47,16 @@
   [atoms/link {:class "btn btn-primary"}
    "/administration/categories"
    (text :t.administration/manage-categories)])
+
+(defn- toggle-enabled [catalogue-item]
+  (status-flags/enabled-toggle-action
+   {:on-change #(rf/dispatch [:rems.administration.catalogue-items/set-catalogue-item-enabled %1 %2 [::enter-page (:id catalogue-item)]])}
+   catalogue-item))
+
+(defn- toggle-archived [catalogue-item]
+  (status-flags/archived-toggle-action
+   {:on-change #(rf/dispatch [:rems.administration.catalogue-items/set-catalogue-item-archived %1 %2 [::enter-page (:id catalogue-item)]])}
+   catalogue-item))
 
 (defn catalogue-item-view [catalogue-item]
   [:div.spaced-vertically-3
@@ -96,8 +106,8 @@
       [administration/back-button "/administration/catalogue-items"]
       [roles/show-when roles/+admin-write-roles+
        [edit-button id]
-       [status-flags/enabled-toggle catalogue-item #(rf/dispatch [:rems.administration.catalogue-items/set-catalogue-item-enabled %1 %2 [::enter-page id]])]
-       [status-flags/archived-toggle catalogue-item #(rf/dispatch [:rems.administration.catalogue-items/set-catalogue-item-archived %1 %2 [::enter-page id]])]]
+       [perform-action-button (toggle-enabled catalogue-item)]
+       [perform-action-button (toggle-archived catalogue-item)]]
       [manage-categories-button]])])
 
 (defn catalogue-item-page []

--- a/src/cljs/rems/administration/category.cljs
+++ b/src/cljs/rems/administration/category.cljs
@@ -1,7 +1,7 @@
 (ns rems.administration.category
   (:require [re-frame.core :as rf]
             [rems.administration.administration :as administration]
-            [rems.administration.components :refer [inline-info-field localized-info-field]]
+            [rems.administration.components :refer [inline-info-field localized-info-field perform-action-button]]
             [rems.atoms :as atoms :refer [document-title]]
             [rems.collapsible :as collapsible]
             [rems.flash-message :as flash-message]
@@ -56,12 +56,11 @@
    (str "/administration/categories/edit/" category-id)
    (text :t.administration/edit)])
 
-(defn- delete-category-button []
-  [:button#delete.btn.btn-primary
-   {:type :button
+(defn- delete-action []
+  (atoms/delete-action
+   {:id :delete
     :on-click #(when (js/confirm (text :t.administration/delete-confirmation))
-                 (rf/dispatch [::delete-category]))}
-   (text :t.administration/delete)])
+                 (rf/dispatch [::delete-category]))}))
 
 (defn category-view []
   (let [category (rf/subscribe [::category])]
@@ -81,7 +80,7 @@
      [:div.col.commands
       [administration/back-button "/administration/categories"]
       [roles/show-when roles/+admin-write-roles+
-       [delete-category-button]
+       [perform-action-button (delete-action)]
        [to-edit-category (:category/id @category)]]]]))
 
 (defn category-page []

--- a/src/cljs/rems/administration/components.cljs
+++ b/src/cljs/rems/administration/components.cljs
@@ -23,8 +23,9 @@
             [rems.fields :as fields]
             [rems.globals]
             [rems.common.roles :as roles]
-            [rems.common.util :refer [andstr clamp parse-int]]
+            [rems.common.util :refer [clamp parse-int]]
             [rems.text :refer [localized text text-format]]
+            [rems.spinner]
             [rems.util :refer [event-checked event-value]]))
 
 (defn- key-to-id [key]
@@ -370,8 +371,17 @@
                                             on-change)}]
      [field-validation-message error label]]))
 
-(defn perform-action-button [{:keys [loading?] :as props}]
-  [atoms/rate-limited-button
-   (-> props
-       (dissoc (when (or loading? @(rf/subscribe [:rems.app/any-pending-request?]))
-                 :on-click)))])
+(defn perform-action-button [{:keys [class disabled id label loading? on-click] :as action}]
+  (let [loading? (if (some? loading?)
+                   loading?
+                   @(rf/subscribe [:rems.app/any-pending-request?]))
+        label (or label (:text action))]
+    [atoms/rate-limited-action-button
+     {:class class
+      :disabled disabled
+      :id id
+      :label (if loading?
+               [:span.d-flex.align-items-center.gap-1 label [rems.spinner/small]]
+               label)
+      :on-click (when-not loading?
+                  on-click)}]))

--- a/src/cljs/rems/administration/create_catalogue_item.cljs
+++ b/src/cljs/rems/administration/create_catalogue_item.cljs
@@ -3,7 +3,7 @@
             [medley.core :refer [find-first map-vals]]
             [re-frame.core :as rf]
             [rems.administration.administration :as administration]
-            [rems.administration.components :refer [localized-text-field organization-field]]
+            [rems.administration.components :refer [localized-text-field organization-field perform-action-button]]
             [rems.atoms :as atoms :refer [document-title]]
             [rems.collapsible :as collapsible]
             [rems.common.util :refer [andstr]]
@@ -284,18 +284,18 @@
      "/administration/catalogue-items")
    (text :t.administration/cancel)])
 
-(defn- save-catalogue-item-button [form editing?]
-  (let [request (build-request form)]
-    [:button.btn.btn-primary
-     {:type :button
-      :id :save
-      :on-click (fn []
-                  (rf/dispatch [:rems.app/user-triggered-navigation])
-                  (if editing?
-                    (rf/dispatch [::edit-catalogue-item request])
-                    (rf/dispatch [::create-catalogue-item request])))
-      :disabled (nil? request)}
-     (text :t.administration/save)]))
+(defn- save-catalogue-item [form]
+  (let [request (build-request form)
+        editing? @(rf/subscribe [::editing?])]
+    (atoms/save-action
+     {:id :save
+      :on-click (when request
+                  (fn []
+                    (rf/dispatch [:rems.app/user-triggered-navigation])
+                    (if editing?
+                      (rf/dispatch [::edit-catalogue-item request])
+                      (rf/dispatch [::create-catalogue-item request]))))
+      :disabled (nil? request)})))
 
 (defn create-catalogue-item-page []
   (let [editing? @(rf/subscribe [::editing?])
@@ -327,4 +327,4 @@
 
                    [:div.col.commands
                     [cancel-button catalogue-item-id]
-                    [save-catalogue-item-button form editing?]]])]}]]))
+                    [perform-action-button (save-catalogue-item form)]]])]}]]))

--- a/src/cljs/rems/administration/create_catalogue_item.cljs
+++ b/src/cljs/rems/administration/create_catalogue_item.cljs
@@ -290,11 +290,9 @@
     (atoms/save-action
      {:id :save
       :on-click (when request
-                  (fn []
-                    (rf/dispatch [:rems.app/user-triggered-navigation])
-                    (if editing?
-                      (rf/dispatch [::edit-catalogue-item request])
-                      (rf/dispatch [::create-catalogue-item request]))))
+                  (if editing?
+                    #(rf/dispatch [::edit-catalogue-item request])
+                    #(rf/dispatch [::create-catalogue-item request])))
       :disabled (nil? request)})))
 
 (defn create-catalogue-item-page []

--- a/src/cljs/rems/administration/create_category.cljs
+++ b/src/cljs/rems/administration/create_category.cljs
@@ -3,7 +3,7 @@
             [re-frame.core :as rf]
             [medley.core :refer [assoc-some]]
             [rems.administration.administration :as administration]
-            [rems.administration.components :refer [localized-text-field number-field]]
+            [rems.administration.components :refer [localized-text-field perform-action-button number-field]]
             [rems.atoms :as atoms :refer [document-title]]
             [rems.collapsible :as collapsible]
             [rems.config]
@@ -104,15 +104,15 @@
        :clearable? true
        :on-change #(rf/dispatch [::set-selected-categories %])}]]))
 
-(defn- save-category-button [form]
+(defn- save-category [form]
   (let [request (build-request form)]
-    [:button#save.btn.btn-primary
-     {:type :button
-      :on-click (fn []
-                  (rf/dispatch [:rems.app/user-triggered-navigation])
-                  (rf/dispatch [::create-category request]))
-      :disabled (nil? request)}
-     (text :t.administration/save)]))
+    (atoms/save-action
+     {:id :save
+      :on-click (when request
+                  (fn []
+                    (rf/dispatch [:rems.app/user-triggered-navigation])
+                    (rf/dispatch [::create-category request])))
+      :disabled (nil? request)})))
 
 (defn- cancel-button []
   [atoms/link {:class "btn btn-secondary"}
@@ -140,4 +140,4 @@
 
                    [:div.col.commands
                     [cancel-button]
-                    [save-category-button form]]])]}]]))
+                    [perform-action-button (save-category form)]]])]}]]))

--- a/src/cljs/rems/administration/create_category.cljs
+++ b/src/cljs/rems/administration/create_category.cljs
@@ -109,9 +109,7 @@
     (atoms/save-action
      {:id :save
       :on-click (when request
-                  (fn []
-                    (rf/dispatch [:rems.app/user-triggered-navigation])
-                    (rf/dispatch [::create-category request])))
+                  #(rf/dispatch [::create-category request]))
       :disabled (nil? request)})))
 
 (defn- cancel-button []

--- a/src/cljs/rems/administration/create_form.cljs
+++ b/src/cljs/rems/administration/create_form.cljs
@@ -19,7 +19,7 @@
             [reagent.format :as rfmt]
             [reagent.ratom :as ra]
             [rems.administration.administration :as administration]
-            [rems.administration.components :refer [checkbox field-validation-message localized-text-field organization-field radio-button-group text-field text-field-inline update-form]]
+            [rems.administration.components :refer [checkbox field-validation-message localized-text-field organization-field perform-action-button radio-button-group text-field text-field-inline update-form]]
             [rems.administration.items :as items]
             [rems.atoms :as atoms :refer [document-title]]
             [rems.collapsible :as collapsible]
@@ -758,9 +758,9 @@
   (atoms/cancel-action
    {:url (str "/administration/forms" (andstr "/" @(rf/subscribe [::form-id])))}))
 
-(defn- save-form-action []
+(defn- save-form []
   (let [editing? @(rf/subscribe [::edit-form?])
-        always-on-save #(rf/dispatch [:rems.spa/user-triggered-navigation])] ; scroll to top
+        always-on-save #(rf/dispatch [:rems.spa/user-triggered-navigation])]
     (atoms/save-action
      {:id :save
       :on-click (if editing?
@@ -782,7 +782,7 @@
                [form-fields]
                [:div.col.commands
                 [atoms/action-button (cancel-action)]
-                [atoms/rate-limited-action-button (save-form-action)]]]}]]
+                [perform-action-button (save-form)]]]}]]
    [:div.col-lg [form-preview]]])
 
 (defn create-form-page []

--- a/src/cljs/rems/administration/create_form.cljs
+++ b/src/cljs/rems/administration/create_form.cljs
@@ -759,13 +759,12 @@
    {:url (str "/administration/forms" (andstr "/" @(rf/subscribe [::form-id])))}))
 
 (defn- save-form []
-  (let [editing? @(rf/subscribe [::edit-form?])
-        always-on-save #(rf/dispatch [:rems.spa/user-triggered-navigation])]
+  (let [editing? @(rf/subscribe [::edit-form?])]
     (atoms/save-action
      {:id :save
       :on-click (if editing?
-                  (comp #(rf/dispatch [::edit-form]) always-on-save)
-                  (comp #(rf/dispatch [::create-form]) always-on-save))})))
+                  #(rf/dispatch [::edit-form])
+                  #(rf/dispatch [::create-form]))})))
 
 (defn- form-page-wrapper []
   @use-autoscroll

--- a/src/cljs/rems/administration/create_license.cljs
+++ b/src/cljs/rems/administration/create_license.cljs
@@ -2,7 +2,7 @@
   (:require [clojure.string :as str]
             [re-frame.core :as rf]
             [rems.administration.administration :as administration]
-            [rems.administration.components :refer [localized-text-field localized-textarea-autosize organization-field radio-button-group]]
+            [rems.administration.components :refer [localized-text-field localized-textarea-autosize organization-field perform-action-button radio-button-group]]
             [rems.atoms :as atoms :refer [document-title failure-symbol file-download]]
             [rems.collapsible :as collapsible]
             [rems.common.atoms :refer [nbsp]]
@@ -199,17 +199,15 @@
                :error [failure-symbol]
                nil)]]])))
 
-(defn- save-license-button [on-click]
-  (let [form @(rf/subscribe [::form])
-        languages @rems.config/languages
-        request (build-request form languages)]
-    [:button#save.btn.btn-primary
-     {:type :button
-      :on-click (fn []
-                  (rf/dispatch [:rems.app/user-triggered-navigation])
-                  (on-click request))
-      :disabled (nil? request)}
-     (text :t.administration/save)]))
+(defn- save-license []
+  (let [request (build-request @(rf/subscribe [::form])
+                               @rems.config/languages)]
+    (atoms/save-action {:id :save
+                        :disabled (nil? request)
+                        :on-click (when request
+                                    (fn []
+                                      (rf/dispatch [:rems.app/user-triggered-navigation])
+                                      (rf/dispatch [::create-license request])))})))
 
 (defn- cancel-button []
   [atoms/link {:class "btn btn-secondary"}
@@ -236,5 +234,5 @@
                   nil)
                 [:div.col.commands
                  [cancel-button]
-                 [save-license-button #(rf/dispatch [::create-license %])]]]}]]))
+                 [perform-action-button (save-license)]]]}]]))
 

--- a/src/cljs/rems/administration/create_license.cljs
+++ b/src/cljs/rems/administration/create_license.cljs
@@ -205,9 +205,7 @@
     (atoms/save-action {:id :save
                         :disabled (nil? request)
                         :on-click (when request
-                                    (fn []
-                                      (rf/dispatch [:rems.app/user-triggered-navigation])
-                                      (rf/dispatch [::create-license request])))})))
+                                    #(rf/dispatch [::create-license request]))})))
 
 (defn- cancel-button []
   [atoms/link {:class "btn btn-secondary"}

--- a/src/cljs/rems/administration/create_organization.cljs
+++ b/src/cljs/rems/administration/create_organization.cljs
@@ -160,11 +160,9 @@
     (atoms/save-action {:id :save
                         :disabled (nil? request)
                         :on-click (when request
-                                    (fn []
-                                      (rf/dispatch [:rems.app/user-triggered-navigation])
-                                      (if id
-                                        (rf/dispatch [::edit-organization request])
-                                        (rf/dispatch [::create-organization request]))))})))
+                                    (if id
+                                      #(rf/dispatch [::edit-organization request])
+                                      #(rf/dispatch [::create-organization request])))})))
 
 (defn- cancel-button []
   [atoms/link {:class "btn btn-secondary"}

--- a/src/cljs/rems/administration/create_organization.cljs
+++ b/src/cljs/rems/administration/create_organization.cljs
@@ -3,7 +3,7 @@
             [medley.core :refer [indexed map-vals remove-nth]]
             [re-frame.core :as rf]
             [rems.administration.administration :as administration]
-            [rems.administration.components :refer [localized-text-field text-field]]
+            [rems.administration.components :refer [localized-text-field perform-action-button text-field]]
             [rems.administration.items :as items]
             [rems.atoms :as atoms :refer [enrich-user document-title]]
             [rems.common.util :refer [+email-regex+ conj-vec]]
@@ -14,7 +14,7 @@
             [rems.flash-message :as flash-message]
             [rems.spinner :as spinner]
             [rems.text :refer [text text-format]]
-            [rems.util :refer [fetch navigate! post! put! trim-when-string]]))
+            [rems.util :refer [navigate! post! put! trim-when-string]]))
 
 (rf/reg-event-fx
  ::enter-page
@@ -150,23 +150,21 @@
   [localized-text-field context {:keys [:organization/name]
                                  :label (text :t.administration/title)}])
 
-(defn- save-organization-button []
+(defn- save-organization []
   (let [form @(rf/subscribe [::form])
         id @(rf/subscribe [::organization-id])
         languages @rems.config/languages
         request (if id
                   (build-edit-request id form languages)
                   (build-create-request form languages))]
-    [:button.btn.btn-primary
-     {:type :button
-      :id :save
-      :on-click (fn []
-                  (rf/dispatch [:rems.app/user-triggered-navigation])
-                  (if id
-                    (rf/dispatch [::edit-organization request])
-                    (rf/dispatch [::create-organization request])))
-      :disabled (nil? request)}
-     (text :t.administration/save)]))
+    (atoms/save-action {:id :save
+                        :disabled (nil? request)
+                        :on-click (when request
+                                    (fn []
+                                      (rf/dispatch [:rems.app/user-triggered-navigation])
+                                      (if id
+                                        (rf/dispatch [::edit-organization request])
+                                        (rf/dispatch [::create-organization request]))))})))
 
 (defn- cancel-button []
   [atoms/link {:class "btn btn-secondary"}
@@ -267,4 +265,4 @@
                   [organization-review-emails-field]
                   [:div.col.commands
                    [cancel-button]
-                   [save-organization-button]]])}]]))
+                   [perform-action-button (save-organization)]]])}]]))

--- a/src/cljs/rems/administration/create_resource.cljs
+++ b/src/cljs/rems/administration/create_resource.cljs
@@ -2,7 +2,7 @@
   (:require [clojure.string :as str]
             [re-frame.core :as rf]
             [rems.administration.administration :as administration]
-            [rems.administration.components :refer [organization-field text-field]]
+            [rems.administration.components :refer [organization-field perform-action-button text-field]]
             [rems.administration.duo :refer [duo-field]]
             [rems.atoms :as atoms :refer [document-title]]
             [rems.collapsible :as collapsible]
@@ -158,15 +158,15 @@
                                      :update-form ::update-duo}
                            :create-field? true}]))])]))
 
-(defn- save-resource-button [form]
+(defn- save-resource [form]
   (let [request (build-request form)]
-    [:button#save.btn.btn-primary
-     {:type :button
-      :on-click (fn []
-                  (rf/dispatch [:rems.app/user-triggered-navigation])
-                  (rf/dispatch [::create-resource request]))
-      :disabled (nil? request)}
-     (text :t.administration/save)]))
+    (atoms/save-action
+     {:id :save
+      :on-click (when request
+                  (fn []
+                    (rf/dispatch [:rems.app/user-triggered-navigation])
+                    (rf/dispatch [::create-resource request])))
+      :disabled (nil? request)})))
 
 (defn- cancel-button []
   [atoms/link {:class "btn btn-secondary"}
@@ -193,5 +193,5 @@
                    (when (:enable-duo @rems.globals/config) [resource-duos-field])
                    [:div.col.commands
                     [cancel-button]
-                    [save-resource-button form]]])]}]]))
+                    [perform-action-button (save-resource form)]]])]}]]))
 

--- a/src/cljs/rems/administration/create_resource.cljs
+++ b/src/cljs/rems/administration/create_resource.cljs
@@ -163,9 +163,7 @@
     (atoms/save-action
      {:id :save
       :on-click (when request
-                  (fn []
-                    (rf/dispatch [:rems.app/user-triggered-navigation])
-                    (rf/dispatch [::create-resource request])))
+                  #(rf/dispatch [::create-resource request]))
       :disabled (nil? request)})))
 
 (defn- cancel-button []

--- a/src/cljs/rems/administration/create_workflow.cljs
+++ b/src/cljs/rems/administration/create_workflow.cljs
@@ -4,7 +4,7 @@
             [re-frame.core :as rf]
             [reagent.format :as rfmt]
             [rems.administration.administration :as administration]
-            [rems.administration.components :refer [localized-text-field organization-field radio-button-group text-field]]
+            [rems.administration.components :refer [localized-text-field organization-field perform-action-button radio-button-group text-field]]
             [rems.administration.items :as items]
             [rems.atoms :as atoms :refer [enrich-user document-title]]
             [rems.collapsible :as collapsible]
@@ -553,7 +553,7 @@
                                         {:command (text :t.commands/change-processing-state)})]
                    [workflow-processing-states]])}])))
 
-(defn- save-workflow-action []
+(defn- save-workflow []
   (b/cond
     :let [loading? @(rf/subscribe [::workflow :fetching?])
           editing? @(rf/subscribe [::editing?])
@@ -595,4 +595,4 @@
 
     [:div.col.commands
      [atoms/action-button (cancel-action)]
-     [atoms/rate-limited-action-button (save-workflow-action)]]]])
+     [perform-action-button (save-workflow)]]]])

--- a/src/cljs/rems/administration/create_workflow.cljs
+++ b/src/cljs/rems/administration/create_workflow.cljs
@@ -129,8 +129,8 @@
                             {:params request
                              :handler (flash-message/default-success-handler
                                        :top description #(navigate! (str "/administration/workflows/" (:id %))))
-                             :error-handler (flash-message/default-error-handler :top description)})
-                     {:dispatch [:rems.app/user-triggered-navigation]})))
+                             :error-handler (flash-message/default-error-handler :top description)}))
+                   {}))
 
 (rf/reg-event-fx ::edit-workflow
                  (fn [_ [_ request]]
@@ -139,8 +139,8 @@
                            {:params request
                             :handler (flash-message/default-success-handler
                                       :top description #(navigate! (str "/administration/workflows/" (:id request))))
-                            :error-handler (flash-message/default-error-handler :top description)})
-                     {:dispatch [:rems.app/user-triggered-navigation]})))
+                            :error-handler (flash-message/default-error-handler :top description)}))
+                   {}))
 
 ;;;; UI
 

--- a/src/cljs/rems/administration/edit_category.cljs
+++ b/src/cljs/rems/administration/edit_category.cljs
@@ -139,9 +139,7 @@
     (atoms/save-action
      {:id :save
       :on-click (when request
-                  (fn []
-                    (rf/dispatch [:rems.app/user-triggered-navigation])
-                    (rf/dispatch [::edit-category request])))
+                  #(rf/dispatch [::edit-category request]))
       :disabled (nil? request)})))
 
 (defn- delete-action []

--- a/src/cljs/rems/administration/form.cljs
+++ b/src/cljs/rems/administration/form.cljs
@@ -2,7 +2,7 @@
   (:require [clojure.string :as str]
             [re-frame.core :as rf]
             [rems.administration.administration :as administration]
-            [rems.administration.components :refer [inline-info-field]]
+            [rems.administration.components :refer [inline-info-field perform-action-button]]
             [rems.administration.create-form :refer [form-preview format-validation-errors]]
             [rems.administration.status-flags :as status-flags]
             [rems.atoms :as atoms :refer [readonly-checkbox document-title]]
@@ -65,6 +65,16 @@
    (str "/administration/forms/create/" id)
    (text :t.administration/copy-as-new)])
 
+(defn- toggle-enabled [form]
+  (status-flags/enabled-toggle-action
+   {:on-change #(rf/dispatch [:rems.administration.forms/set-form-enabled %1 %2 [::enter-page (:form/id form)]])}
+   form))
+
+(defn- toggle-archived [form]
+  (status-flags/archived-toggle-action
+   {:on-change #(rf/dispatch [:rems.administration.forms/set-form-archived %1 %2 [::enter-page (:form/id form)]])}
+   form))
+
 (defn form-view [form]
   [:div.spaced-vertically-3
    [collapsible/component
@@ -85,8 +95,8 @@
       [roles/show-when roles/+admin-write-roles+
        [edit-button id]
        [copy-as-new-button id]
-       [status-flags/enabled-toggle form #(rf/dispatch [:rems.administration.forms/set-form-enabled %1 %2 [::enter-page id]])]
-       [status-flags/archived-toggle form #(rf/dispatch [:rems.administration.forms/set-form-archived %1 %2 [::enter-page id]])]]])
+       [perform-action-button (toggle-enabled form)]
+       [perform-action-button (toggle-archived form)]]])
    (when-let [errors (:form/errors form)]
      [:div.alert.alert-danger
       [text :t.administration/has-errors]

--- a/src/cljs/rems/administration/form.cljs
+++ b/src/cljs/rems/administration/form.cljs
@@ -53,9 +53,7 @@
 (defn edit-action [form-id]
   (atoms/edit-action
    {:class "edit-form"
-    :on-click (fn []
-                (rf/dispatch [:rems.app/user-triggered-navigation])
-                (rf/dispatch [::edit-form form-id]))}))
+    :on-click #(rf/dispatch [::edit-form form-id])}))
 
 (defn edit-button [form-id]
   [atoms/action-button (edit-action form-id)])

--- a/src/cljs/rems/administration/license.cljs
+++ b/src/cljs/rems/administration/license.cljs
@@ -128,6 +128,7 @@
    {:id "licenses"
     :title (text :t.administration/licenses)
     :top-less-button? (> (count licenses) 5)
+    :bottom-less-button? (pos? (count licenses))
     :open? (<= (count licenses) 5)
     :collapse (if (seq licenses)
                 (into [:div]

--- a/src/cljs/rems/administration/resource.cljs
+++ b/src/cljs/rems/administration/resource.cljs
@@ -2,7 +2,7 @@
   (:require [re-frame.core :as rf]
             [rems.administration.administration :as administration]
             [rems.administration.blacklist :as blacklist]
-            [rems.administration.components :refer [inline-info-field]]
+            [rems.administration.components :refer [inline-info-field perform-action-button]]
             [rems.administration.license :refer [licenses-view]]
             [rems.administration.duo :refer [duo-info-field]]
             [rems.administration.status-flags :as status-flags]
@@ -63,6 +63,16 @@
                                                                 {:resource/id (:id resource)})))}])
               [:p (text :t.duo/no-duo-codes)])}])
 
+(defn- toggle-enabled [resource]
+  (status-flags/enabled-toggle-action
+   {:on-change #(rf/dispatch [:rems.administration.resources/set-resource-enabled %1 %2 [::enter-page (:id resource)]])}
+   resource))
+
+(defn- toggle-archived [resource]
+  (status-flags/archived-toggle-action
+   {:on-change #(rf/dispatch [:rems.administration.resources/set-resource-archived %1 %2 [::enter-page (:id resource)]])}
+   resource))
+
 (defn resource-view [resource]
   (let [config @rems.globals/config]
     [:div.spaced-vertically-3
@@ -77,12 +87,11 @@
      (when (:enable-duo config)
        [resource-duos resource])
      [resource-blacklist]
-     (let [id (:id resource)]
-       [:div.col.commands
-        [administration/back-button "/administration/resources"]
-        [roles/show-when roles/+admin-write-roles+
-         [status-flags/enabled-toggle resource #(rf/dispatch [:rems.administration.resources/set-resource-enabled %1 %2 [::enter-page id]])]
-         [status-flags/archived-toggle resource #(rf/dispatch [:rems.administration.resources/set-resource-archived %1 %2 [::enter-page id]])]]])]))
+     [:div.col.commands
+      [administration/back-button "/administration/resources"]
+      [roles/show-when roles/+admin-write-roles+
+       [perform-action-button (toggle-enabled resource)]
+       [perform-action-button (toggle-archived resource)]]]]))
 
 (defn resource-page []
   (let [resource (rf/subscribe [::resource])

--- a/src/cljs/rems/administration/resources.cljs
+++ b/src/cljs/rems/administration/resources.cljs
@@ -71,6 +71,7 @@
 
 (defn- modify-resource-dropdown [resource]
   [atoms/commands-group-button
+   {:label (text :t.actions/modify)}
    (when (roles/can-modify-organization-item? resource)
      (list
       (status-flags/enabled-toggle-action {:on-change #(rf/dispatch [::set-resource-enabled %1 %2 [::fetch-resources]])} resource)

--- a/src/cljs/rems/administration/update_catalogue_item.cljs
+++ b/src/cljs/rems/administration/update_catalogue_item.cljs
@@ -1,6 +1,7 @@
 (ns rems.administration.update-catalogue-item
   (:require [re-frame.core :as rf]
             [rems.administration.administration :as administration]
+            [rems.administration.components :refer [perform-action-button]]
             [rems.atoms :as atoms :refer [document-title]]
             [rems.dropdown :as dropdown]
             [rems.flash-message :as flash-message]
@@ -139,14 +140,12 @@
                      (= (:id workflow) (:wfid item)))))
           items))
 
-(defn- update-catalogue-item-button [items {:keys [form workflow]}]
-  [atoms/rate-limited-action-button
-   {:id :update-catalogue-item
-    :class "btn-primary"
-    :on-click (fn [] (item-update-loop items form workflow))
-    :disabled (or (empty? items)
-                  (all-items-have-the-form-and-workflow-already? items form workflow))
-    :label [text :t.administration/update-catalogue-item]}])
+(defn- update-catalogue-items [items form workflow]
+  {:id :update-catalogue-item
+   :on-click #(item-update-loop items form workflow)
+   :disabled (or (empty? items)
+                 (all-items-have-the-form-and-workflow-already? items form workflow))
+   :label [text :t.administration/update-catalogue-item]})
 
 
 
@@ -220,7 +219,9 @@
   ;; catalogue items must be setup in the previous page
   ;; it can be empty when we reload or relogin
   ;; then we can redirect back to the previous page
-  (let [catalogue-items @(rf/subscribe [::catalogue-items])]
+  (let [catalogue-items @(rf/subscribe [::catalogue-items])
+        form @(rf/subscribe [::form])
+        workflow @(rf/subscribe [::workflow])]
     (when (empty? catalogue-items)
       (navigate! "/administration/catalogue-items"))
     [:div
@@ -234,6 +235,4 @@
       [workflow-select]
       [:div.col.commands
        [administration/back-button "/administration/catalogue-items"]
-       [update-catalogue-item-button catalogue-items
-        {:form @(rf/subscribe [::form])
-         :workflow @(rf/subscribe [::workflow])}]]]]))
+       [perform-action-button (update-catalogue-items catalogue-items form workflow)]]]]))

--- a/src/cljs/rems/administration/workflow.cljs
+++ b/src/cljs/rems/administration/workflow.cljs
@@ -4,7 +4,7 @@
             [medley.core :refer [indexed]]
             [re-frame.core :as rf]
             [rems.administration.administration :as administration]
-            [rems.administration.components :refer [inline-info-field]]
+            [rems.administration.components :refer [inline-info-field perform-action-button]]
             [rems.administration.status-flags :as status-flags]
             [rems.atoms :as atoms :refer [document-title enrich-user readonly-checkbox]]
             [rems.collapsible :as collapsible]
@@ -203,6 +203,16 @@
    {:class "edit-workflow"
     :url (str "/administration/workflows/edit/" workflow-id)}))
 
+(defn- toggle-enabled [workflow]
+  (status-flags/enabled-toggle-action
+   {:on-change #(rf/dispatch [:rems.administration.workflows/set-workflow-enabled %1 %2 [::enter-page (:id workflow)]])}
+   workflow))
+
+(defn- toggle-archived [workflow]
+  (status-flags/archived-toggle-action
+   {:on-change #(rf/dispatch [:rems.administration.workflows/set-workflow-archived %1 %2 [::enter-page (:id workflow)]])}
+   workflow))
+
 (defn workflow-page []
   [:div
    [administration/navigator]
@@ -225,5 +235,5 @@
         [administration/back-button "/administration/workflows"]
         [roles/show-when roles/+admin-write-roles+
          [atoms/action-button (edit-workflow-action (:id workflow))]
-         [status-flags/enabled-toggle workflow #(rf/dispatch [:rems.administration.workflows/set-workflow-enabled %1 %2 [::enter-page (:id workflow)]])]
-         [status-flags/archived-toggle workflow #(rf/dispatch [:rems.administration.workflows/set-workflow-archived %1 %2 [::enter-page (:id workflow)]])]]]])]])
+         [perform-action-button (toggle-enabled workflow)]
+         [perform-action-button (toggle-archived workflow)]]]])]])

--- a/src/cljs/rems/atoms.cljs
+++ b/src/cljs/rems/atoms.cljs
@@ -322,6 +322,12 @@
   (assoc action
          :label [text :t.administration/save]))
 
+(defn delete-action
+  "Standard delete action helper, to use with e.g. `action-button` or `action-link`."
+  [action]
+  (assoc action
+         :label [text :t.administration/delete]))
+
 (defn commands
   "Creates a standard commands group with left alignment."
   [& commands]

--- a/src/cljs/rems/atoms.cljs
+++ b/src/cljs/rems/atoms.cljs
@@ -282,7 +282,7 @@
             (dissoc :on-click :text :url)
             (assoc-some :on-click on-click)
             (assoc :id id
-                   :label (:text action label) ; XXX: consider refactoring :text -> :label
+                   :label (or label (:text action)) ; XXX: consider refactoring :text -> :label
                    :href (or url "#")
                    :class (class-names :btn :btn-link class)
                    :role :button))])
@@ -290,12 +290,12 @@
 (defn rate-limited-action-button
   "Takes an `action` description and creates a button that triggers it.
    Click events are rate limited."
-  [{:keys [class disabled id label on-click]}]
+  [{:keys [class disabled id label on-click] :as action}]
   [rate-limited-button {:class (str/trim (str "btn-secondary " class))
                         :disabled disabled
                         :id id
                         :on-click on-click
-                        :text label ; XXX: button and rate-limited-button could use label instead
+                        :text (or label (:text action)) ; XXX: button and rate-limited-button could use label instead
                         }])
 
 (defn new-action

--- a/test/clj/rems/test_browser.clj
+++ b/test/clj/rems/test_browser.clj
@@ -2848,8 +2848,8 @@
 (deftest test-blacklist
   (btu/with-postmortem
     (testing "set up resource & user"
-      (test-helpers/create-resource! {:resource-ext-id "blacklist-test"})
-      (test-helpers/create-user! {:userid "baddie" :name "Bruce Baddie" :email "bruce@example.com"}))
+      (is (test-helpers/create-resource! {:resource-ext-id "blacklist-test"}))
+      (is (test-helpers/create-user! {:userid "baddie" :name "Bruce Baddie" :email "bruce@example.com"})))
     (testing "add blacklist entry via resource page"
       (login-as "owner")
       (go-to-admin "Resources")
@@ -2858,7 +2858,8 @@
       (wait-page-title "Resource – REMS")
       (btu/wait-page-loaded)
       (is (btu/eventually-visible? :blacklist))
-      (is (= [] (slurp-rows :blacklist)))
+      (is (= [{"rems-no-rows" "No rows"}]
+             (slurp-rows :blacklist)))
       (btu/fill-human :blacklist-user "baddie\n")
       (btu/fill-human :blacklist-comment "This is a test.")
       (btu/screenshot "test-blacklist-1")
@@ -2894,7 +2895,8 @@
       (is (btu/eventually-visible? {:css ".alert-success"}))
       (is (str/includes? (btu/get-element-text {:css ".alert-success"}) "Success"))
       (is (btu/eventually-visible? :blacklist))
-      (is (= [] (slurp-rows :blacklist))))))
+      (is (= [{"rems-no-rows" "No rows"}]
+             (slurp-rows :blacklist))))))
 
 (deftest test-report
   (btu/with-postmortem


### PR DESCRIPTION
Includes fixes and quality-of-life improvements:

- spam protection in status flag buttons (toggle enabled / toggle archived) and all/most "hazard" actions in admin pages
  - `rems.administration.components/perform-action-button` renders loading spinner when e.g. waiting for API request
- admin actions shift focus after request completes, not immediately on click
  - removed `user-triggered-navigation` dispatches except for the secretary navigation hook. this was used primarily for getting user attention to flash message, but flash message already calls focus on render?
- resources list:
  - fixed issue with modify resource button that never renders (even for owner)
- resource view:
  - licenses no longer render "show less" button when there are no licenses
  - fixed issue where blacklist table renders every resource(s) blacklist rows after adding/removing user
- table component:
  - `standard-table` no longer renders search and pagination when the table has no rows
  - table now renders "no rows" if the table has no rows

<img width="917" alt="Screenshot 2024-11-07 at 18 26 52" src="https://github.com/user-attachments/assets/f1bcc067-def9-48c1-9811-4b22980d97c9">

# Checklist for author

Remove items that aren't applicable, check items that are done.

## Reviewability
- [ ] Link to issue (no issue)
- [x] Consider adding screenshots for ease of review

## Documentation
- [ ] Update changelog if necessary
- [ ] Components are added to guide page

## Follow-up
- [ ] New tasks are created for pending or remaining tasks
