### PR TITLE
Fix action buttons rendering wrong label

### DIFF
--- a/src/cljs/rems/collapsible.cljs
+++ b/src/cljs/rems/collapsible.cljs
@@ -36,7 +36,7 @@
 
 (defn- base-action
   "Base attributes for collapsible action."
-  [{:keys [collapsible-id label] :as action}]
+  [{:keys [collapsible-id] :as action}]
   (let [state @(rf/subscribe [::expanded collapsible-id])]
     (-> action
         (dissoc :collapsible-id :hide? :on-close :on-open :show?)
@@ -44,9 +44,11 @@
                :aria-expanded (if state
                                 "true"
                                 "false"))
-        (assoc-some :label (cond label nil
-                                 state (text :t.collapse/hide)
-                                 :else (text :t.collapse/show))))))
+        (assoc-some :label (when-not (or (:label action)
+                                         (:text action))
+                             (if state
+                               (text :t.collapse/hide)
+                               (text :t.collapse/show)))))))
 
 (defn focus-on-first-input [id]
   (focus/scroll-into-view-and-focus (rfmt/format "#%s .collapse-open :is(textarea, input)" id)))


### PR DESCRIPTION
Fixes regression from #3345 that causes request review buttons to render "show more" instead of the actual translation.

Some actions, e.g links pass `:text` attribute instead of `:label`, and collapsible base action happened to only expect `:label`, which is the preferred way to pass label. Due to this cascade, request review action links rendered collapsible default "show more" instead of the actual translation.

![Screenshot 2024-11-25 at 19 09 49](https://github.com/user-attachments/assets/ba6b1423-a326-4330-85e3-addd6a1bf0ba)
![Screenshot 2024-11-25 at 19 12 07](https://github.com/user-attachments/assets/8b78bca4-afd9-4f52-8ea8-120789e5032f)

# Checklist for author

Remove items that aren't applicable, check items that are done.

## Reviewability
- [ ] Link to issue (issue introduced by #3345)
- [x] Consider adding screenshots for ease of review

## Testing
- [ ] Valuable features are integration / browser / acceptance tested automatically (could be worthwhile to substitute E2E test ids for text-based query)

## Follow-up
- [ ] New tasks are created for pending or remaining tasks