### PR TITLE
Fix markdown syntax in a few links

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ See the [release page](https://github.com/CSCfi/rems/releases) for the releases.
 - We welcome [issues through GitHub](https://github.com/CSCfi/rems/issues).
 - You can [contact the team on the discussion board](https://github.com/CSCfi/rems/discussions) or [via email](mailto:rems@csc.fi).
 - In case you would like to contribute to the development, perhaps you participate in Hacktoberfest, then please refer to the [contributing document](CONTRIBUTING.md). We'll guide you through to get your pull request reviewed and merged.
-- You can follow the progress of the project on the [GitHub project board]([https://github.com/CSCfi/rems/projects/1](https://github.com/orgs/CSCfi/projects/13)).
+- You can follow the progress of the project on the [GitHub project board](https://github.com/orgs/CSCfi/projects/13/views/1).
 
 ## Documentation
 

--- a/docs/presentations/README.md
+++ b/docs/presentations/README.md
@@ -4,11 +4,11 @@ Here we have presentation materials for REMS. Each presentation is in the form o
 
 ## How to use – reveal.js
 
-Follow the [https://revealjs.com/installation/#full-setup](instructions) to setup reveal.js, and off you go.
+Follow the [instructions](https://revealjs.com/installation/#full-setup) to setup reveal.js, and off you go.
 
 ## How to use – CSC's training template
 
-This is a bit more cumbersome than the previous example but does not require setting up a local web server. [https://pandoc.org](Pandoc) is required, however.
+This is a bit more cumbersome than the previous example but does not require setting up a local web server. [Pandoc](https://pandoc.org) is required, however.
 
 1. `git clone https://github.com/csc-training/slide-template`
 


### PR DESCRIPTION
Found a link that wasn't working while browsing through the docs, and a couple of others by grepping the pattern `[http`