### PR TITLE
Add named languages to language switcher

### DIFF
--- a/dev-config.edn
+++ b/dev-config.edn
@@ -20,6 +20,7 @@
                          {:attribute "organizations"}
                          {:attribute "groups" :name {:en "Groups" :fi "Ryhmät" :sv "Grupper" :da "Grupper"}}]
  :languages [:en :fi :sv]
+ :language-names {:en "English" :fi "Suomi" :sv "Svenska"}
  :public-url "http://localhost:3000/"
  :extra-pages [{:id "about"
                 :translations {:fi {:title "Info"

--- a/resources/config-defaults.edn
+++ b/resources/config-defaults.edn
@@ -177,6 +177,7 @@
 
  ;; List of supported languages. They will be selectable in the UI.
  :languages [:en :fi]
+ :language-names {:en "English" :fi "Suomi"}
  :default-language :en
 
  ;; Path to a directory with translations for additional languages.

--- a/src/clj/rems/api/public.clj
+++ b/src/clj/rems/api/public.clj
@@ -33,6 +33,7 @@
    :attachment-max-size (s/maybe s/Int)
    :entitlement-default-length-days (s/maybe s/Int)
    :languages [s/Keyword]
+   :language-names {s/Keyword s/Str}
    :default-language s/Keyword
    :oidc-extra-attributes [{:attribute s/Str
                             s/Keyword s/Any}]

--- a/src/clj/rems/service/public.clj
+++ b/src/clj/rems/service/public.clj
@@ -27,6 +27,7 @@
                     :entitlement-default-length-days
                     :extra-pages
                     :languages
+                    :language-names
                     :oidc-extra-attributes
                     :enable-assign-external-id-ui
                     :enable-doi

--- a/src/clj/rems/user_simulator.clj
+++ b/src/clj/rems/user_simulator.clj
@@ -5,7 +5,7 @@
    interface (CLI). Various user scenarios are implemented as functions in this
    namespace, enabling flexible testing of different workflows. Multiple
    simulations can run concurrently to test system performance and user load.
-   
+
    User simulator can be started from CLI with e.g. Leiningen:
    - `lein run user-simulator` (uses default values), or
    - `lein run user-simulator http://localhost:3000/ alice,elsa,frank` when replacing default values"
@@ -64,7 +64,7 @@
                 (et/delete-cookies (btu/get-driver))
                 (btu/go (btu/get-server-url))
                 (et/refresh (btu/get-driver))
-                (btu/scroll-and-click [{:css ".language-switcher"} {:fn/text "EN"}]) ; make sure language is stable
+                (btu/scroll-and-click [{:css ".language-switcher"} {:fn/text "English"}]) ; make sure language is stable
                 (action)))))
 
         (catch InterruptedException e

--- a/src/cljs/rems/language_switcher.cljs
+++ b/src/cljs/rems/language_switcher.cljs
@@ -1,6 +1,7 @@
 (ns rems.language-switcher
   (:require [clojure.string :as str]
             [rems.config]
+            [rems.globals]
             [rems.guide-util :refer [component-info example]]
             [rems.text :refer [text-format]]
             [rems.user-settings]))
@@ -10,6 +11,20 @@
     "btn btn-link active"
     "btn btn-link"))
 
+(defn get-language-name [language]
+  (or (get (@rems.globals/config :language-names) language)
+      (str/upper-case (name language))))
+
+(defn language-button [language]
+  [:button {:type :button
+            :class (lang-link-classes @rems.config/current-language language)
+            :on-click #(rems.user-settings/save-user-language! language)
+            :aria-label (text-format :t.navigation/change-language
+                                     (get-language-name language))
+            :data-toggle "collapse"
+            :data-target ".navbar-collapse.show"}
+   (get-language-name language)])
+
 (defn language-switcher
   "Language switcher widget"
   []
@@ -17,15 +32,7 @@
     (when (> (count languages) 1)
       (into [:div.language-switcher]
             (for [language languages]
-              (let [lang-str (str/upper-case (name language))]
-                [:form.inline
-                 [:button {:type :button
-                           :class (lang-link-classes @rems.config/current-language language)
-                           :on-click #(rems.user-settings/save-user-language! language)
-                           :aria-label (text-format :t.navigation/change-language lang-str)
-                           :data-toggle "collapse"
-                           :data-target ".navbar-collapse.show"}
-                  lang-str]]))))))
+              [:form.inline (language-button language)])))))
 
 (defn guide []
   [:div

--- a/test/clj/rems/test_browser.clj
+++ b/test/clj/rems/test_browser.clj
@@ -3626,7 +3626,7 @@
     (btu/wait-invisible :small-navbar) ; menu should be hidden
     (wait-page-title "Applications – REMS")
     (btu/scroll-and-click {:css ".navbar-toggler"})
-    (btu/scroll-and-click [:small-navbar {:tag :button :fn/text "FI"}])
+    (btu/scroll-and-click [:small-navbar {:tag :button :fn/text "Suomi"}])
     (btu/wait-invisible :small-navbar) ; menu should be hidden
     (wait-page-title "Hakemukset – REMS")
     (rems.db.user-settings/delete-user-settings! "alice"))) ; clear language settings


### PR DESCRIPTION

https://github.com/CSCfi/rems/issues/3463
Add named languages to language switcher 

Alternative implementations:
- Use extra translations instead of config
- Use a dictionary in config, e.g. `:languages { :code :fi :name "Suomi" ... }`, requires more effort in refactoring


Todo:
- Changelog


<img width="480" height="300" alt="Screenshot From 2026-07-02 21-02-08" src="https://github.com/user-attachments/assets/b034b56c-3ce0-4d66-9f56-c15d9f6ad8e3" />

# Checklist for author

Remove items that aren't applicable, check items that are done.

## Reviewability
- [x] Link to issue
- [ ] Note if PR is on top of other PR
- [ ] Note if related change in rems-deploy repo
- [x] Consider adding screenshots for ease of review

## Backwards compatibility
- [ ] API is backwards compatible or completely new
- [ ] Events are backwards compatible _or_ have migrations
- [ ] Config is backwards compatible
- [ ] Feature appears correctly in PDF print

## Documentation
- [ ] Update changelog if necessary
- [ ] API is documented and shows up in Swagger UI
- [ ] Components are added to guide page
- [ ] Update docs/ (if applicable)
- [ ] Update manual/ (if applicable)
- [ ] ADR for major architectural decisions or experiments
- [ ] New config options in config-defaults.edn

## Testing
- [ ] Complex logic is unit tested
- [ ] Valuable features are integration / browser / acceptance tested automatically

## Follow-up
- [ ] New tasks are created for pending or remaining tasks
