### PR TITLE
Add custom action button for approved applications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ have notable changes.
 
 Changes since v2.39
 
+### Additions
+
+- Added a custom action button for approved applications. The button is defined in extra translations. (#3413)
+
 ## v2.39 "Jätkäsaarenlaituri" 2026-01-21
 
 ### Additions

--- a/resources/translations/da.edn
+++ b/resources/translations/da.edn
@@ -45,6 +45,7 @@
             :member-name "Navn"
             :modify "Ændr"
             :name-and-email-required "Navn og e-mail er påkrævede."
+            :pre-actions-info ""
             :redact-attachments "Fjern bilag"
             :reject "Afvis"
             :remark "Bemærkning"

--- a/resources/translations/en.edn
+++ b/resources/translations/en.edn
@@ -45,6 +45,7 @@
             :member-name "Name"
             :modify "Modify"
             :name-and-email-required "Name and email are required."
+            :pre-actions-info ""
             :redact-attachments "Redact attachments"
             :reject "Reject"
             :remark "Remark"

--- a/resources/translations/fi.edn
+++ b/resources/translations/fi.edn
@@ -43,6 +43,7 @@
             :member-name "Nimi"
             :modify "Muokkaa"
             :name-and-email-required "Nimi ja sähköposti ovat pakollisia."
+            :pre-actions-info ""
             :redact-attachments "Muokkaa liitetiedostoja"
             :reject "Hylkää"
             :remark "Kirjaa huomio"

--- a/resources/translations/sv.edn
+++ b/resources/translations/sv.edn
@@ -43,6 +43,7 @@
             :member-name "Namn"
             :modify "Ändra"
             :name-and-email-required "Namn och e-postadress är obligatoriska"
+            :pre-actions-info ""
             :redact-attachments "Ändra bilagor"
             :reject "Avslå"
             :remark "Gör anteckning"

--- a/src/cljs/rems/application.cljs
+++ b/src/cljs/rems/application.cljs
@@ -1070,6 +1070,8 @@
   (let [app-id (:application/id application)
         show-comment-field? (is-handling-user? application)
         actions (action-buttons application)
+        state (:application/state application)
+        pre-actions-info (when (= state :application.state/approved) (text :t.actions/pre-actions-info))
         reload (r/partial reload! app-id)
         go-to-applications #(do (flash-message/show-default-success! :top [text :t.actions/delete])
                                 (navigate! "/applications"))]
@@ -1079,7 +1081,7 @@
         :title (text :t.form/actions)
         :always [:div
 
-                 (into [:div#action-commands] actions)
+                 (into [:div#action-commands] [pre-actions-info actions])
 
                  [:div#actions-forms.mt-3
                   [request-review-form app-id reload]


### PR DESCRIPTION
https://github.com/CSCfi/rems/issues/3413

Add a custom action button for approved applications. The button is defined in extra translations.



<img width="1920" height="1048" alt="Screenshot From 2026-01-26 10-31-35" src="https://github.com/user-attachments/assets/5397ba67-7c9e-4096-86c5-0a5eaaa035f3" />

Application is approved and translation exists:

<img width="1920" height="1048" alt="Screenshot From 2026-01-26 10-24-04" src="https://github.com/user-attachments/assets/4689481c-6960-4669-a095-31b2bf41f9fc" />

Application is approved and translation does not exist:

<img width="1920" height="1048" alt="Screenshot From 2026-01-26 10-27-53" src="https://github.com/user-attachments/assets/7d9b7e6f-c3b4-4c90-9f91-98a1e20017d7" />

Not approved and translation exists:

<img width="1920" height="1048" alt="Screenshot From 2026-01-26 10-28-21" src="https://github.com/user-attachments/assets/8b83cb5b-6609-4ca0-aefe-6af65fe34a71" />



# Checklist for author

Remove items that aren't applicable, check items that are done.

## Reviewability
- [x] Link to issue
- [ ] Note if PR is on top of other PR
- [ ] Note if related change in rems-deploy repo
- [x] Consider adding screenshots for ease of review

## Backwards compatibility
- [ ] API is backwards compatible or completely new
- [ ] Events are backwards compatible _or_ have migrations
- [ ] Config is backwards compatible
- [ ] Feature appears correctly in PDF print

## Documentation
- [ ] Update changelog if necessary
- [ ] API is documented and shows up in Swagger UI
- [ ] Components are added to guide page
- [ ] Update docs/ (if applicable)
- [ ] Update manual/ (if applicable)
- [ ] ADR for major architectural decisions or experiments
- [ ] New config options in config-defaults.edn

## Testing
- [ ] Complex logic is unit tested
- [ ] Valuable features are integration / browser / acceptance tested automatically

## Follow-up
- [ ] New tasks are created for pending or remaining tasks
