### PR TITLE
feat: faster reload after catalogue item edit

### DIFF
--- a/.cljfmt.edn
+++ b/.cljfmt.edn
@@ -1,3 +1,6 @@
 {:paths ["project.clj" "src/clj" "src/cljc" "src/cljs" "test/clj" "test/cljc" "test/cljs"] ; need explicit paths to include cljs
- :extra-indents {delay [[:inner 0]]}
+ :extra-indents {delay [[:inner 0]]
+                 ;; macros, originally defined in rems.api.test-catalogue-items
+                 is-logged? [[:block 3]] ; :default indent for arguments [0 1 2], and :inner afterwards
+                 is-not-logged? [[:block 3]]}
  :remove-consecutive-blank-lines? false} ; too many changes for now, probably not desirable

--- a/src/clj/rems/service/catalogue.clj
+++ b/src/clj/rems/service/catalogue.clj
@@ -115,18 +115,20 @@
   (rems.db.catalogue/edit-catalogue-item! id {:categories (:categories item)
                                               :localizations localizations
                                               :organization-id (:organization/id organization)})
-  (rems.db.applications/reload-cache!)
+  (rems.db.applications/reload-applications! {:by-catalogue-item-ids [id]})
   {:success true})
 
 (defn set-catalogue-item-enabled! [{:keys [id enabled]}]
   (check-allowed-to-edit! id)
   (rems.db.catalogue/set-attributes! id {:enabled enabled})
+  (rems.db.applications/reload-applications! {:by-catalogue-item-ids [id]})
   {:success true})
 
 (defn set-catalogue-item-archived! [{:keys [id archived]}]
   (check-allowed-to-edit! id)
   (or (dependencies/change-archive-status-error archived {:catalogue-item/id id})
       (do (rems.db.catalogue/set-attributes! id {:archived archived})
+          (rems.db.applications/reload-applications! {:by-catalogue-item-ids [id]})
           {:success true})))
 
 (defn change-form!
@@ -151,6 +153,9 @@
 
       ;; hide the old catalogue item
       (rems.db.catalogue/set-attributes! (:id item) {:archived true :enabled false})
+
+      ;; notify applications with old catalogue item
+      (rems.db.applications/reload-applications! {:by-catalogue-item-ids [(:id item)]})
 
       {:success true :catalogue-item-id new-item-id})))
 
@@ -190,5 +195,8 @@
 
       ;; hide the old catalogue item
       (rems.db.catalogue/set-attributes! (:id item) {:archived true :enabled false})
+
+      ;; notify applications with old catalogue item
+      (rems.db.applications/reload-applications! {:by-catalogue-item-ids [(:id item)]})
 
       {:success true :catalogue-item-id new-item-id})))

--- a/test/clj/rems/api/test_catalogue_items.clj
+++ b/test/clj/rems/api/test_catalogue_items.clj
@@ -1,17 +1,36 @@
 (ns ^:integration rems.api.test-catalogue-items
   (:require [clojure.string :as str]
-            [clojure.test :refer :all]
-            [rems.api.testing :refer :all]
+            [clojure.test :refer [deftest is testing use-fixtures]]
+            [clojure.tools.logging.test :as log-test]
+            [rems.api.testing :refer [api-call api-fixture authenticate read-body read-ok-body response-is-forbidden? response-is-not-found? response-is-unauthorized?]]
             [rems.db.applications]
             [rems.db.test-data-helpers :as test-helpers]
             [rems.db.testing :refer [owners-fixture +test-api-key+]]
             [rems.handler :refer [handler]]
-            [ring.mock.request :refer :all]))
+            [ring.mock.request :refer [json-body request]]))
 
 (use-fixtures
   :each
   api-fixture
   owners-fixture)
+
+(defmacro with-logged?
+  "Evaluates `body`, asserts `(is (clojure.tools.logging.test/logged? logger-ns level message))`,
+   and returns the result of `body`."
+  [logger-ns level message body]
+  `(clojure.tools.logging.test/with-log
+     (let [result# (do ~body)]
+       (is (clojure.tools.logging.test/logged? ~logger-ns ~level ~message))
+       result#)))
+
+(defmacro with-not-logged?
+  "Evaluates `body`, asserts `(is (not (clojure.tools.logging.test/logged? logger-ns level message)))`,
+   and returns the result of `body`."
+  [logger-ns level message body]
+  `(clojure.tools.logging.test/with-log
+     (let [result# (do ~body)]
+       (is (not (clojure.tools.logging.test/logged? ~logger-ns ~level ~message)))
+       result#)))
 
 (deftest catalogue-items-api-test
   (let [user-id "alice"
@@ -120,6 +139,7 @@
         form-id (test-helpers/create-form! {:organization {:organization/id "organization1"}})
         wf-id (test-helpers/create-workflow! {:organization {:organization/id "organization1"}})
         res-id (test-helpers/create-resource! {:organization {:organization/id "organization1"}})]
+
     (testing "create"
       (let [create (-> (request :post "/api/catalogue-items/create")
                        (authenticate +test-api-key+ owner)
@@ -140,6 +160,7 @@
           (is (= {:sv "http://info.se"}
                  (:catalogue-item/infourl
                   (first (:application/resources (get-app))))))
+
           (testing "... and fetch"
             (let [data (-> (request :get (str "/api/catalogue-items/" id))
                            (authenticate +test-api-key+ user)
@@ -152,22 +173,26 @@
               (is (= {:title "Sv title"
                       :infourl "http://info.se"}
                      (dissoc (get-in data [:localizations :sv]) :id :langcode)))))
+
           (testing "... and edit (as owner)"
-            (let [response (-> (request :put "/api/catalogue-items/edit")
-                               (authenticate +test-api-key+ owner)
-                               (json-body {:id id
-                                           :organization {:organization/id changed-organization1}
-                                           :localizations {:sv {:title "Sv title 2"
-                                                                :infourl nil}
-                                                           :fi {:title "Fi title"
-                                                                :infourl "http://info.fi"}}})
-                               handler
-                               read-ok-body)]
+            (let [response (with-logged? "rems.db.applications" :info "Reloading 1 applications because of catalogue item changes"
+                             (-> (request :put "/api/catalogue-items/edit")
+                                 (authenticate +test-api-key+ owner)
+                                 (json-body {:id id
+                                             :organization {:organization/id changed-organization1}
+                                             :localizations {:sv {:title "Sv title 2"
+                                                                  :infourl nil}
+                                                             :fi {:title "Fi title"
+                                                                  :infourl "http://info.fi"}}})
+                                 handler
+                                 read-ok-body))]
               (is (:success response) (pr-str response))
+
               (testing "application is updated when catalogue item is edited"
                 (is (= {:fi "http://info.fi"}
                        (:catalogue-item/infourl
                         (first (:application/resources (get-app)))))))
+
               (testing "... and fetch"
                 (let [data (-> (request :get (str "/api/catalogue-items/" id))
                                (authenticate +test-api-key+ user)
@@ -184,52 +209,80 @@
                   (is (= {:title "Fi title"
                           :infourl "http://info.fi"}
                          (dissoc (get-in data [:localizations :fi]) :id :langcode)))))))
+
           (testing "... and edit (as organization owner)"
-            (let [response (-> (request :put "/api/catalogue-items/edit")
-                               (authenticate +test-api-key+ "organization-owner1")
-                               (json-body {:id id
-                                           :organization {:organization/id changed-organization2}
-                                           :localizations {:sv {:title "Sv title 2"
-                                                                :infourl nil}
-                                                           :fi {:title "Fi title 2"
-                                                                :infourl "http://info.fi"}}})
-                               handler
-                               read-ok-body)]
+            (let [response (with-logged? "rems.db.applications" :info "Reloading 1 applications because of catalogue item changes"
+                             (-> (request :put "/api/catalogue-items/edit")
+                                 (authenticate +test-api-key+ "organization-owner1")
+                                 (json-body {:id id
+                                             :organization {:organization/id changed-organization2}
+                                             :localizations {:sv {:title "Sv title 2"
+                                                                  :infourl nil}
+                                                             :fi {:title "Fi title 2"
+                                                                  :infourl "http://info.fi"}}})
+                                 handler
+                                 read-ok-body))]
               (is (:success response) (pr-str response))))
+
           (testing "... and edit (as organization owner but no rights to target org)"
-            (let [response (-> (request :put "/api/catalogue-items/edit")
-                               (authenticate +test-api-key+ "organization-owner1")
-                               (json-body {:id id
-                                           :organization {:organization/id "organization2"}
-                                           :localizations {:sv {:title "Sv title 2"
-                                                                :infourl nil}
-                                                           :fi {:title "Fi title 2"
-                                                                :infourl "http://info.fi"}}})
-                               handler)]
+            (let [response (with-not-logged? "rems.db.applications" :info #"Reloading"
+                             (-> (request :put "/api/catalogue-items/edit")
+                                 (authenticate +test-api-key+ "organization-owner1")
+                                 (json-body {:id id
+                                             :organization {:organization/id "organization2"}
+                                             :localizations {:sv {:title "Sv title 2"
+                                                                  :infourl nil}
+                                                             :fi {:title "Fi title 2"
+                                                                  :infourl "http://info.fi"}}})
+                                 handler))]
               (is (response-is-forbidden? response))
               (is (= "no access to organization \"organization2\"" (read-body response)))))
+
           (testing "... and edit (as organization owner for another organization)"
-            (let [response (-> (request :put "/api/catalogue-items/edit")
-                               (authenticate +test-api-key+ "organization-owner2")
-                               (json-body {:id id
-                                           :localizations {:sv {:title "Sv title 2"
-                                                                :infourl nil}
-                                                           :fi {:title "Fi title 2"
-                                                                :infourl "http://info.fi"}}})
-                               handler)]
+            (let [response (with-not-logged? "rems.db.applications" :info #"Reloading"
+                             (-> (request :put "/api/catalogue-items/edit")
+                                 (authenticate +test-api-key+ "organization-owner2")
+                                 (json-body {:id id
+                                             :localizations {:sv {:title "Sv title 2"
+                                                                  :infourl nil}
+                                                             :fi {:title "Fi title 2"
+                                                                  :infourl "http://info.fi"}}})
+                                 handler))]
               (is (response-is-forbidden? response))
               (is (= "no access to organization \"changed-organization2\"" (read-body response))))))))
 
     (testing "edit nonexisting"
-      (let [response (-> (request :put "/api/catalogue-items/edit")
-                         (authenticate +test-api-key+ owner)
-                         (json-body {:id 999999999
-                                     :localizations {:sv {:title "Sv title 2"
-                                                          :infourl nil}
-                                                     :fi {:title "Fi title"
-                                                          :infourl "http://info.fi"}}})
-                         handler)]
-        (is (response-is-not-found? response))))))
+      (let [response (with-not-logged? "rems.db.applications" :info #"Reloading"
+                       (-> (request :put "/api/catalogue-items/edit")
+                           (authenticate +test-api-key+ owner)
+                           (json-body {:id 999999999
+                                       :localizations {:sv {:title "Sv title 2"
+                                                            :infourl nil}
+                                                       :fi {:title "Fi title"
+                                                            :infourl "http://info.fi"}}})
+                           handler))]
+        (is (response-is-not-found? response))))
+
+    (testing "edit one with no created applications"
+      (let [create (-> (request :post "/api/catalogue-items/create")
+                       (authenticate +test-api-key+ owner)
+                       (json-body {:form form-id
+                                   :resid res-id
+                                   :wfid wf-id
+                                   :organization {:organization/id "organization1"}
+                                   :localizations {:en {:title "No applications test"}}})
+                       handler
+                       read-ok-body)]
+        (is (:success create))
+        (let [response (with-logged? "rems.db.applications" :info "Reloading 0 applications because of catalogue item changes"
+                         (-> (request :put "/api/catalogue-items/edit")
+                             (authenticate +test-api-key+ owner)
+                             (json-body {:id (:id create)
+                                         :localizations {:en {:title "No applications test"
+                                                              :infourl "http://info.en"}}})
+                             handler
+                             read-ok-body))]
+          (is (:success response) (pr-str response)))))))
 
 
 (deftest catalogue-items-api-security-test
@@ -262,21 +315,24 @@
                handler
                (read-body)))))
   (testing "edit without authentication"
-    (let [response (-> (request :post (str "/api/catalogue-items/edit"))
-                       (json-body {:id 1
-                                   :localizations {:en {:title "malicious localization"}}})
-                       handler)
+    (let [response (with-not-logged? "rems.db.applications" :info #"Reloading"
+                     (-> (request :post (str "/api/catalogue-items/edit"))
+                         (json-body {:id 1
+                                     :localizations {:en {:title "malicious localization"}}})
+                         handler))
           body (read-body response)]
       (is (response-is-unauthorized? response))
       (is (str/includes? body "Invalid anti-forgery token"))))
   (testing "edit with wrong API-Key"
-    (is (= "Invalid anti-forgery token"
-           (-> (request :put (str "/api/catalogue-items/edit"))
-               (assoc-in [:headers "x-rems-api-key"] "invalid-api-key")
-               (json-body {:id 1
-                           :localizations {:en {:title "malicious localization"}}})
-               handler
-               (read-body))))))
+    (let [body (with-not-logged? "rems.db.applications" :info #"Reloading"
+                 (-> (request :put (str "/api/catalogue-items/edit"))
+                     (assoc-in [:headers "x-rems-api-key"] "invalid-api-key")
+                     (json-body {:id 1
+                                 :localizations {:en {:title "malicious localization"}}})
+                     handler
+                     (read-body)))]
+      (is (= "Invalid anti-forgery token"
+             body)))))
 
 (deftest change-form-test ; XXX: deprecated
   (let [resource-id (test-helpers/create-resource! {:organization {:organization/id "organization1"}})
@@ -293,52 +349,59 @@
                                 :form-id old-form-id
                                 :categories [category]})]
 
+    (test-helpers/create-user! {:userid "alice"})
+    (test-helpers/create-application! {:catalogue-item-ids [old-catalogue-item-id]
+                                       :actor "alice"})
+
     (testing "when the form is changed a new catalogue item is created"
-      (let [new-catalogue-item-id (-> (request :post (str "/api/catalogue-items/" old-catalogue-item-id "/change-form"))
-                                      (authenticate +test-api-key+ "owner")
-                                      (json-body {:form new-form-id})
-                                      handler
-                                      read-ok-body
-                                      :catalogue-item-id)
-            new-catalogue-item (-> (request :get (str "/api/catalogue-items/" new-catalogue-item-id))
-                                   (authenticate +test-api-key+ "owner")
-                                   handler
-                                   read-ok-body)
-            old-catalogue-item (-> (request :get (str "/api/catalogue-items/" old-catalogue-item-id))
-                                   (authenticate +test-api-key+ "owner")
-                                   handler
-                                   read-ok-body)]
-        (testing "the new item"
-          (is (:enabled new-catalogue-item))
-          (is (= new-form-id (:formid new-catalogue-item)) "has the new changed form id"))
+      (let [new-catalogue-item-id (with-logged? "rems.db.applications" :info "Reloading 1 applications because of catalogue item changes"
+                                    (-> (request :post (str "/api/catalogue-items/" old-catalogue-item-id "/change-form"))
+                                        (authenticate +test-api-key+ "owner")
+                                        (json-body {:form new-form-id})
+                                        handler
+                                        read-ok-body
+                                        :catalogue-item-id))]
+        (let [new-catalogue-item (-> (request :get (str "/api/catalogue-items/" new-catalogue-item-id))
+                                     (authenticate +test-api-key+ "owner")
+                                     handler
+                                     read-ok-body)
+              old-catalogue-item (-> (request :get (str "/api/catalogue-items/" old-catalogue-item-id))
+                                     (authenticate +test-api-key+ "owner")
+                                     handler
+                                     read-ok-body)]
+          (testing "the new item"
+            (is (:enabled new-catalogue-item))
+            (is (= new-form-id (:formid new-catalogue-item)) "has the new changed form id"))
 
-        (testing "the old item"
-          (is (:archived old-catalogue-item))
-          (is (not (:enabled old-catalogue-item))))
+          (testing "the old item"
+            (is (:archived old-catalogue-item))
+            (is (not (:enabled old-catalogue-item))))
 
-        (let [same-keys [:wfid :workflow-name :resid :resource-id :resource-name :categories]]
-          (is (= (select-keys old-catalogue-item same-keys)
-                 (select-keys new-catalogue-item same-keys))))
+          (let [same-keys [:wfid :workflow-name :resid :resource-id :resource-name :categories]]
+            (is (= (select-keys old-catalogue-item same-keys)
+                   (select-keys new-catalogue-item same-keys))))
 
-        (doseq [langcode (into (keys (:localizations old-catalogue-item))
-                               (keys (:localizations new-catalogue-item)))]
-          (is (= (dissoc (get-in old-catalogue-item [:localizations langcode]) :id)
-                 (dissoc (get-in new-catalogue-item [:localizations langcode]) :id))))))
+          (doseq [langcode (into (keys (:localizations old-catalogue-item))
+                                 (keys (:localizations new-catalogue-item)))]
+            (is (= (dissoc (get-in old-catalogue-item [:localizations langcode]) :id)
+                   (dissoc (get-in new-catalogue-item [:localizations langcode]) :id)))))))
 
     (testing "can change to form that's in another organization"
       (let [form-id (test-helpers/create-form! {:form/internal-name "wrong organization"
                                                 :organization {:organization/id "organization2"}})
-            response (-> (request :post (str "/api/catalogue-items/" old-catalogue-item-id "/change-form"))
-                         (authenticate +test-api-key+ "owner")
-                         (json-body {:form form-id})
-                         handler
-                         read-ok-body)]
+            response (with-logged? "rems.db.applications" :info "Reloading 1 applications because of catalogue item changes"
+                       (-> (request :post (str "/api/catalogue-items/" old-catalogue-item-id "/change-form"))
+                           (authenticate +test-api-key+ "owner")
+                           (json-body {:form form-id})
+                           handler
+                           read-ok-body))]
         (is (true? (:success response)))))
 
     (testing "can change to nil form"
-      (let [response (api-call :post (str "/api/catalogue-items/" old-catalogue-item-id "/change-form")
-                               {:form nil}
-                               +test-api-key+ "owner")
+      (let [response (with-logged? "rems.db.applications" :info "Reloading 1 applications because of catalogue item changes"
+                       (api-call :post (str "/api/catalogue-items/" old-catalogue-item-id "/change-form")
+                                 {:form nil}
+                                 +test-api-key+ "owner"))
             new-catalogue-item-id (:catalogue-item-id response)]
         (is (true? (:success response)))
         (is (= {:id new-catalogue-item-id
@@ -349,9 +412,10 @@
                              +test-api-key+ "owner")
                    (select-keys [:formid :form-name :id :resource-id]))))
         (testing "and back"
-          (let [response (api-call :post (str "/api/catalogue-items/" new-catalogue-item-id "/change-form")
-                                   {:form new-form-id}
-                                   +test-api-key+ "owner")
+          (let [response (with-logged? "rems.db.applications" :info "Reloading 0 applications because of catalogue item changes"
+                           (api-call :post (str "/api/catalogue-items/" new-catalogue-item-id "/change-form")
+                                     {:form new-form-id}
+                                     +test-api-key+ "owner"))
                 new-new-catalogue-item-id (:catalogue-item-id response)]
             (is (true? (:success response)))
             (is (= {:id new-new-catalogue-item-id
@@ -363,18 +427,20 @@
                        (select-keys [:formid :form-name :id :resource-id]))))))))
 
     (testing "can change form as organization owner"
-      (is (true? (-> (request :post (str "/api/catalogue-items/" old-catalogue-item-id "/change-form"))
-                     (authenticate +test-api-key+ "organization-owner1")
-                     (json-body {:form new-form-id})
-                     handler
-                     read-ok-body
-                     :success))))
+      (let [body (with-logged? "rems.db.applications" :info "Reloading 1 applications because of catalogue item changes"
+                   (-> (request :post (str "/api/catalogue-items/" old-catalogue-item-id "/change-form"))
+                       (authenticate +test-api-key+ "organization-owner1")
+                       (json-body {:form new-form-id})
+                       handler
+                       read-ok-body))]
+        (is (true? (:success body)))))
 
     (testing "can't change form as owner of different organization"
-      (let [response (-> (request :post (str "/api/catalogue-items/" old-catalogue-item-id "/change-form"))
-                         (authenticate +test-api-key+ "organization-owner2")
-                         (json-body {:form new-form-id})
-                         handler)]
+      (let [response (with-not-logged? "rems.db.applications" :info #"Reloading"
+                       (-> (request :post (str "/api/catalogue-items/" old-catalogue-item-id "/change-form"))
+                           (authenticate +test-api-key+ "organization-owner2")
+                           (json-body {:form new-form-id})
+                           handler))]
         (is (response-is-forbidden? response))
         (is (= "no access to organization \"organization1\"" (read-body response)))))))
 
@@ -399,14 +465,19 @@
                                 :wfid old-workflow-id
                                 :categories [category]})]
 
+    (test-helpers/create-user! {:userid "alice"})
+    (test-helpers/create-application! {:catalogue-item-ids [old-catalogue-item-id]
+                                       :actor "alice"})
+
     (testing "after update a new catalogue item is created"
-      (let [new-catalogue-item-id (-> (request :post (str "/api/catalogue-items/" old-catalogue-item-id "/update"))
-                                      (authenticate +test-api-key+ "owner")
-                                      (json-body {:form new-form-id
-                                                  :workflow new-workflow-id})
-                                      handler
-                                      read-ok-body
-                                      :catalogue-item-id)
+      (let [new-catalogue-item-id (with-logged? "rems.db.applications" :info "Reloading 1 applications because of catalogue item changes"
+                                    (-> (request :post (str "/api/catalogue-items/" old-catalogue-item-id "/update"))
+                                        (authenticate +test-api-key+ "owner")
+                                        (json-body {:form new-form-id
+                                                    :workflow new-workflow-id})
+                                        handler
+                                        read-ok-body
+                                        :catalogue-item-id))
             new-catalogue-item (-> (request :get (str "/api/catalogue-items/" new-catalogue-item-id))
                                    (authenticate +test-api-key+ "owner")
                                    handler
@@ -439,22 +510,24 @@
                    (dissoc (get-in new-catalogue-item [:localizations langcode]) :id)))))
 
         (testing "and if we are done already, we get the same item"
-          (let [new-catalogue-item-id2 (-> (request :post (str "/api/catalogue-items/" new-catalogue-item-id "/update"))
-                                           (authenticate +test-api-key+ "owner")
-                                           (json-body {:form new-form-id
-                                                       :workflow new-workflow-id})
-                                           handler
-                                           read-ok-body
-                                           :catalogue-item-id)]
+          (let [new-catalogue-item-id2 (with-not-logged? "rems.db.applications" :info #"Reloading"
+                                         (-> (request :post (str "/api/catalogue-items/" new-catalogue-item-id "/update"))
+                                             (authenticate +test-api-key+ "owner")
+                                             (json-body {:form new-form-id
+                                                         :workflow new-workflow-id})
+                                             handler
+                                             read-ok-body
+                                             :catalogue-item-id))]
             (is (= new-catalogue-item-id new-catalogue-item-id2))))))
 
     (testing "when the form is updated a new catalogue item is created"
-      (let [new-catalogue-item-id (-> (request :post (str "/api/catalogue-items/" old-catalogue-item-id "/update"))
-                                      (authenticate +test-api-key+ "owner")
-                                      (json-body {:form new-form-id})
-                                      handler
-                                      read-ok-body
-                                      :catalogue-item-id)
+      (let [new-catalogue-item-id (with-logged? "rems.db.applications" :info "Reloading 1 applications because of catalogue item changes"
+                                    (-> (request :post (str "/api/catalogue-items/" old-catalogue-item-id "/update"))
+                                        (authenticate +test-api-key+ "owner")
+                                        (json-body {:form new-form-id})
+                                        handler
+                                        read-ok-body
+                                        :catalogue-item-id))
             new-catalogue-item (-> (request :get (str "/api/catalogue-items/" new-catalogue-item-id))
                                    (authenticate +test-api-key+ "owner")
                                    handler
@@ -473,12 +546,13 @@
                    (select-keys new-catalogue-item same-keys)))))))
 
     (testing "when the workflow is updated a new catalogue item is created"
-      (let [new-catalogue-item-id (-> (request :post (str "/api/catalogue-items/" old-catalogue-item-id "/update"))
-                                      (authenticate +test-api-key+ "owner")
-                                      (json-body {:workflow new-workflow-id})
-                                      handler
-                                      read-ok-body
-                                      :catalogue-item-id)
+      (let [new-catalogue-item-id (with-logged? "rems.db.applications" :info "Reloading 1 applications because of catalogue item changes"
+                                    (-> (request :post (str "/api/catalogue-items/" old-catalogue-item-id "/update"))
+                                        (authenticate +test-api-key+ "owner")
+                                        (json-body {:workflow new-workflow-id})
+                                        handler
+                                        read-ok-body
+                                        :catalogue-item-id))
             new-catalogue-item (-> (request :get (str "/api/catalogue-items/" new-catalogue-item-id))
                                    (authenticate +test-api-key+ "owner")
                                    handler
@@ -501,18 +575,20 @@
                                                 :organization {:organization/id "organization2"}})
             workflow-id (test-helpers/create-workflow! {:title "wrong organization"
                                                         :organization {:organization/id "organization2"}})
-            response (-> (request :post (str "/api/catalogue-items/" old-catalogue-item-id "/update"))
-                         (authenticate +test-api-key+ "owner")
-                         (json-body {:form form-id
-                                     :workflow workflow-id})
-                         handler
-                         read-ok-body)]
+            response (with-logged? "rems.db.applications" :info "Reloading 1 applications because of catalogue item changes"
+                       (-> (request :post (str "/api/catalogue-items/" old-catalogue-item-id "/update"))
+                           (authenticate +test-api-key+ "owner")
+                           (json-body {:form form-id
+                                       :workflow workflow-id})
+                           handler
+                           read-ok-body))]
         (is (true? (:success response)))))
 
     (testing "can update to nil form"
-      (let [response (api-call :post (str "/api/catalogue-items/" old-catalogue-item-id "/update")
-                               {:form nil}
-                               +test-api-key+ "owner")
+      (let [response (with-logged? "rems.db.applications" :info "Reloading 1 applications because of catalogue item changes"
+                       (api-call :post (str "/api/catalogue-items/" old-catalogue-item-id "/update")
+                                 {:form nil}
+                                 +test-api-key+ "owner"))
             new-catalogue-item-id (:catalogue-item-id response)]
         (is (true? (:success response)))
         (is (= {:id new-catalogue-item-id
@@ -523,9 +599,10 @@
                              +test-api-key+ "owner")
                    (select-keys [:formid :form-name :id :resource-id]))))
         (testing "and back"
-          (let [response (api-call :post (str "/api/catalogue-items/" new-catalogue-item-id "/update")
-                                   {:form new-form-id}
-                                   +test-api-key+ "owner")
+          (let [response (with-logged? "rems.db.applications" :info "Reloading 0 applications because of catalogue item changes"
+                           (api-call :post (str "/api/catalogue-items/" new-catalogue-item-id "/update")
+                                     {:form new-form-id}
+                                     +test-api-key+ "owner"))
                 new-new-catalogue-item-id (:catalogue-item-id response)]
             (is (true? (:success response)))
             (is (= {:id new-new-catalogue-item-id
@@ -537,20 +614,22 @@
                        (select-keys [:formid :form-name :id :resource-id]))))))))
 
     (testing "can update as organization owner"
-      (is (true? (-> (request :post (str "/api/catalogue-items/" old-catalogue-item-id "/update"))
-                     (authenticate +test-api-key+ "organization-owner1")
-                     (json-body {:form new-form-id
-                                 :workflow new-workflow-id})
-                     handler
-                     read-ok-body
-                     :success))))
+      (let [body (with-logged? "rems.db.applications" :info "Reloading 1 applications because of catalogue item changes"
+                   (-> (request :post (str "/api/catalogue-items/" old-catalogue-item-id "/update"))
+                       (authenticate +test-api-key+ "organization-owner1")
+                       (json-body {:form new-form-id
+                                   :workflow new-workflow-id})
+                       handler
+                       read-ok-body))]
+        (is (true? (:success body)))))
 
     (testing "can't update as owner of different organization"
-      (let [response (-> (request :post (str "/api/catalogue-items/" old-catalogue-item-id "/update"))
-                         (authenticate +test-api-key+ "organization-owner2")
-                         (json-body {:form new-form-id
-                                     :workflow new-workflow-id})
-                         handler)]
+      (let [response (with-not-logged? "rems.db.applications" :info #"Reloading"
+                       (-> (request :post (str "/api/catalogue-items/" old-catalogue-item-id "/update"))
+                           (authenticate +test-api-key+ "organization-owner2")
+                           (json-body {:form new-form-id
+                                       :workflow new-workflow-id})
+                           handler))]
         (is (response-is-forbidden? response))
         (is (= "no access to organization \"organization1\"" (read-body response)))))))
 
@@ -564,42 +643,58 @@
         fetch #(api-call :get (str "/api/catalogue-items/" id)
                          nil
                          +test-api-key+ "owner")]
+
+    (test-helpers/create-user! {:userid "alice"})
+    (test-helpers/create-application! {:catalogue-item-ids [id]
+                                       :actor "alice"})
+
     (doseq [user ["owner" "organization-owner1"]]
       (testing user
         (testing "disable"
-          (is (:success (api-call :put "/api/catalogue-items/enabled"
-                                  {:id id
-                                   :enabled false}
-                                  +test-api-key+ user)))
-          (is (false? (:enabled (fetch)))))
+          (let [response (with-logged? "rems.db.applications" :info "Reloading 1 applications because of catalogue item changes"
+                           (api-call :put "/api/catalogue-items/enabled"
+                                     {:id id
+                                      :enabled false}
+                                     +test-api-key+ user))]
+            (is (:success response))
+            (is (false? (:enabled (fetch))))))
         (testing "enable"
-          (is (:success (api-call :put "/api/catalogue-items/enabled"
-                                  {:id id
-                                   :enabled true}
-                                  +test-api-key+ user)))
-          (is (true? (:enabled (fetch)))))
+          (let [response (with-logged? "rems.db.applications" :info "Reloading 1 applications because of catalogue item changes"
+                           (api-call :put "/api/catalogue-items/enabled"
+                                     {:id id
+                                      :enabled true}
+                                     +test-api-key+ user))]
+            (is (:success response))
+            (is (true? (:enabled (fetch))))))
         (testing "archive"
-          (is (:success (api-call :put "/api/catalogue-items/archived"
-                                  {:id id
-                                   :archived true}
-                                  +test-api-key+ user)))
-          (is (true? (:archived (fetch)))))
+          (let [response (with-logged? "rems.db.applications" :info "Reloading 1 applications because of catalogue item changes"
+                           (api-call :put "/api/catalogue-items/archived"
+                                     {:id id
+                                      :archived true}
+                                     +test-api-key+ user))]
+            (is (:success response))
+            (is (true? (:archived (fetch))))))
         (testing "unarchive"
-          (is (:success (api-call :put "/api/catalogue-items/archived"
-                                  {:id id
-                                   :archived false}
-                                  +test-api-key+ user)))
-          (is (false? (:archived (fetch)))))))
+          (let [response (with-logged? "rems.db.applications" :info "Reloading 1 applications because of catalogue item changes"
+                           (api-call :put "/api/catalogue-items/archived"
+                                     {:id id
+                                      :archived false}
+                                     +test-api-key+ user))]
+            (is (:success response))
+            (is (false? (:archived (fetch))))))))
+
     (testing "incorrect organization owner can't"
       (testing "enable"
-        (let [response (-> (request :put "/api/catalogue-items/enabled")
-                           (authenticate +test-api-key+ "organization-owner2")
-                           (json-body {:id id :enabled true})
-                           handler)]
+        (let [response (with-not-logged? "rems.db.applications" :info #"Reloading"
+                         (-> (request :put "/api/catalogue-items/enabled")
+                             (authenticate +test-api-key+ "organization-owner2")
+                             (json-body {:id id :enabled true})
+                             handler))]
           (is (response-is-forbidden? response))))
       (testing "archive"
-        (let [response (-> (request :put "/api/catalogue-items/archived")
-                           (authenticate +test-api-key+ "organization-owner2")
-                           (json-body {:id id :archived true})
-                           handler)]
+        (let [response (with-not-logged? "rems.db.applications" :info #"Reloading"
+                         (-> (request :put "/api/catalogue-items/archived")
+                             (authenticate +test-api-key+ "organization-owner2")
+                             (json-body {:id id :archived true})
+                             handler))]
           (is (response-is-forbidden? response)))))))


### PR DESCRIPTION
Similar optimization as what workflow and blacklist services perform, makes application reloading orders of magnitude faster when only portion of applications are concerned.

# Checklist for author

Remove items that aren't applicable, check items that are done.

## Reviewability
- [ ] Link to issue

## Documentation
- [ ] Update changelog if necessary

## Testing
- [x] Complex logic is unit tested
- [x] Valuable features are integration / browser / acceptance tested automatically

## Follow-up
- [ ] New tasks are created for pending or remaining tasks
