### PR TITLE
Fix issue that prevents workflow voting removal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ have notable changes.
 
 Changes since v2.38
 
+### Fixes
+- Resolved issue where workflow voting could not be removed, which caused UI to display raw translation keys due to nil voting values. (#3357)
+
 ## v2.38 "Välimerenkatu" 2024-11-28
 
 This release contains major changes to the REMS internal architecture regarding the caching of information. We have improved the caching behavior previously during the year, but now we drop the requirement for REMS to reload the application cache every hour or so. This was problematic, if the reload was slow, because it would stop REMS for a while and could lead to running out of memory. REMS got slower with more data, handlers and so on which made the problem worse.

--- a/src/clj/rems/db/workflow.clj
+++ b/src/clj/rems/db/workflow.clj
@@ -120,11 +120,11 @@
                            (-> (:workflow wf)
                                ;; cache uses formatted values but db does not
                                (assoc :handlers (or handlers old-handlers)
-                                      :licenses old-licenses)
+                                      :licenses old-licenses
+                                      :voting voting)
                                (assoc-some :anonymize-handling anonymize-handling
                                            :disable-commands disable-commands
-                                           :processing-states processing-states
-                                           :voting voting)))}]
+                                           :processing-states processing-states)))}]
     (db/edit-workflow! (update new-wf :workflow json/generate-string))
     (cache/miss! workflow-cache id)
     {:success true}))

--- a/src/cljs/rems/administration/create_workflow.cljs
+++ b/src/cljs/rems/administration/create_workflow.cljs
@@ -347,7 +347,7 @@
     [:div.fields.voting
      [select-voting-type-field {:label (text :t.administration/voting)
                                 :value (:type voting)
-                                :on-change #(rf/dispatch [::set-voting (assoc voting :type %)])}]]))
+                                :on-change #(rf/dispatch [::set-voting (some->> % (assoc voting :type))])}]]))
 
 (rf/reg-sub ::disable-commands (fn [db _] (get-in db [::form :disable-commands])))
 (rf/reg-event-db ::new-disable-command (fn [db _] (update-in db [::form :disable-commands] conj-vec {})))


### PR DESCRIPTION
fixes #3357 

Resolves issue where workflow voting could not be removed, which in turn causes UI to display raw translation keys due to nil voting values.

# Checklist for author

Remove items that aren't applicable, check items that are done.

## Reviewability
- [x] Link to issue
- [ ] Consider adding screenshots for ease of review

## Documentation
- [x] Update changelog if necessary

## Testing
- [x] Valuable features are integration / browser / acceptance tested automatically
