### PR TITLE
feat: Linebreak support in form labels

### DIFF
--- a/src/cljs/rems/util.cljs
+++ b/src/cljs/rems/util.cljs
@@ -131,23 +131,35 @@
 
 (def ^:private link-regex #"(?:http://|https://|www\.\w).*?(?=[^a-zA-Z0-9_/]*(?: |$))")
 
-(defn linkify
+(defn- linkify-links
   "Given a string, return a vector that, when concatenated, forms the
   original string, except that all substrings that resemble a link have
   been changed to hiccup links."
   [s]
+  (let [splitted (-> s
+                     (str/replace link-regex #(str "\t" %1 "\t"))
+                     (str/split "\t"))
+        link? (fn [s] (re-matches link-regex s))
+        text-to-url (fn [s] (if (re-matches #"^(http://|https://).*" s)
+                              s
+                              (str "http://" s)))]
+    (map #(if (link? %)
+            ^{:key %} [:a {:target :_blank :href (text-to-url %)} %]
+            %)
+         splitted)))
+
+(defn linkify
+  "Given a string, return a vector that, when concatenated, forms the
+  original string, except that all substrings that resemble a link have
+  been changed to hiccup links, and all newlines have been changed to
+  hiccup line breaks."
+  [s]
   (when s
-    (let [splitted (-> s
-                       (str/replace link-regex #(str "\t" %1 "\t"))
-                       (str/split "\t"))
-          link? (fn [s] (re-matches link-regex s))
-          text-to-url (fn [s] (if (re-matches #"^(http://|https://).*" s)
-                                s
-                                (str "http://" s)))]
-      (map #(if (link? %)
-              ^{:key %} [:a {:target :_blank :href (text-to-url %)} %]
-              %)
-           splitted))))
+    (let [lines (str/split s #"\n" -1)]
+      (->> lines
+           (map linkify-links)
+           (interpose (list ^{:key (gensym "br")} [:br]))
+           (apply concat)))))
 
 (defn visibility-ratio
   "Given a DOM node, return a number from 0.0 to 1.0 describing how much of an element is inside the viewport."

--- a/test/cljs/rems/test_util.cljs
+++ b/test/cljs/rems/test_util.cljs
@@ -50,4 +50,19 @@
              (linkify "(See http://www.abc.com?)"))))
     (testing "a link without http-prefix"
       (is (= ["(See www-page at " [:a {:target :_blank :href "http://www.abc.com"} "www.abc.com"] ".)"]
-             (linkify "(See www-page at www.abc.com.)"))))))
+             (linkify "(See www-page at www.abc.com.)"))))
+    (testing "change newlines to hiccup line breaks"
+      (is (= ["a" [:br] "b"]
+             (linkify "a\nb")))
+      (is (= ["a" [:br] "b" [:br] "c"]
+             (linkify "a\nb\nc"))))
+    (testing "retain empty lines around line breaks"
+      (is (= ["" [:br] "a"]
+             (linkify "\na")))
+      (is (= ["a" [:br] ""]
+             (linkify "a\n")))
+      (is (= ["a" [:br] "" [:br] "b"]
+             (linkify "a\n\nb"))))
+    (testing "combine links and line breaks"
+      (is (= ["See " link [:br] "and more"]
+             (linkify "See http://www.abc.com\nand more"))))))


### PR DESCRIPTION
Converts \n characters found in form labels into actual HTML linebreaks - rather than rendering them as whitespace which is the current behaviour.

## Reviewability
- [x] Link to issue
- [x] Consider adding screenshots for ease of review

## Backwards compatibility
- [x] Config is backwards compatible
- [ ] Feature appears correctly in PDF print

## Documentation
- [ ] Update changelog if necessary
- [ ] Update docs/ (if applicable)
- [ ] Update manual/ (if applicable)

## Testing
- [x] Complex logic is unit tested
