### PR TITLE
Missing user settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Changes since v2.38
 
 ### Fixes
 - Resolved issue where workflow voting could not be removed, which caused UI to display raw translation keys due to nil voting values. (#3357)
+- Fixed bug in user settings cache that caused notification emails to not show up in the UI, API or CLI until modified.
 
 ## v2.38 "Välimerenkatu" 2024-11-28
 

--- a/src/clj/rems/db/user_settings.clj
+++ b/src/clj/rems/db/user_settings.clj
@@ -2,7 +2,7 @@
   (:require [clojure.string :as str]
             [medley.core :refer [assoc-some map-vals]]
             [rems.cache :as cache]
-            [rems.common.util :refer [+email-regex+]]
+            [rems.common.util :refer [+email-regex+ index-by]]
             [rems.config :refer [env]]
             [rems.db.core :as db]
             [rems.json :as json]
@@ -54,7 +54,7 @@
                              cache/absent))
                 :reload-fn (fn []
                              (->> (db/get-user-settings {})
-                                  (group-by :userid)
+                                  (index-by [:userid])
                                   (map-vals parse-user-settings-raw)
                                   (map-vals merge-defaults)))}))
 


### PR DESCRIPTION
Resolves an issue with user settings cache that caused users to not be up-to-date initially. Cache reload used `group-by`, which returns a sequence as value for each key. However, the value was processed like it was a map, causing the cache to not populate correctly.

- Fix cache reload by using index-by for consistent behavior with other caches
- Add test to verify single settings per user behavior

# Checklist for author

Remove items that aren't applicable, check items that are done.

## Reviewability
- [ ] Link to issue

## Documentation
- [x] Update changelog if necessary

## Testing
- [x] Valuable features are integration tested automatically

## Follow-up
- [ ] New tasks are created for pending or remaining tasks
