### PR TITLE
fix: properly format audit log response

### DIFF
--- a/src/clj/rems/api/audit_log.clj
+++ b/src/clj/rems/api/audit_log.clj
@@ -1,6 +1,7 @@
 (ns rems.api.audit-log
   (:require [compojure.api.sweet :refer :all]
             [rems.db.core :as db]
+            [ring.util.http-response :refer [ok]]
             [schema.core :as s])
   (:import (org.joda.time DateTime)))
 
@@ -23,8 +24,8 @@
                      {before :- (describe DateTime "Only show entries before this time") nil}]
       :roles #{:reporter}
       :return [AuditLogEntry]
-      (db/get-audit-log {:userid userid
-                         :after after
-                         :path (when application-id
-                                 (str "/api/applications/" application-id "%"))
-                         :before before}))))
+      (ok (db/get-audit-log {:userid userid
+                             :after after
+                             :path (when application-id
+                                     (str "/api/applications/" application-id "%"))
+                             :before before})))))


### PR DESCRIPTION
Fix #3380 

We should use `ok` helper like elsewhere.

# Checklist for author

Remove items that aren't applicable, check items that are done.

## Reviewability
- [x] Link to issue

## Backwards compatibility
- [x] API is backwards compatible or completely new

## Documentation
- [x] Update changelog if necessary

## Testing
- The HTTP level response is not tested. It is perhaps not worth it, although this bug would have been found.
