### PR TITLE
fix: error page default text

### DIFF
--- a/resources/translations/da.edn
+++ b/resources/translations/da.edn
@@ -685,6 +685,6 @@
   :unknown "Ukendt"
   :forbidden-page {:forbidden "Forbudt"
                    :you-are-forbidden "Adgang til indholdet ikke tlladt."}
-  :error-page {:title "Problem"}
+  :error-page {:title "Problem" :unknown-error "Ukendt fejl."}
   :meta {:description "Resource Entitlement Management System is a tool for managing access rights to resources, such as research datasets."
          :keywords "REMS, entitlement, access management, tool, access rights, resources, datasets"}}}

--- a/resources/translations/en.edn
+++ b/resources/translations/en.edn
@@ -739,6 +739,6 @@
   :unknown "Unknown"
   :forbidden-page {:forbidden "Forbidden"
                    :you-are-forbidden "Access to the page is forbidden."}
-  :error-page {:title "Problem"}
+  :error-page {:title "Problem" :unknown-error "Unknown error."}
   :meta {:description "Resource Entitlement Management System is a tool for managing access rights to resources, such as research datasets."
          :keywords "REMS, entitlement, access management, tool, access rights, resources, datasets"}}}

--- a/resources/translations/fi.edn
+++ b/resources/translations/fi.edn
@@ -637,6 +637,6 @@
   :unknown "Tuntematon"
   :forbidden-page {:forbidden "Kielletty"
                    :you-are-forbidden "Sivun käyttö on kielletty."}
-  :error-page {:title "Ongelma"}
+  :error-page {:title "Ongelma" :unknown-error "Tuntematon virhe."}
   :meta {:description "Resource Entitlement Management System is a tool for managing access rights to resources, such as research datasets."
          :keywords "REMS, entitlement, access management, tool, access rights, resources, datasets"}}}

--- a/resources/translations/sv.edn
+++ b/resources/translations/sv.edn
@@ -636,6 +636,6 @@
   :unknown "Okänd"
   :forbidden-page {:forbidden "Förbjuden"
                    :you-are-forbidden "Innehåll förbjudet."}
-  :error-page {:title "Problem"}
+  :error-page {:title "Problem" :unknown-error "Okänd fel."}
   :meta {:description "Resource Entitlement Management System is a tool for managing access rights to resources, such as research datasets."
          :keywords "REMS, entitlement, access management, tool, access rights, resources, datasets"}}}

--- a/src/cljs/rems/app.cljs
+++ b/src/cljs/rems/app.cljs
@@ -249,12 +249,16 @@
     [:div
      [document-title (text :t.error-page/title)]
      [flash-message/component :top]
-     (let [args (:args error)]
-       [:p (text-format
-            (:key error)
-            (if (string? args)
-              (text args)
-              (str/join ", " (map text args))))])]))
+     (let [{args :args
+            error-key :key} error]
+       [:p
+        (if-not (str/blank? error-key)
+          (text-format
+           error-key
+           (if (string? args)
+             (text args)
+             (str/join ", " (map text args))))
+          (text :t.error-page/unknown-error))])]))
 
 (defn not-found-page []
   [:div


### PR DESCRIPTION
Fix: #3480

The scope of this PR is to make it explicit that an error is declared unknown when it is in fact unknown (the supplied translation key is missing)

For some reason, the error page couldn't be navigated to in browser tests, so there are none, as the changes are rather insignificant. Let's look at that separately along with the OIDC configuration error handling, because that would be the more interesting subject to write a test about.

# Checklist for author

Remove items that aren't applicable, check items that are done.

## Reviewability
- [x] Link to issue
- [x] Consider adding screenshots for ease of review

<img width="1095" height="813" alt="Screenshot 2026-09-01 at 15 07 17" src="https://github.com/user-attachments/assets/a00ab3dc-7618-47fc-a2b6-058250f11d65" />
