### PR TITLE
Friendlier cache in development mode

### DIFF
--- a/src/clj/rems/cache.clj
+++ b/src/clj/rems/cache.clj
@@ -185,11 +185,14 @@
         (logr/debug "<" id :evict k)))))
 
 (defn basic [{:keys [depends-on id miss-fn reload-fn]}]
-  (assert (not (contains? @caches id)) (format "error overriding cache id %s" id))
+  (when (contains? @caches id)
+    (if (:dev rems.config/env)
+      (logr/warnf "overriding cache id %s" id)
+      (assert false (format "error overriding cache id %s" id))))
   (let [initialized? false
         statistics (if (:dev rems.config/env)
-                     (select-keys initial-statistics [:reload :upsert :evict]) ; :get statistics can become big quickly
-                     initial-statistics)
+                     initial-statistics
+                     (select-keys initial-statistics [:reload :upsert :evict])) ; :get statistics can become big quickly
         the-cache (w/basic-cache-factory {})
         cache (->RefreshableCache id
                                   (atom statistics)


### PR DESCRIPTION
Reloading namespaces with caches causes some friction when cache is mistakenly treated as duplicate.

- only log warning **in dev mode** when cache is created using existing cache id

# Checklist for author

Remove items that aren't applicable, check items that are done.

## Reviewability
- [ ] Link to issue (no issue)

## Testing
- [x] Complex logic is unit tested
